### PR TITLE
Improve aurora based continuous integration

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -4,17 +4,21 @@
 # Notice this will do an incremental build, not a full build, so it
 # really to catch errors earlier.
 
+MIRROR=${MIRROR:-/build/mirror}
+ALIBUILD_REPO=${ALIBUILD_REPO:-alisw/alibuild}
+ALIDIST_REPO=${ALIDIST_REPO:-alisw/alidist}
+
 while true; do
   if [ ! -e alibuild ]; then
-    git clone https://github.com/alisw/alibuild
+    git clone https://github.com/$ALIBUILD_REPO
   fi
   if [ ! -e alidist ]; then
-    git clone https://github.com/alisw/alidist
+    git clone https://github.com/$ALIDIST_REPO
   fi
   if [ ! -e AliPhysics ]; then
     git clone http://git.cern.ch/pub/AliPhysics
   fi
-  if [ ! -e AliPhysics ]; then
+  if [ ! -e AliRoot ]; then
     git clone http://git.cern.ch/pub/AliRoot
   fi
   for d in alibuild alidist AliRoot AliPhysics; do
@@ -23,5 +27,7 @@ while true; do
     popd
   done
 
-  aliBuild/aliBuild build AliPhysics
+  alibuild/aliDoctor AliPhysics || DOCTOR_ERROR=$?
+  alibuild/aliBuild -j ${JOBS:-`nproc`} --reference-sources $MIRROR build AliPhysics || BUILD_ERROR=$?
+  sleep 10
 done


### PR DESCRIPTION
- ALIBUILD_REPO to configure where to pick up alibuild
- ALIDIST_REPO to configure where to pick up alidist
- Do not die if build fails.
- Use reference sources
- Fix AliPhysics -> AliRoot typo