### PR TITLE
GAR builder: more debug options and support for exotic recipes

### DIFF
--- a/build-ib.sh
+++ b/build-ib.sh
@@ -11,7 +11,7 @@
 function PrintUsage() (
   cat <<'EoF'
 Usage:
-  build-ib.sh.sh --software <software_name> \
+  build-ib.sh.sh --software <[software_group:]software_name> \
                  --recipe-version <recipe_version> \
                  [--recipe-base-url <base_svn_url>] \
                  [--recipe-svn-user <recipe_svn_user>] \
@@ -29,6 +29,18 @@ Alternatively it possible to specify parameters as envvars:
   --recipe-svn-user --> DEFAULT_RECIPE_USER
   --recipe-svn-pass --> DEFAULT_RECIPE_PASS
   --ncores          --> DEFAULT_NCORES
+
+Software name can take two different forms:
+
+  sw_group:sw_name  # e.g. geant4:geant4_vmc
+
+or simply:
+
+  sw_name  # e.g. root
+
+The latter will assume that software group is equal to software name:
+
+  sw_name:sw_name
 
 EoF
 )
@@ -60,6 +72,11 @@ if [[ "$RecipeSw" == '' || "$RecipeVer" == '' ]] ; then
   PrintUsage
   exit 1
 fi
+
+# Separate group:component with ':'. If not provided, group and component will
+# be identical
+RecipeSwGroup=${RecipeSw%%:*}
+RecipeSwComponent=${RecipeSw#*:}
 
 # Other variables
 RecipeUrl="${RecipeBaseUrl}/${RecipeVer}"
@@ -94,5 +111,5 @@ cd "$RecipeDir"
 ./configure --prefix="$BuildScratchDir"
 
 # Build a specific software on all possible cores (override hardcoded values)
-cd "${RecipeDir}/apps/${RecipeSw}/${RecipeSw}"
+cd "${RecipeDir}/apps/${RecipeSwGroup}/${RecipeSwComponent}"
 exec time make -j"$MakeCores" install AUTOREGISTER=0 BUILD_ARGS=-j"$MakeCores"

--- a/build-ib.sh
+++ b/build-ib.sh
@@ -16,7 +16,8 @@ Usage:
                  [--recipe-base-url <base_svn_url>] \
                  [--recipe-svn-user <recipe_svn_user>] \
                  [--recipe-svn-pass <recipe_svn_pass>] \
-                 [--ncores <make_j_cores>]
+                 [--ncores <make_j_cores>] \
+                 [--drop-to-shell]
 
 Example:
   build-ib.sh.sh --software root --recipe-version v5-06-25
@@ -63,6 +64,7 @@ while [[ $# -gt 0 ]] ; do
     --ncores) MakeCores="$2" ; shift 2 ;;
     --recipe-svn-user) RecipeSvnUser="$2" ; shift 2 ;;
     --recipe-svn-pass) RecipeSvnPass="$2" ; shift 2 ;;
+    --drop-to-shell) DropToShell=1 ; shift ;;
     *) shift ;;
   esac
 done
@@ -112,4 +114,10 @@ cd "$RecipeDir"
 
 # Build a specific software on all possible cores (override hardcoded values)
 cd "${RecipeDir}/apps/${RecipeSwGroup}/${RecipeSwComponent}"
-exec time make -j"$MakeCores" install AUTOREGISTER=0 BUILD_ARGS=-j"$MakeCores"
+
+# Drop to shell, or proceed automatically?
+if [[ "$DropToShell" == 1 ]] ; then
+  exec bash
+else
+  exec time make -j"$MakeCores" install AUTOREGISTER=0 BUILD_ARGS=-j"$MakeCores"
+fi


### PR DESCRIPTION
Changes related to the GAR builder.

* Optionally drop to shell with `--drop-to-shell` after fetching the recipe. This is only used manually for debug.

* Support recipes where the software to be built resides in a software group with a different name. This is not the case with, *e.g.* **AliRoot** (where the recipe is under `apps/aliroot/aliroot`), where it is still sufficient to specify `--software aliroot` to build it. It is however the case with, *e.g.* **Geant4 VMC**: the recipe is under `apps/geant4/geant4_vm`; it is now possible to build it by specifying `--software geant4:geant4_vmc`.