### PR TITLE
Introduce a few monitors for Mesos / Marathon using Riemann

### DIFF
--- a/riemann/riemann.config
+++ b/riemann/riemann.config
@@ -57,6 +57,23 @@
       (throttle 1 3600 slacker)
     )
 
+    ; "mesos health" expired, means Mesos checks have troubles.
+    ; We throttle by 60 seconds to avoid flip-floppings.
+    (changed-state {:init "ok"}
+      (where
+        (service #"mesos health")
+        (throttle 1 60 slacker)
+      )
+    )
+    ; "marathon health" expired, means marathon checks have troubles.
+    ; We throttle by 60 seconds to avoid flip-floppings.
+    (changed-state {:init "ok"}
+      (where
+        (service #"marathon health")
+        (throttle 1 60 slacker)
+      )
+    )
+
     ; When we have a too many task staging, it means we might have a
     ; stuck node.
     (where

--- a/riemann/riemann.config
+++ b/riemann/riemann.config
@@ -93,6 +93,25 @@
       (throttle 1 3600 slacker)
     )
 
+    ; Any monitored disk above 50% usage should be a warning.
+    (where
+      (and
+        (service #"disk /.*")
+        (< 0.5 metric 0.8)
+      )
+      (with {:state "warning"} index)
+      (with {:state "warning"} (by [:host] (throttle 1 3600 slacker)))
+    )
+    ; Any monitored disk above 80% usage should be a critical.
+    (where
+      (and
+        (service #"disk /.*")
+        (> metric 0.8)
+      )
+      (with {:state "critical"} index)
+      (with {:state "critical"} (by [:host] (throttle 1 3600 slacker)))
+    )
+
     ; Create separate streams for entries in alibuild_log streams which
     ; have error: or warning: in the description.
     ; Error remain in the index for 3600 seconds.

--- a/riemann/riemann.config
+++ b/riemann/riemann.config
@@ -21,6 +21,12 @@
                                  :channel "#monitoring"
                                 }))
 
+; A few limits
+(def min_mesos_slaves 10)
+
+; Report to slack only once per hour.
+(def report-to-slack (throttle 1 3600 slacker))
+
 ; Listen on the local interface over TCP (5555), UDP (5555), and websockets
 ; (5556)
 (let [host "0.0.0.0"]
@@ -40,7 +46,16 @@
       ; Log expired events.
       (expired
         (fn [event] (info "expired" event))))
-    
+
+    ; When we have a too active few mesos slaves, notify slack.    
+    (where
+      (and
+        (service #"mesos master/slaves_active")
+        (< metric min_mesos_slaves)
+      )
+      (throttle 1 3600 slacker)
+    )
+
     ; Create separate streams for entries in alibuild_log streams which
     ; have error: or warning: in the description.
     ; Error remain in the index for 3600 seconds.

--- a/riemann/riemann.config
+++ b/riemann/riemann.config
@@ -21,8 +21,9 @@
                                  :channel "#monitoring"
                                 }))
 
-; A few limits
+; A few limits to monitor an healthy mesos cluster.
 (def min_mesos_slaves 10)
+(def max_mesos_task_staging 2)
 
 ; Report to slack only once per hour.
 (def report-to-slack (throttle 1 3600 slacker))
@@ -52,6 +53,25 @@
       (and
         (service #"mesos master/slaves_active")
         (< metric min_mesos_slaves)
+      )
+      (throttle 1 3600 slacker)
+    )
+
+    ; When we have a too many task staging, it means we might have a
+    ; stuck node.
+    (where
+      (and
+        (service #"mesos master/tasks_staging")
+        (> metric max_mesos_task_staging)
+      )
+      (throttle 1 3600 slacker)
+    )
+
+    ; When the master is not elected, we are in trouble
+    (where
+      (and
+        (service #"mesos master/elected")
+        (== metric 0)
       )
       (throttle 1 3600 slacker)
     )


### PR DESCRIPTION
Most of the monitors report to slack when a given threshold is passed or there is a state change.