### PR TITLE
Add shuttle aliBuild steering script

### DIFF
--- a/make-shuttle.sh
+++ b/make-shuttle.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+type aliBuild &> /dev/null
+[[ $# == 1 ]] || { printf "Please specify an AliRoot tag as the only argument.\n"; exit 1; }
+mkdir -p ~/alibuild/sw/MIRROR && cd ~/alibuild
+[[ -d alidist/.git ]] || git clone https://github.com/alisw/alidist alidist/
+[[ -d sw/MIRROR/aliroot ]] || git clone --bare https://github.com/alisw/AliRoot sw/MIRROR/aliroot
+[[ -d AliRoot ]] || git clone --reference sw/MIRROR/aliroot https://github.com/alisw/AliRoot AliRoot/
+if [[ $1 != master && ! $MAKE_SHUTTLE_RETRY ]]; then
+  [[ -d AliRoot_master ]] || git clone --reference sw/MIRROR/aliroot https://github.com/alisw/AliRoot AliRoot_master/
+  pushd AliRoot_master
+    # Upstream master of AliRoot
+    git fetch --all
+    git clean -fxd
+    git checkout master
+    git reset --hard origin/master
+  popd
+fi
+pushd AliRoot
+  # Upstream user-defined tag of AliRoot
+  git fetch --all
+  git clean -fxd
+  git checkout master
+  git reset --hard refs/tags/$1 || git reset --hard origin/$1 || git reset --hard $1
+popd
+[[ -d AliRoot_master && ! $MAKE_SHUTTLE_RETRY ]] && rsync -av --delete AliRoot_master/SHUTTLE/ AliRoot/SHUTTLE/ || true
+( cd AliRoot && git status )
+# If we are building the master and the build fails, fall back to the latest
+# working version. Do not fall back in case we are building a tag.
+aliBuild build AliRoot --debug --defaults shuttle || \
+  { [[ $1 != master || $MAKE_SHUTTLE_RETRY ]] && exit 1; } || \
+  { export MAKE_SHUTTLE_RETRY=1; exec "$0" $(cat latest_working_hash); }
+LOCAL_HASH=$( cd AliRoot && git rev-parse HEAD )
+UPSTREAM_HASH=$( cd AliRoot && git rev-parse origin/master )
+printf $LOCAL_HASH > latest_working_hash
+printf "\n\033[1;32mAliRoot SHUTTLE version $LOCAL_HASH compiled OK.\n"
+[[ $LOCAL_HASH == $UPSTREAM_HASH ]] && printf "This matches the upstream version.\033[m\n\n" \
+                                    || printf "\033[33mThis is different from the upstream version ($UPSTREAM_HASH).\033[m\n\n"


### PR DESCRIPTION
* For both the test shuttle and the production one
* Uses aliBuild
* When building master it falls back to the latest working version in case it
  does not compile