### PR TITLE
Pick a failed/reviewed PR to re-test randomly

### DIFF
--- a/list-branch-pr
+++ b/list-branch-pr
@@ -315,7 +315,8 @@ if __name__ == "__main__":
                 err, out = getstatusoutput("sleep {0}".format(args.poll_time))
                 if err or timeSince(start) >= args.maxWait:
                     # return whatever we have (may be empty)
-                    prs = (grouped["not_successful"][:1] or 
-                           grouped["reviewed"][:1])
-                    sendToStdOut(prs)
+                    if grouped["not_successful"]:
+                      sendToStdOut([random.choice(grouped["not_successful"])])
+                    elif grouped["reviewed"]:
+                      sendToStdOut([random.choice(grouped["reviewed"])])
                     break


### PR DESCRIPTION
Current C.I. mechanism favors untested PRs, and in case no PR is untested, it
retests the first one which failed (or the first one which was reviewed), not
giving any chance to other failed PRs to get retested. This PR mitigates the
problem by picking a random failed (or reviewed) PR instead of the first one.