### PR TITLE
Do not parse comments when updating branch issues

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -8,6 +8,7 @@ from os.path import dirname, join
 from sys import exit
 import os
 import sys
+from hashlib import sha1
 
 from github import Github
 
@@ -90,25 +91,32 @@ if __name__ == "__main__":
     message = "Error while checking %s for %s:\n```\n%s\n```\nFull log [here](%s).\n" % (args.status, sha, error_log, logUrl)
     for issue in repo.get_issues(state="open"):
       # Look for open issues:
-      # - If we find one which was opened for the same branch / sha
-      #   pair, we update it, if needed.
+      # - If we find one which was opened for the same branch / sha / error message sha
+      #   triplet, we consider having already commented.
+      # - If we find one which was opened for the same branch / sha, but with a different
+      #   error message sha, we close it (as we assume the error message is now different).
       # - If we find one which was opened for a different branch / sha
       #   pair, close it (as we assume it's now obsolete since the branch
       #   points to something else).
       # - If no issue was found for the given branch, create one and add a comment
       #   about the failure.
+      messageSha = sha1(message).hexdigest()[0:10]
+      if issue.title.startswith("Error while checking branch %s@%s:%s" % (pr_id, sha, messageSha)):
+        print("Issue still valid. Exiting.", file=sys.stderr)
+        exit(0)
       if issue.title.startswith("Error while checking branch %s@%s" % (pr_id, sha)):
-        for comment in issue.get_comments():
-          if comment.body == message:
-            print("Comment on branch was already done", file=sys.stderr)
-            exit(0)
-          comment.edit(message)
-          exit(0)
+        print("Issue is about something different. Updating.")
+        issue.create_comment(body="Error for commit %s has changed.\n" % sha + message)
+        issue.edit(title="Error while checking branch %s@%s:%s" % (pr_id, sha, messageSha))
+        exit(0)
       if issue.title.startswith("Error while checking branch %s@" % pr_id):
         issue.create_comment("Branch was updated. Closing issue.")
         issue.edit(state="close")
         continue
-    issue = repo.create_issue(title="Error while checking branch %s@%s" % (pr_id, sha))
+    # The first time we report an issue with a commit, we do so as issue body.
+    # Subsequent changes will be reported as comments.
+    issue = repo.create_issue(title="Error while checking branch %s@%s:%s" % (pr_id, sha, messageSha),
+                              body=message)
     issue.create_comment(body=message)
     exit(0)
 


### PR DESCRIPTION
Rather than parsing comments to see if we have a new error to report,
we encode the error as part of the the issue title, so that we can
immediately spot if something needs to be changed. This should
spare us a few API calls.