### PR TITLE
Address the fact we currently do not have ubuntu builders.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -47,6 +47,6 @@
 -
   name: aliroot
   include: v5-.*
-  architecture: ubuntu_x86-64
+  architecture: slc7_x86-64
   env:
     TEST: all


### PR DESCRIPTION
- Drop ubuntu
- Add slc7