### PR TITLE
Do not publish CMake any longer

### DIFF
--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -56,9 +56,6 @@ architectures:
       jemalloc:
        - ^v4\.1\.0-[0-9]+$
       AliGenerators: true
-      # Build requires
-      CMake:
-       - ^v3\.5\.2-3$
     exclude:
       AliPhysics:
        - ^vAN-20150910.*$

--- a/publish/test.yaml
+++ b/publish/test.yaml
@@ -1,8 +1,6 @@
 slc5_x86-64:
   cctools:
     v5.4.1-1               : False
-  CMake:
-    v3.5.2-3               : True
   AliEn-WorkQueue:
     v1.0-1                 : False
   AliGenerators:


### PR DESCRIPTION
This reverts #386. We cannot publish that CMake version (missing modulefile).