### PR TITLE
Disable Vc in daily DA RPMs

### DIFF
--- a/daq-da-rpms.sh
+++ b/daq-da-rpms.sh
@@ -7,7 +7,7 @@ ALIDIST_BRANCH=${ALIDIST_REPO##*:}
 ALIDIST_REPO=${ALIDIST_REPO%:*}
 OVERRIDE_TAGS="AliRoot=$ALIROOT_VERSION"
 DEFAULTS=daq
-DISABLE=AliEn-Runtime,GEANT4_VMC,GEANT3,fastjet,GCC-Toolchain
+DISABLE=AliEn-Runtime,GEANT4_VMC,GEANT3,fastjet,GCC-Toolchain,Vc
 REMOTE_STORE=rsync://repo.marathon.mesos/store/
 
 function getver() {


### PR DESCRIPTION
External Vc is too recent and requires C++11, which is not allowed by SLC6
compiler (DAQ requirement).