### PR TITLE
Fix HLT vault token in inventory file

### DIFF
--- a/jenkins/deploy-hlt-updates
+++ b/jenkins/deploy-hlt-updates
@@ -27,7 +27,7 @@ node ("slc7_x86-64-light") {
         set -e
         set -o pipefail
         cd ansible/inventory
-        sed -e "s/^\\($MY_HOST\\..*\\)$/\\1 vault_token=$MY_VAULT_TOKEN/" hltvoboxes > hltvoboxes.0
+        sed -e "s/^\\($MY_HOST\\..*\\)$/\\1 vault_token=\"$MY_VAULT_TOKEN\"/" hltvoboxes > hltvoboxes.0
         mv -f hltvoboxes.0 hltvoboxes
       '''
       }


### PR DESCRIPTION
Quotes were missing causing occasional YAML parsing errors.