### PR TITLE
Fix HEAD lookup in daily tag script

### DIFF
--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -72,8 +72,9 @@ pushd $AUTOTAG_CLONE
     fi
 
     if [[ "$AUTOTAG_HASH" == '' ]]; then
-      AUTOTAG_HASH=$( (git ls-remote | grep -E '\sHEAD$' || true) | tail -n1 | awk '{print $1}' )
-      [[ "$AUTOTAG_HASH" != '' ]]
+      # sed + grep to make it work reliably on SLC5 too (grep does not support '\s' there)
+      AUTOTAG_HASH=$( (git ls-remote | sed -e 's/\t/ /g' | grep -E ' HEAD$' || true) | tail -n1 | awk '{print $1}' )
+      [[ $AUTOTAG_HASH ]] || { echo "FATAL: Cannot find any hash pointing to HEAD (repo's default branch)!" >&2; exit 1; }
       git push origin $AUTOTAG_HASH:refs/heads/$AUTOTAG_BRANCH
     fi
   fi


### PR DESCRIPTION
* Remove `grep -E '\s'` not supported on SLC5's `grep`...
* Add check to make sure `AUTOTAG_HASH` is never empty, to prevent turning
  commands like `git push origin $AUTOTAG_BRANCH:...` into accidental deletions