### PR TITLE
Monitor Marathon apps

### DIFF
--- a/riemann/riemann.config
+++ b/riemann/riemann.config
@@ -102,6 +102,16 @@
       (throttle 1 3600 slacker)
     )
 
+    ; Monitor Marathon apps and report to slack when the number of instances
+    ; drops to 0.
+    (where
+      (and
+          (service #"marathon apps/.*/tasksRunning")
+          (== metric 0)
+      )
+      (by [:service] (throttle 1 3600 slacker))
+    )
+
     ; Any monitored disk above 50% usage should be a warning.
     (where
       (and


### PR DESCRIPTION
Notify slack if the number of instances for an app drops to zero.