### PR TITLE
Test pull requests for the specified repository

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -21,20 +21,39 @@ while true; do
   DOCTOR_ERROR=""
   BUILD_ERROR=""
 
-  alibuild/aliDoctor ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS} $PACKAGE || DOCTOR_ERROR=$?
-  if [[ $DOCTOR_ERROR != '' ]]; then
-    ali-bot/set-github-status -c alisw/alidist@$ALIDIST_REF -s doctor/$PACKAGE${ALIBUILD_DEFAULTS:+/$ALIBUILD_DEFAULTS}/error
+  if [[ "$PR_REPO" != "" ]]; then
+    HASHES=`ali-bot/list-branch-pr --trusted $TRUSTED_USERS $PR_REPO@$PR_BRANCH`
   else
-    ali-bot/set-github-status -c alisw/alidist@$ALIDIST_REF -s doctor/$PACKAGE${ALIBUILD_DEFAULTS:+/$ALIBUILD_DEFAULTS}/success
+    HASHES="0"
   fi
-  alibuild/aliBuild -j ${JOBS:-`nproc`}                                    \
-                       ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS} \
-                       --reference-sources $MIRROR                         \
-                       build $PACKAGE || BUILD_ERROR=$?
-  if [[ $BUILD_ERROR != '' ]]; then
-    ali-bot/set-github-status -c alisw/alidist@$ALIDIST_REF -s build/$PACKAGE${ALIBUILD_DEFAULTS:+/$ALIBUILD_DEFAULTS}/error
-  else
-    ali-bot/set-github-status -c alisw/alidist@$ALIDIST_REF -s build/$PACKAGE${ALIBUILD_DEFAULTS:+/$ALIBUILD_DEFAULTS}/success
-  fi
-  sleep ${DELAY:-10}
+  for pr_hash in $HASHES; do
+    if [[ "$PR_REPO" != "" ]]; then
+      pushd `basename $PR_REPO`
+        git reset --hard $PR_BRANCH
+        git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
+        git fetch origin
+        git clean -fxd
+        git merge $pr_hash
+        PR_REF=$pr_hash
+      popd
+    fi
+
+    alibuild/aliDoctor ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS} $PACKAGE || DOCTOR_ERROR=$?
+    STATUS_REF=${PR_REPO:-alisw/alidist}@${PR_REF:-$ALIDIST_REF}
+    if [[ $DOCTOR_ERROR != '' ]]; then
+      ali-bot/set-github-status -c ${STATUS_REF} -s doctor/$PACKAGE${ALIBUILD_DEFAULTS:+/$ALIBUILD_DEFAULTS}/error
+    else
+      ali-bot/set-github-status -c ${STATUS_REF} -s doctor/$PACKAGE${ALIBUILD_DEFAULTS:+/$ALIBUILD_DEFAULTS}/success
+    fi
+    alibuild/aliBuild -j ${JOBS:-`nproc`}                                    \
+                         ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS} \
+                         --reference-sources $MIRROR                         \
+                         build $PACKAGE || BUILD_ERROR=$?
+    if [[ $BUILD_ERROR != '' ]]; then
+      ali-bot/set-github-status -c ${STATUS_REF} -s build/$PACKAGE${ALIBUILD_DEFAULTS:+/$ALIBUILD_DEFAULTS}/error
+    else
+      ali-bot/set-github-status -c ${STATUS_REF} -s build/$PACKAGE${ALIBUILD_DEFAULTS:+/$ALIBUILD_DEFAULTS}/success
+    fi
+    sleep ${DELAY:-10}
+  done
 done


### PR DESCRIPTION
Introduces a PR_REPO and PR_BRANCH variable which can be used to point
to a branch in a repository for which to test all the available pull
requests. A TRUSTED list of user can also be specified to limit only to
PRs of trusted users.