### PR TITLE
Make .*/root6 branch derived from .*/next

### DIFF
--- a/auto-update-git-branches
+++ b/auto-update-git-branches
@@ -36,6 +36,6 @@ fi
 
 git fetch origin
 
-(updateBranch IB/v5-08/prod IB/master/root6) || true
+(updateBranch IB/v5-08/next IB/master/root6) || true
 (updateBranch IB/v5-06/prod IB/v5-06/next) || true
 (updateBranch IB/v5-08/prod IB/v5-08/next) || true


### PR DESCRIPTION
As discussed in alisw/alidist#337, we need to derive the root6 branch from next, so that it can be useful also for O2 developments. 

<!---
@huboard:{"order":235.0,"milestone_order":235,"custom_state":""}
-->
