### PR TITLE
Publisher: much faster check if installed on AliEn

### DIFF
--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -186,6 +186,7 @@ class AliEnPackMan(object):
     self._dryRun = dryRun
     self._publishScriptTpl = publishScriptTpl
     self._packs = None
+    self._cachedArchs = []
 
   def _kw(self, url, arch, pkgName, pkgVer, deps):
     kw =  { "url": url, "package": pkgName, "version": pkgVer, "arch": arch, "dependencies": deps }
@@ -206,15 +207,17 @@ class AliEnPackMan(object):
           self._packs[pkg] = {}
         self._packs[pkg].update({ver: []})
 
-    platf = self._packs.get(pkgName, {}).get(pkgVer, [])
-    if len(platf) == 0:
-      _,out = grabOutput([ "alien", "-exec", "ls",
-                           format("/alice/packages/%(package)s/%(version)s", **kw) ])
-      for line in out.split("\n"):
-        if search(r"^[A-Za-z0-9]+-[A-Za-z0-9-_]+$", line):
-          platf.append(line)
+    if not arch in self._cachedArchs:
+      for line in grabOutput([ "alien", "-exec", "find", "/alice/packages", arch ])[1].split("\n"):
+        m = search(r"^/alice/packages/([^/]+)/([^/]+)/", line)
+        if not m: continue
+        pkg = m.group(1)
+        ver = m.group(2)
+        if not pkg in self._packs: continue
+        self._packs[pkg].get(ver, []).append(arch)
+      self._cachedArchs.append(arch)
 
-    return arch in platf
+    return arch in self._packs.get(pkgName, {}).get(pkgVer, [])
 
   def install(self, url, arch, pkgName, pkgVer, deps, allDeps):
     kw = self._kw(url, arch, pkgName, pkgVer,


### PR DESCRIPTION
Using a single "alien find" rather than an "alien ls" per package.

Thanks Miguel Martinez Pedreira!