### PR TITLE
CVMFS alienv updates for O2 deployment

### DIFF
--- a/cvmfs/alienv
+++ b/cvmfs/alienv
@@ -193,6 +193,7 @@ EOF
 # Old modulefiles were not loading AliEn automatically as a dependency. For
 # those packages we must do it manually.
 function load_alien_if_missing {
+  echo $MODULEPATH | grep 'x86_64-2.6-gnu-4.1.2/Modules/modulefiles' -q || return 0  # load AliEn only on SLC5
   local REQ_ALIEN="ROOT GEANT3 GEANT4 AliRoot AliPhysics"
   if ! $moduleenv $modulecmd bash -t list 2>&1 | grep -q AliEn-Runtime; then
     for PKG in $REQ_ALIEN; do

--- a/cvmfs/alienv
+++ b/cvmfs/alienv
@@ -293,12 +293,15 @@ if [[ x"$PACKAGES" != x ]]; then
     [ x$OK == x1 ] && break || { [ x$ALIENV_DEBUG == x1 ] && printf "WARNING: cannot find packages with MODULEPATH set to $MODULEPATH\n"; }
   done
 else
+  # PACKAGES is empty, meaning we are executing list operations. Use all paths
+  # in MODULEPATH because we want to list packages for all platforms.
   moduledirs="`echo "$modulepath
                      $cvmfsdir/x86_64-2.6-gnu-4.1.2
                      $cvmfsdir/x86_64-2.6-gnu-4.7.2
                      $cvmfsdir/x86_64-2.6-gnu-4.8.3
                      $cvmfsdir/x86_64-2.6-gnu-4.8.4
-                     $cvmfsdir/el6-x86_64"`"
+                     $cvmfsdir/el6-x86_64
+                     $cvmfsdir/el7-x86_64"`"
   export MODULEPATH=$(modulepath modulefiles $moduledirs)
   [ x$platform != x ] && MODULEPATH="$cvmfsdir/etc/toolchain/modulefiles/${platform}-${uname_m}:$MODULEPATH"
 fi

--- a/publish/aliPublish-nightlies.conf
+++ b/publish/aliPublish-nightlies.conf
@@ -39,6 +39,8 @@ architectures:
     CVMFS: el6-x86_64
     include:
       GCC-Toolchain: *latest_gcc
+      O2:
+        - ^nightly-20[0-9]{6}-[0-9]+$
 
   slc7_x86-64:
     CVMFS: el7-x86_64
@@ -48,14 +50,10 @@ architectures:
       mesos: True
       aurora-server: True
       mesos-agent: True
-      O2:
-        - ^nightly-20[0-9]{6}-[0-9]+$
+      O2: False
     exclude:
       flpproto:
         - ^v20170915-1$
-      O2:
-        - ^fa3ea88837_O2_DAQ-1$
-        - ^nightly-20171122-1$
       mesos:
         - ^v0.*
 

--- a/publish/test-nightlies.yaml
+++ b/publish/test-nightlies.yaml
@@ -15,13 +15,18 @@ slc6_x86-64:
   GCC-Toolchain:
     v4.9.3-alice2-1        : False
     v4.9.3-alice3-1        : True
+    v6.2.0-alice1-1        : True
+  O2:
+    nightly-20171130-1     : True
+    nightly-20171201-1     : True
 
 slc7_x86-64:
   GCC-Toolchain:
     v4.9.3-2               : False
     v4.9.3-alice3-1        : True
+    v6.2.0-alice1-1        : True
   O2:
-    nightly-20171123-1     : True
+    nightly-20171123-1     : False
     nightly-20171122-1     : False
     nightly-22171122-1     : False
 
@@ -29,7 +34,9 @@ ubt14_x86-64:
   GCC-Toolchain:
     v4.9.3-8               : False
     v4.9.3-alice3-1        : True
+    v6.2.0-alice1-1        : True
 
 ubt1604_x86-64:
   GCC-Toolchain:
     v4.9.3-alice3-1        : True
+    v6.2.0-alice1-1        : True


### PR DESCRIPTION
Such updates are backwards-compatible and do not break current production
`alienv` usage on the Grid