### PR TITLE
Add check to AliEn PackMan output

### DIFF
--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -155,6 +155,9 @@ class RiemannPkgNotify(object):
     except Exception as e:
       error("Cannot send Riemann notification: %s" % e)
 
+class PublishException(Exception):
+  pass
+
 class CvmfsServer(object):
 
   def __init__(self, repository, modulefileTpl, pkgdirTpl, publishScriptTpl,
@@ -284,6 +287,9 @@ class AliEnPackMan(object):
         if not pkg in self._packs:
           self._packs[pkg] = {}
         self._packs[pkg].update({ver: []})
+
+    if not self._packs:
+      raise PublishException("PackMan: could not get list of packages from AliEn this time")
 
     if not arch in self._cachedArchs:
       for line in grabOutput([ "alien", "-exec", "find", "/alice/packages", arch ])[1].split("\n"):


### PR DESCRIPTION
AliEn PackMan might silently return zero packages from time to time. This is now considered an error condition and does not trigger any longer the republishing of all packages.