### PR TITLE
Expose PR information to builder

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -145,6 +145,7 @@ while true; do
     git config --global credential.helper "store --file ~/.git-creds"
 
     ALIBUILD_HEAD_HASH=$pr_hash ALIBUILD_BASE_HASH=$base_hash                              \
+    PR_NUMBER=${pr_number} PR_BRANCH=${PR_BRANCH}                                          \
     GITLAB_USER= GITLAB_PASS= GITHUB_TOKEN= INFLUXDB_WRITE_URL=                            \
     $LONG_TIMEOUT_CMD                                                                      \
     alibuild/aliBuild -j ${JOBS:-`nproc`}                                                  \


### PR DESCRIPTION
This is required for codecov.io integration of PR reports.