### PR TITLE
Fix nightlies sender email

### DIFF
--- a/publish/aliPublish-nightlies.conf
+++ b/publish/aliPublish-nightlies.conf
@@ -85,7 +85,7 @@ notification_email:
       Automatically loaded dependencies:
 
       %(alldependencies_fmt)s
-      You can use the CVMFS package (e.g. from lxplus) like this:
+      You can use the CVMFS package from lxplus.cern.ch like this:
 
         /cvmfs/alice-nightlies.cern.ch/bin/alienv enter %(package)s/%(version)s
 
@@ -93,7 +93,7 @@ notification_email:
       --
       The ALICE Build Infrastructure
     subject: "[CVMFS-Nightlies] %(package)s %(version)s published"
-    from: "ALICE Builder <noreply@cern.ch>"
+    from: "ALICE Builder <alice-o2-software-support@cern.ch>"
     to:
       AliRoot: *experts_email_notif
       AliPhysics: *experts_email_notif


### PR DESCRIPTION
Allows posting _to_ alice-o2-software-support@cern.ch by using the same _from_ address.