### PR TITLE
Revert "Publish ROOT6 builds on test repo"

### DIFF
--- a/publish/aliPublish-nightlies.conf
+++ b/publish/aliPublish-nightlies.conf
@@ -14,10 +14,7 @@ architectures:
     CVMFS: x86_64-2.6-gnu-4.1.2
     include:
       AliPhysics:
-       # Release candidates
        - ^v5-0[8]-[0-9]+[a-z]?-0[1-9]-rc[0-9]+-[0-9]+$
-       # ROOT 6 test releases
-       - ^v5-0[8]-[0-9]+[a-z]?-0[1-9]_ROOT6-[0-9]+$
     exclude:
       AliPhysics:
        - ^v5-08-(0[0-9]|1[0-7])[a-z]?.*$

--- a/publish/test-nightlies.yaml
+++ b/publish/test-nightlies.yaml
@@ -3,4 +3,3 @@ slc5_x86-64:
     v5-08-13b-01-rc5-2: False
     v5-08-17-01-rc1-1: False
     v5-08-18-01-rc2-1: True
-    v5-08-18-01_ROOT6-1: True


### PR DESCRIPTION
Reverts alisw/ali-bot#331 in the hope this is what actually broke publishing.