### PR TITLE
Add generation of "updatable" RPMs

### DIFF
--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -373,8 +373,9 @@ class AliEnPackMan(object):
 
 class RPM(object):
 
-  def __init__(self, repoDir, publishScriptTpl, connParams, dryRun=False):
+  def __init__(self, repoDir, publishScriptTpl, connParams, genUpdatableRpms, dryRun=False):
     self._dryRun = dryRun
+    self._genUpdatableRpms = genUpdatableRpms
     self._repoDir = repoDir
     self._publishScriptTpl = publishScriptTpl
     self._countChanges = 0
@@ -382,11 +383,21 @@ class RPM(object):
     self._archs = []
 
   def _kw(self, url, arch, pkgName, pkgVer, workDir=None, deps=None):
-    kw =  { "url": url, "package": pkgName, "version": pkgVer, "arch": arch, "dependencies": deps,
-            "repodir": self._repoDir+"/"+arch, "workdir": workDir }
+    kw =  { "url"          : url,
+            "package"      : pkgName,
+            "version"      : pkgVer,
+            "version_rpm"  : pkgVer.replace("-", "_"),
+            "arch"         : arch,
+            "dependencies" : deps,
+            "repodir"      : self._repoDir+"/"+arch,
+            "workdir"      : workDir,
+            "updatable"    : "1" if self._genUpdatableRpms else "" }
     kw.update(self._connParams)
     kw["http_ssl_verify"] = 1 if kw["http_ssl_verify"] else 0
-    kw.update({ "rpm": format("alisw-%(package)s+%(version)s-1-1.%(arch)s.rpm", **kw) })
+    if self._genUpdatableRpms:
+      kw.update({ "rpm": format("alisw-%(package)s-%(version_rpm)s-1.%(arch)s.rpm", **kw) })
+    else:
+      kw.update({ "rpm": format("alisw-%(package)s+%(version)s-1-1.%(arch)s.rpm", **kw) })
     return kw
 
   def installed(self, arch, pkgName, pkgVer):
@@ -883,10 +894,12 @@ def main():
       if not isinstance(conf.get("rpm_repo_dir", None), basestring):
         error("rpm_repo_dir must be a string")
         sys.exit(1)
+      conf["rpm_updatable"] = conf.get("rpm_updatable", False)
       archKey = "RPM"
       pub = RPM(repoDir=conf["rpm_repo_dir"],
                 publishScriptTpl=open(progDir+"/pub-rpms-template.sh").read(),
                 connParams=connParams,
+                genUpdatableRpms=conf["rpm_updatable"],
                 dryRun=args.dryRun)
     if args.abort:
       pub.abort(force=True)

--- a/publish/pub-rpms-template.sh
+++ b/publish/pub-rpms-template.sh
@@ -12,18 +12,19 @@ SSLVERIFY=%(http_ssl_verify)d
 CONNTIMEOUT=%(conn_timeout_s)d
 CONNRETRY=%(conn_retries)d
 CONNRETRYDELAY=%(conn_dethrottle_s)d
+RPM_IS_UPDATABLE=%(updatable)s
 [[ $SSLVERIFY == 0 ]] && SSLVERIFY=-k || SSLVERIFY=
 which fpm
 cd $TMPDIR
 
 # Create aliswmod RPM
-ALISWMOD_VERSION=1
+ALISWMOD_VERSION=2
 ALISWMOD_RPM="alisw-aliswmod-$ALISWMOD_VERSION-1.%(arch)s.rpm"
 if [[ ! -e "%(repodir)s/$ALISWMOD_RPM" ]]; then
   mkdir -p aliswmod/bin
   cat > aliswmod/bin/aliswmod <<EOF
 #!/bin/bash -e
-export MODULEPATH=$INSTALLPREFIX/$FLAVOUR/modulefiles:\$MODULEPATH
+export MODULEPATH=$INSTALLPREFIX/$FLAVOUR/modulefiles:$INSTALLPREFIX/$FLAVOUR/etc/Modules/modulefiles:\$MODULEPATH
 EOF
   cat >> aliswmod/bin/aliswmod <<\EOF
 MODULES_SHELL=$(ps -e -o pid,command | grep -E "^\s*$PPID\s+" | awk '{print $2}' | sed -e 's/^-\{0,1\}\(.*\)$/\1/')
@@ -57,64 +58,109 @@ else
   ALISWMOD_RPM=
 fi
 
-# Create RPM from tarball
-curl -Lsf $SSLVERIFY                \
-     --connect-timeout $CONNTIMEOUT \
-     --retry-delay $CONNRETRYDELAY  \
-     --retry $CONNRETRY "%(url)s"   | tar --strip-components=2 -xzf -
-[[ -e "%(package)s/%(version)s/etc/modulefiles/%(package)s" ]]
 DEPS=()
-DEPS+=("--depends" "alisw-aliswmod")
-for D in %(dependencies)s; do
-  DEPS+=("--depends" "$D = 1-1.$FLAVOUR")
-done
+DEPS+=("--depends" "alisw-aliswmod >= $ALISWMOD_VERSION")
+
+# Updatable RPMs don't have the version number hardcoded in the package name
+if [[ $RPM_IS_UPDATABLE ]]; then
+  RPM_VERSION="%(version)s"
+  RPM_VERSION=${RPM_VERSION//-/_}
+  RPM_PACKAGE="alisw-%(package)s"
+  RPM_TAR_STRIP=4
+  RPM_ROOT="."
+  RPM_UNPACK_DIR="."
+  RPM_MODULEFILE_PREFIX=
+  for D in %(dependencies)s; do
+    DEP_NAME=${D%%+*}
+    DEP_VER=${D#*+}
+    DEP_VER=${DEP_VER//-/_}
+    DEPS+=("--depends" "$DEP_NAME = ${DEP_VER}-1.$FLAVOUR")
+  done
+else
+  RPM_VERSION=1
+  RPM_PACKAGE="alisw-%(package)s+%(version)s"
+  RPM_TAR_STRIP=2
+  RPM_ROOT="%(package)s/%(version)s"
+  RPM_UNPACK_DIR="%(package)s"
+  for D in %(dependencies)s; do
+    DEPS+=("--depends" "$D = 1-1.$FLAVOUR")
+  done
+fi
+
+# Create RPM from tarball
+mkdir -p unpack_rpm
+pushd unpack_rpm
+  # RPM's root dir will be $TMPDIR/unpack_rpm/$RPM_UNPACK_DIR
+  curl -Lsf $SSLVERIFY                \
+       --connect-timeout $CONNTIMEOUT \
+       --retry-delay $CONNRETRYDELAY  \
+       --retry $CONNRETRY "%(url)s"   | tar --strip-components=$RPM_TAR_STRIP -xzf -
+  # Make sure Modulefile is there
+  [[ -e "$RPM_ROOT/etc/modulefiles/%(package)s" ]]
+  # Remove useless files conflicting between packages
+  rm -rfv $RPM_ROOT/.build-hash            \
+          $RPM_ROOT/etc/profile.d/init.sh* \
+          $RPM_ROOT/.original-unrelocated
+popd
+
 AFTER_INSTALL=$TMPDIR/after_install.sh
 AFTER_REMOVE=$TMPDIR/after_remove.sh
+
 cat > $AFTER_INSTALL <<EOF
 #!/bin/bash -e
+RPM_IS_UPDATABLE=$RPM_IS_UPDATABLE
 export WORK_DIR=$INSTALLPREFIX
 cd \$WORK_DIR
-export PKGPATH=$FLAVOUR/%(package)s/%(version)s
-source \$PKGPATH/relocate-me.sh
-mkdir -p $INSTALLPREFIX/$FLAVOUR/modulefiles/%(package)s
-ln -nfs ../../%(package)s/%(version)s/etc/modulefiles/%(package)s \
-        $INSTALLPREFIX/$FLAVOUR/modulefiles/%(package)s/%(version)s
-mkdir -p $INSTALLPREFIX/$FLAVOUR/modulefiles/BASE
-echo -e "#%%Module\nsetenv BASEDIR $INSTALLPREFIX/$FLAVOUR" > \
-        $INSTALLPREFIX/$FLAVOUR/modulefiles/BASE/1.0
+[[ \$RPM_IS_UPDATABLE ]] && export PKGPATH=${FLAVOUR} || export PKGPATH="${FLAVOUR}/%(package)s/%(version)s"
 EOF
+grep -v 'profile\.d/init\.sh\.unrelocated' unpack_rpm/$RPM_ROOT/relocate-me.sh >> $AFTER_INSTALL
+rm -fv unpack_rpm/$RPM_ROOT/relocate-me.sh
+cat >> $AFTER_INSTALL <<EOF
+MODULE_DEST_DIR=$INSTALLPREFIX/$FLAVOUR/\${RPM_IS_UPDATABLE:+etc/Modules/}modulefiles
+mkdir -p \$MODULE_DEST_DIR/%(package)s
+if [[ \$RPM_IS_UPDATABLE ]]; then
+  sed -e 's|%(package)s/\$version||g; s|%(package)s/%(version)s||g' $INSTALLPREFIX/$FLAVOUR/etc/modulefiles/%(package)s > \$MODULE_DEST_DIR/%(package)s/%(version)s
+else
+  ln -nfs ../../%(package)s/%(version)s/etc/modulefiles/%(package)s \$MODULE_DEST_DIR/%(package)s/%(version)s
+fi
+mkdir -p \$MODULE_DEST_DIR/BASE
+echo -e "#%%Module\nsetenv BASEDIR $INSTALLPREFIX/$FLAVOUR" > \$MODULE_DEST_DIR/BASE/1.0
+EOF
+
 cat > $AFTER_REMOVE <<EOF
 #!/bin/bash
 ( rm -f $INSTALLPREFIX/$FLAVOUR/modulefiles/%(package)s/%(version)s
+  rm -f $INSTALLPREFIX/$FLAVOUR/etc/Modules/modulefiles/%(package)s/%(version)s
   rmdir $INSTALLPREFIX/$FLAVOUR/modulefiles/%(package)s
-  find $INSTALLPREFIX/$FLAVOUR/%(package)s/%(version)s -depth -type d \
-       -exec rmdir '{}' \;
+  find $INSTALLPREFIX/$FLAVOUR/%(package)s/%(version)s -depth -type d -exec rmdir '{}' \;
   rmdir $INSTALLPREFIX/$FLAVOUR/%(package)s
-  if [[ "\$(find $INSTALLPREFIX/$FLAVOUR \
-                 -mindepth 1 -maxdepth 1 -type d \
-                 -not -name modulefiles )" == "" ]]; then
+  if [[ "\$(find $INSTALLPREFIX/$FLAVOUR -mindepth 1 -maxdepth 1 -type d -not -name modulefiles )" == "" ]]; then
     rm -rf $INSTALLPREFIX/$FLAVOUR
     rmdir $INSTALLPREFIX
   fi
 ) 2> /dev/null
 true
 EOF
+
 # We must put the full version in the package name to allow multiple versions
 # to be installed at the same time, see [1]
 # [1] http://www.rpm.org/wiki/PackagerDocs/MultipleVersions
-fpm -s dir \
-    -t rpm \
-    --force \
-    "${DEPS[@]}" \
-    --prefix $INSTALLPREFIX/$FLAVOUR \
-    --architecture $ARCHITECTURE \
-    --version 1 \
-    --iteration 1.$FLAVOUR \
-    --name alisw-%(package)s+%(version)s \
-    --after-install $AFTER_INSTALL \
-    --after-remove $AFTER_REMOVE \
-    "%(package)s/"
-RPM="alisw-%(package)s+%(version)s-1-1.%(arch)s.rpm"
-[[ -e $RPM ]]
-mkdir -vp %(repodir)s
+pushd unpack_rpm
+  fpm -s dir                           \
+      -t rpm                           \
+      --force                          \
+      "${DEPS[@]}"                     \
+      --prefix $INSTALLPREFIX/$FLAVOUR \
+      --architecture $ARCHITECTURE     \
+      --version "$RPM_VERSION"         \
+      --iteration 1.$FLAVOUR           \
+      --name "$RPM_PACKAGE"            \
+      --after-install $AFTER_INSTALL   \
+      --after-remove $AFTER_REMOVE     \
+      "$RPM_UNPACK_DIR"
+  RPM="${RPM_PACKAGE}-${RPM_VERSION}-1.%(arch)s.rpm"
+  [[ -e $RPM ]]
+  mkdir -vp %(repodir)s
+  mv -v $RPM ../
+popd
 mv -v $RPM $ALISWMOD_RPM %(repodir)s


### PR DESCRIPTION
Along with normal aliPublish RPMs, allowing for multiple versions of the same
package to be installed at the same time, this feature enables the creation
of more standard RPMs, without the version name hardcoded in the package string.

Such RPMs are installable without specifying the version:

    yum install alisw-dim

and updatable the same way.

All updatable RPMs get unpacked under the same prefix (as opposed to a different
prefix for each package). Modulefiles through the `aliswmod` command work
accordingly.