### PR TITLE
Improve notifications

### DIFF
--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -568,10 +568,18 @@ def notify(conf, archs, pack, dryRun):
 
       body = format(conf.get(key, {}).get("body", ""), **kw)
       subj = format(conf.get(key, {}).get("subject", "%(package)s %(version)s: "+key), **kw)
-      to = isinstance(conf.get(key, {}).get("to", []), basestring) and \
-           [conf.get(key, {})["to"]] or conf.get(key, {}).get("to", [])
+
+      to = conf.get(key, {}).get("to", "")
+      if isinstance(to, dict):
+        to = to.get(p["name"], to.get("default", ""))
+      if isinstance(to, list):
+        to = ",".join(to)
+      to = [ x.strip() for x in to.split(",") ] if to else []
+
       sender = format(conf.get(key, {}).get("from", "noreply@localhost"), **kw)
       if body == "" or not to:
+        debug(format("Not sending email notification for %(package)s %(version)s (%(arch)s)",
+                     package=p["name"], version=p["ver"], arch=archs[arch]))
         continue
       body = ("Subject: %s\nFrom: %s\nTo: %s\n\n" % (subj, sender, ", ".join(to))) + body
       if dryRun:

--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -489,7 +489,7 @@ def sync(pub, architectures, baseUrl, rules, includeFirst, autoIncludeDeps,
       if not pub.transaction():
         sys.exit(2)  # fatal
       else:
-        riemann.notify("warning", arch, pack["name"], pack["ver"])
+        if riemann: riemann.notify("warning", arch, pack["name"], pack["ver"])
         rv = pub.install(pkgUrl, architectures[arch], pack["name"], pack["ver"],
                          deps["dist-direct-runtime"], deps["dist-runtime"])
         newPackages[arch].append({ "name": pack["name"],
@@ -500,11 +500,11 @@ def sync(pub, architectures, baseUrl, rules, includeFirst, autoIncludeDeps,
       if rv == 0:
         info(format("%(arch)s / %(pack)s / %(ver)s: installed successfully",
                      arch=arch, pack=pack["name"], ver=pack["ver"]))
-        riemann.notify("ok", arch, pack["name"], pack["ver"])
+        if riemann: riemann.notify("ok", arch, pack["name"], pack["ver"])
       else:
         error(format("%(arch)s / %(pack)s / %(ver)s: publish script failed with %(rv)d",
                      arch=arch, pack=pack["name"], ver=pack["ver"], rv=rv))
-        riemann.notify("critical", arch, pack["name"], pack["ver"])
+        if riemann: riemann.notify("critical", arch, pack["name"], pack["ver"])
 
   # Publish eventually
   if pub.publish():
@@ -712,7 +712,9 @@ def main():
     architectures = dict((arch, isinstance(maps, dict) and maps.get(archKey, arch) or arch)
                          for (arch,maps) in conf["architectures"].iteritems())
     debug("Architecture names mappings: %s" % json.dumps(architectures, indent=2))
-    riemann = RiemannPkgNotify(conf["riemann_host"], conf["riemann_port"])
+    debug(args.dryRun)
+    riemann = None if args.dryRun \
+              else RiemannPkgNotify(conf["riemann_host"], conf["riemann_port"])
     sync(pub=pub,
          architectures=architectures,
          baseUrl=conf["base_url"],

--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -5,6 +5,12 @@ base_url: http://188.184.162.83/TARS
 # riemann.marathon.mesos:5555
 riemann_host: 128.142.140.63:5555
 
+# YAML variables. Not aliPublish-specific.
+alice_email_notif_conf: &alice_email_notif alice-analysis-operations@cern.ch
+experts_email_notif_conf: &experts_email_notif
+  - dario.berzano@cern.ch
+  - giulio.eulisse@cern.ch
+
 architectures:
 
   slc6_x86-64:
@@ -65,6 +71,8 @@ cvmfs_modulefile: /cvmfs/%(repo)s/%(arch)s/Modules/modulefiles/%(package)s/%(ver
 # RPM-specific configuration
 rpm_repo_dir: /repo/RPMS
 
+# Please remember to escape the percentage sign by doubling it. This body is
+# processed by the Python formatter.
 notification_email:
   server: cernmx.cern.ch
   package_format: "  VO_ALICE@%(package)s::%(version)s\n"
@@ -72,24 +80,28 @@ notification_email:
     body: |
       Dear ALICE fellows,
 
-        %(package)s %(version)s was registered and it is ready to be used. While
-      there is a delay of up to two hours before the tag is propagated on CVMFS,
-      test trains can be run right away.
+        %(package)s %(version)s was registered and it is ready to be used.
+      Although there is a delay of up to two hours before the tag is propagated
+      on CVMFS, test trains can be run right away.
 
-      This package has the following dependencies:
-
-      %(dependencies_fmt)s
-      If you launch Grid jobs, it is sufficient to specify this single package.
-      No other package is required.
+      Load this package in a JDL like this:
 
         Packages = {
           "VO_ALICE@%(package)s::%(version)s"
         }
 
-      Do not specify explicitly any of the other dependencies: all the correct
-      ones will be automatically loaded in the job's environment.
+      Use the following URL to check if the package is available on CVMFS:
 
-      You can use the CVMFS package from lxplus like this:
+        http://alimonitor.cern.ch/packages/?packagename=VO_ALICE%%40%(package)s%%3A%%3A%(version)s
+
+      Note that all its dependencies will be loaded implicitly: please DO NOT
+      specify them manually to reduce the chance of making a mistake.
+
+      Automatically loaded dependencies:
+
+      %(alldependencies_fmt)s
+      You can use the CVMFS package from lxplus (or any other CVMFS-enabled
+      host) like this:
 
         source /cvmfs/alice.cern.ch/etc/login.sh
         alienv enter VO_ALICE@%(package)s::%(version)s
@@ -102,7 +114,10 @@ notification_email:
       The ALICE Build Infrastructure
     subject: "[AliBuild] %(package)s %(version)s on the Grid"
     from: "ALICE Builder <alice-analysis-operations@cern.ch>"
-    to: alice-analysis-operations@cern.ch
+    to:
+      AliRoot: *alice_email_notif
+      AliPhysics: *alice_email_notif
+      default: *experts_email_notif
   failure:
     body: |
       CVMFS publishing failed for %(package)s %(version)s. Please have a look.
@@ -112,9 +127,7 @@ notification_email:
       The ALICE Build Infrastructure
     subject: "[CVMFS] Failed: %(package)s %(version)s"
     from: "ALICE Builder <noreply@cern.ch>"
-    to:
-     - dario.berzano@cern.ch
-     - giulio.eulisse@cern.ch
+    to: *experts_email_notif
 
 # What packages to publish
 auto_include_deps: True


### PR DESCRIPTION
* Riemann disabled on dry runs
* Notify all ALICE only on new AliRoot/AliPhysics
* Notify experts only for the rest, and in case of errors