### PR TITLE
Improve alibuild-release process

### DIFF
--- a/jenkins/release-alibuild
+++ b/jenkins/release-alibuild
@@ -1,3 +1,4 @@
+#!groovy
 node ("slc7_x86-64-light") {
   stage "Check tag"
   sh '''
@@ -5,7 +6,7 @@ node ("slc7_x86-64-light") {
     git clone https://github.com/alisw/alibuild
     cd alibuild
     git fetch origin --tags
-    LAST_TAG=`git tag --points-at master | sed -e 's|^v||' | grep -e "[0-9]*[.][0-9]*[.][0-9]*"`
+    LAST_TAG=`git tag --points-at master | sed -e 's|^v||' | grep -e "[0-9]*[.][0-9]*[.][0-9]*" | head -n 1`
     if [ "X$LAST_TAG" = X ]; then
       echo "Nothing to release."
       exit 1


### PR DESCRIPTION
Support multiple tags for same commit when releasing alibuild.
Only the last one will be used.