### PR TITLE
Exclude publishing of faulty tags

### DIFF
--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -90,6 +90,8 @@ architectures:
        - ^vAN-2017(01|02|03)(0[2-9]|[1-2][0-9]|3[0-1])(_TEST|_GITHUB)?-.*$
        - ^vAN-201704(0[2-9]|1[0-6])(_TEST|_GITHUB)?-.*$
        - ^v5-06-23-01-30-xrd-1$
+       # Excluded after determining they were faulty
+       - ^vAN-201707(0[6-9]|1[0-9]|2[012])-.*$
        # Faulty AliRoot v5-09-08 and all related tags
        - ^vAN-2017((05(29|30|31))|(06(0[1-9]|1[0-5])))-.*$
        - ^v5-09-08-01-.*$

--- a/publish/test.yaml
+++ b/publish/test.yaml
@@ -200,6 +200,23 @@ slc5_x86-64:
     vAN-20170301_GITHUB-1  : False
     v5-09-01-01-1          : True
     v5-09-01-01-newTPCsm1-1 : True
+    vAN-20170706-1 : False
+    vAN-20170707-1 : False
+    vAN-20170708-1 : False
+    vAN-20170709-1 : False
+    vAN-20170710-1 : False
+    vAN-20170711-1 : False
+    vAN-20170712-1 : False
+    vAN-20170713-1 : False
+    vAN-20170714-1 : False
+    vAN-20170715-1 : False
+    vAN-20170716-1 : False
+    vAN-20170717-1 : False
+    vAN-20170718-1 : False
+    vAN-20170719-1 : False
+    vAN-20170720-1 : False
+    vAN-20170721-1 : False
+    vAN-20170722-1 : False
 
 slc6_x86-64:
   cctools:


### PR DESCRIPTION
Analysis tags depending on v5-09-10 and v5-09-11 have to be removed as per
the Physics Board decision. See alisw/AliRoot#332.