### PR TITLE
Short-circuit consistency tests for PR

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -84,7 +84,7 @@ while true; do
 
     GITHUB_TOKEN= alibuild/aliBuild -j ${JOBS:-`nproc`}                       \
                          ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS}  \
-                         -z $(echo ${pr_number} | tr - _)                     \
+                         ${ASSUME_CONSISTENT_EXTERNALS:--z $(echo ${pr_number} | tr - _)} \
                          --reference-sources $MIRROR                          \
                          ${REMOTE_STORE:+--remote-store $REMOTE_STORE}        \
                          ${DEBUG:+--debug}                                    \


### PR DESCRIPTION
This should solve the infamous "PR check takes ~20 minutes" reports.
What was happening is that in order to ensure consistency of the builds
we triggered a full rebuild of development packages for each pull
request. This makes sense in the case of alidist pull requests because
you could have non-trivial interpackage dependencies like "use ROOT6
rather than ROOT5" which would fail miserably if short-circuited, at
least in the generic case. This is however not the case for AliRoot /
AliPhysics PR, where make / CMake takes care of the consistency for us
making the extra rebuild unneeded.