### PR TITLE
Remove POWHEG and Rivet from direct publishing

### DIFF
--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -48,11 +48,7 @@ architectures:
        - ^v5-.*-itsmisalign-[0-9]+$
       jemalloc:
        - ^v4\.1\.0-[0-9]+$
-      POWHEG: true
       AliGenerators: true
-      Rivet:
-       - ^2\.4\.3-alice[0-9]+-[0-9]+$
-       - ^2\.5\.1-alice[0-9]+-[0-9]+$
     exclude:
       AliPhysics:
        - ^vAN-20150910.*$

--- a/publish/test.yaml
+++ b/publish/test.yaml
@@ -5,8 +5,6 @@ slc5_x86-64:
     v1.0-1                 : False
   AliGenerators:
     v20160829-1            : True
-  Rivet:
-    2.5.1-alice1-1         : True
   AliPhysics:
     vAN-20151110-1         : False
     vAN-20151201-1         : False


### PR DESCRIPTION
They are dependencies of AliGenerators.