### PR TITLE
Use alidist defaults for Jenkins daily builds

### DIFF
--- a/daily-aliphysics.sh
+++ b/daily-aliphysics.sh
@@ -15,7 +15,19 @@ WORKAREA_INDEX=0
 [[ $ALIBUILD_REPO == */* ]] || ALIBUILD_REPO=$ALIBUILD_REPO/alibuild
 [[ $ALIDIST_REPO == */* ]] || ALIDIST_REPO=$ALIDIST_REPO/alidist
 rm -rf alibuild/ alidist/
-git clone -b $ALIDIST_BRANCH https://github.com/$ALIDIST_REPO alidist/
+
+# Correctly interpret <latest> in alidist version specification
+git clone https://github.com/$ALIDIST_REPO alidist/
+if [[ $ALIDIST_BRANCH == *'<latest>'* ]]; then
+  ALIDIST_BRANCH=${ALIDIST_BRANCH/<latest>/[0-9a-zA-Z_-]\+}
+  ALIDIST_BRANCH=$(cd alidist; git log --date-order --graph --tags --simplify-by-decoration --pretty=format:'%d' | grep -oE "$ALIDIST_BRANCH" | head -n1)
+  #ALIDIST_BRANCH=$(cd alidist; git tag --sort=-v:refname | grep -E -- "$ALIDIST_BRANCH" | head -1)
+  [[ $ALIDIST_BRANCH ]] || { echo "Cannot find latest tag matching expression!"; exit 1; }
+fi
+pushd alidist
+  git checkout $ALIDIST_BRANCH
+  exit 0
+popd
 
 # Get aliBuild with pip in a temporary directory. Gets all dependencies too
 export PYTHONUSERBASE=$(mktemp -d)

--- a/jenkins/daily-aliphysics
+++ b/jenkins/daily-aliphysics
@@ -1,7 +1,7 @@
 #!groovy
 node ("slc7_x86-64-light") {
   try {
-    currentBuild.displayName = "#${env.BUILD_NUMBER} - $PACKAGE_NAME $OVERRIDE_TAGS $ARCHITECTURE"
+    currentBuild.displayName = "#${env.BUILD_NUMBER} - $PACKAGE_NAME $DEFAULTS $ARCHITECTURE"
 
     stage "Wait pull requests"
     if ("$WAIT_PR" == "true") {
@@ -83,11 +83,7 @@ node ("slc7_x86-64-light") {
                    "ALIBOT_REPO=${ALIBOT_REPO}",
                    "ARCHITECTURE=${ARCHITECTURE}",
                    "PACKAGE_NAME=${PACKAGE_NAME}",
-                   "OVERRIDE_TAGS=${OVERRIDE_TAGS}",
-                   "DISABLE=${DISABLE}",
                    "DEFAULTS=${DEFAULTS}",
-                   "PUBLISH_BUILDS=${PUBLISH_BUILDS}",
-                   "USE_REMOTE_STORE=${USE_REMOTE_STORE}",
                    "TEST_TAG=${TEST_TAG}",
                    "REMOVE_RC_BRANCH_FIRST=${REMOVE_RC_BRANCH_FIRST}"]) {
             sh '''


### PR DESCRIPTION
This allows to move entirely the "latest AliRoot version" configuration to alidist, via proper defaults. Jenkins configuration will not need any update anymore.