### PR TITLE
Fix CI InfluxDB and timeout on macOS

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -18,10 +18,14 @@ export ALIBOT_ANALYTICS_APP_NAME="continuous-builder.sh"
 TIME_STARTED=$(date -u +%s)
 CI_HASH=$(cd "$(dirname "$0")" && git rev-parse HEAD)
 
+# timeout vs. gtimeout (macOS with Homebrew)
+TIMEOUT_EXEC=timeout
+type timeout > /dev/null 2>&1 || TIMEOUT_EXEC=gtimeout
+
 MIRROR=${MIRROR:-/build/mirror}
 PACKAGE=${PACKAGE:-AliPhysics}
-TIMEOUT_CMD="timeout -s9 ${TIMEOUT:-600}"
-LONG_TIMEOUT_CMD="timeout -s9 ${LONG_TIMEOUT:-36000}"
+TIMEOUT_CMD="$TIMEOUT_EXEC -s9 ${TIMEOUT:-600}"
+LONG_TIMEOUT_CMD="$TIMEOUT_EXEC -s9 ${LONG_TIMEOUT:-36000}"
 
 # If INFLUXDB_WRITE_URL starts with insecure_https://, then strip "insecure" and
 # set the proper option to curl

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -5,7 +5,7 @@
 
 source ~/.continuous-builder || true
 ERR=0
-for V in GITHUB_TOKEN GITLAB_USER GITLAB_PASS PR_REPO PACKAGE CHECK_NAME PR_BRANCH ALIBUILD_DEFAULTS; do
+for V in GITHUB_TOKEN GITLAB_USER GITLAB_PASS PR_REPO PACKAGE CHECK_NAME PR_BRANCH ALIBUILD_DEFAULTS INFLUXDB_WRITE_URL; do
   [[ $(eval echo \$$V) ]] || { echo "Required variable $V not defined!"; ERR=1; continue; }
   eval "export $V"
 done


### PR DESCRIPTION
* Add support for INFLUXDB_WRITE_URL
* Add support for `gtimeout` from Homebrew if `timeout` is n.a.