### PR TITLE
Improve CVMFS monitor notify logic

### DIFF
--- a/cvmfs-mon/cvmfs-mon.yml
+++ b/cvmfs-mon/cvmfs-mon.yml
@@ -36,7 +36,7 @@ repos:
 
 notif:
   smtp: cernmx.cern.ch:25
-  from: noreply@cern.ch
+  from: "ALICE CVMFS bot <noreply@cern.ch>"
   subject: "Stratum 1 %(stratum_name)s for %(repo)s is outdated"
   body: |
     Stratum 1 %(stratum_name)s for CVMFS repository %(repo)s appears out of date:
@@ -59,6 +59,7 @@ notif:
     --
     ALICE CVMFS check bot
 
-sleep: 3600
+sleep: 1800
 snooze: 14400
-outdated: 3600
+max_timedelta: 3600
+max_revdelta: 4


### PR DESCRIPTION
Current logic matches the one from the webpage[1]. Service is considered:

* OK if Stratum-1 and Stratum-0 have the same snapshot
* Syncing if Stratum-1 is behind less than `max_revdelta` revisions and
  Stratum-0 changed less than `max_timedelta` seconds ago
* Error if Stratum-1 is outdated, either too many revisions or more than
  `max_timedelta` seconds

Logic introduced by #359 is fine but way too tolerant: in the case of the ALICE
OCDB for instance updates are very frequent so notifications were never
triggered even if the Stratum-1 was too many revisions behind.

[1] http://cernvm-monitor.cern.ch/cvmfs-monitor/alice-ocdb.cern.ch/