### PR TITLE
Complain when mesos slaves go MIA

### DIFF
--- a/riemann/riemann.config
+++ b/riemann/riemann.config
@@ -61,9 +61,18 @@
     ; We throttle by 60 seconds to avoid flip-floppings.
     (changed-state {:init "ok"}
       (where
-        (service #"mesos health")
+        (service #"mesos slave/health")
         (throttle 1 60 slacker)
       )
+    )
+
+    ; Consider ok a mesos slave which has more than one cpu.
+    (where
+      (service #"mesos slave/resources/cpus")
+      (with {:service "mesos slave/health"
+             :state "ok"
+             :metric 1
+            } reinject)
     )
     ; "marathon health" expired, means marathon checks have troubles.
     ; We throttle by 60 seconds to avoid flip-floppings.


### PR DESCRIPTION
Compute mesos slave/health metric and send a Slack message when it expires,
meaning the Mesos Master unregistered it.