### PR TITLE
Only build aliroot, not aliroot-test for root6

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ integration_rules:
   architecture: slc7_x86-64
   alidist: IB/master/root6
   alibuild: master
-  package: aliroot-test
+  package: aliroot
 -
   branch: master
   architecture: slc7_x86-64


### PR DESCRIPTION
The scheduling logic cannot distinguish between aliroot-test ROOT5 and
aliroot-test (ROOT6). This works around the problem. The correct solution would
be to include the alidist / aliroot tag in the name of the scheduled entity.