### PR TITLE
Add build-coverage pipeline

### DIFF
--- a/jenkins/build-coverage
+++ b/jenkins/build-coverage
@@ -1,0 +1,59 @@
+#!groovy
+node ("scheduler") {
+
+  stage 'Secrets Setup'
+
+  withCredentials([[$class: 'StringBinding',
+                    credentialsId: 'alibuild-ssh-vault-token', variable: 'VAULT_TOKEN']]) {
+    withEnv(["VAULT_ADDR=${VAULT_ADDR}",
+             "VAULT_SKIP_VERIFY=1"]) {
+      retry (3) {
+        sh """
+        mkdir -p /root/.ssh
+        git config --global user.name ${BUILDER_USER}
+        git config --global user.email ${BUILDER_EMAIL}
+        [[ ! -f /root/.ssh/id_rsa ]] && vault read -field=ssh-key ${VAULT_SECRET_PATH} > /root/.ssh/id_rsa
+        [[ ! -f /root/.ssh/known_hosts ]] && vault read -field=ssh-known-hosts ${VAULT_SECRET_PATH} > /root/.ssh/known_hosts
+        echo >> /root/.ssh/known_hosts
+        chmod 750 /root/.ssh
+        chmod 400 /root/.ssh/id_rsa
+        """
+      }
+    }
+  }
+
+  stage 'Checkout repositories'
+  def workspace = pwd()
+  parallel (
+    checkout_aliroot: {
+      sh """
+        rm -rf AliRoot 
+        time git clone --reference /build/mirror/aliroot http://git.cern.ch/pub/AliRoot AliRoot
+      """},
+    checkout_aliphysics: {
+      sh """
+        rm -rf AliPhysics
+        time git clone --reference /build/mirror/aliroot http://git.cern.ch/pub/AliPhysics AliPhysics
+      """},
+    checkout_results: {
+      sh """
+        rm -fr aliphysics-coverage
+        time git clone -b gh-pages git@github.com:${DESTINATION_REPO}/aliphysics-coverage
+      """}
+    )
+
+    stage 'Process and commit results'
+    sh """
+      export WORKSPACE="${workspace}"
+      alibuild/aliBuild --defaults coverage build AliRoot-test
+
+      eval $(alibuild/alienv load AliRoot/latest)
+      lcov --capture --directory sw/osx_x86-64/profile-data --output-file coverage.info
+      genhtml coverage.info --output-directory aliphysics-coverage
+
+      cd aliphysics-coverage
+      git add .
+      git commit -m 'Updated results.' || true
+      git push origin master
+    """
+}


### PR DESCRIPTION
This pipeline will download and build AliRoot using the coverage
defaults so that code coverage compilation options are added.

The results should be published in the gitlab repository
aliphysics-coverage and then published to ali-ci.cern.ch.

This is the initial work to get that done.