### PR TITLE
Publish GCC-Toolchain for Ubuntu 16.04

### DIFF
--- a/publish/aliPublish-nightlies.conf
+++ b/publish/aliPublish-nightlies.conf
@@ -7,6 +7,8 @@ experts_email_notif_conf: &experts_email_notif
   - dario.berzano@cern.ch
   - giulio.eulisse@cern.ch
   - peter.hristov@cern.ch
+latest_gcc_conf: &latest_gcc
+  - ^v4\.9\.3-alice3-1$
 
 architectures:
 
@@ -25,20 +27,22 @@ architectures:
   slc6_x86-64:
     CVMFS: el6-x86_64
     include:
-      GCC-Toolchain:
-       - ^v4\.9\.3-alice2-1$
+      GCC-Toolchain: *latest_gcc
 
   slc7_x86-64:
     CVMFS: el7-x86_64
     include:
-      GCC-Toolchain:
-       - ^v4\.9\.3-alice2-2$
+      GCC-Toolchain: *latest_gcc
 
   ubt14_x86-64:
     CVMFS: ubuntu1404-x86_64
     include:
-      GCC-Toolchain:
-       - ^v4\.9\.3-8$
+      GCC-Toolchain: *latest_gcc
+
+  ubt1604_x86-64:
+    CVMFS: ubuntu1604-x86_64
+    include:
+      GCC-Toolchain: *latest_gcc
 
 cvmfs_repository: alice-nightlies.cern.ch
 cvmfs_package_dir: /cvmfs/%(repo)s/%(arch)s/Packages/%(package)s/%(version)s

--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -12,6 +12,8 @@ alice_email_notif_conf: &alice_email_notif alice-analysis-operations@cern.ch
 experts_email_notif_conf: &experts_email_notif
   - dario.berzano@cern.ch
   - giulio.eulisse@cern.ch
+latest_gcc_conf: &latest_gcc
+  - ^v4\.9\.3-alice3-1$
 
 architectures:
 
@@ -80,8 +82,7 @@ architectures:
     AliEn: false
     RPM: false
     include:
-      GCC-Toolchain:
-       - ^v4\.9\.3-([9]|[1-9][0-9]+)$
+      GCC-Toolchain: *latest_gcc
       cctools: true
       AliEn-WorkQueue: true
 
@@ -90,16 +91,21 @@ architectures:
     AliEn: false
     RPM: false
     include:
-      GCC-Toolchain:
-       - ^v4\.9\.3-([8-9]|[1-9][0-9]+)$
+      GCC-Toolchain: *latest_gcc
 
   ubt14_x86-64:
     CVMFS: ubuntu1404-x86_64
     AliEn: false
     RPM: false
     include:
-      GCC-Toolchain:
-       - ^v4\.9\.3-([7-9]|[1-9][0-9]+)$
+      GCC-Toolchain: *latest_gcc
+
+  ubt1604_x86-64:
+    CVMFS: ubuntu1604-x86_64
+    AliEn: false
+    RPM: false
+    include:
+      GCC-Toolchain: *latest_gcc
 
 # CVMFS-specific configuration
 cvmfs_repository: alice.cern.ch

--- a/publish/test-nightlies.yaml
+++ b/publish/test-nightlies.yaml
@@ -4,3 +4,22 @@ slc5_x86-64:
     v5-08-17-01-rc1-1: False
     v5-08-18-01-rc2-1: True
     v5-08-18-01_ROOT6-1: True
+
+slc6_x86-64:
+  GCC-Toolchain:
+    v4.9.3-alice2-1        : False
+    v4.9.3-alice3-1        : True
+
+slc7_x86-64:
+  GCC-Toolchain:
+    v4.9.3-2               : False
+    v4.9.3-alice3-1        : True
+
+ubt14_x86-64:
+  GCC-Toolchain:
+    v4.9.3-8               : False
+    v4.9.3-alice3-1        : True
+
+ubt1604_x86-64:
+  GCC-Toolchain:
+    v4.9.3-alice3-1        : True

--- a/publish/test.yaml
+++ b/publish/test.yaml
@@ -193,3 +193,20 @@ slc6_x86-64:
     v5.4.1-2               : True
   AliEn-WorkQueue:
     v1.0-2                 : True
+  GCC-Toolchain:
+    v4.9.3-alice2-1        : False
+    v4.9.3-alice3-1        : True
+
+slc7_x86-64:
+  GCC-Toolchain:
+    v4.9.3-2               : False
+    v4.9.3-alice3-1        : True
+
+ubt14_x86-64:
+  GCC-Toolchain:
+    v4.9.3-8               : False
+    v4.9.3-alice3-1        : True
+
+ubt1604_x86-64:
+  GCC-Toolchain:
+    v4.9.3-alice3-1        : True


### PR DESCRIPTION
Also prevents to pollute CVMFS with plenty of useless GCC versions by specifying
a fixed one instead of a broad regexp.