### PR TITLE
Make coverage work for branches

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -158,7 +158,7 @@ while true; do
     git credential-store --file ~/.git-creds store
     git config --global credential.helper "store --file ~/.git-creds"
 
-    FETCH_REPOS=$(alibuild/aliBuild build --help | grep fetch-repos)
+    FETCH_REPOS="$(alibuild/aliBuild build --help | grep fetch-repos || true)"
     ALIBUILD_HEAD_HASH=$pr_hash ALIBUILD_BASE_HASH=$base_hash                             \
     GITLAB_USER= GITLAB_PASS= GITHUB_TOKEN= INFLUXDB_WRITE_URL= CODECOV_TOKEN=            \
     $LONG_TIMEOUT_CMD                                                                     \

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -191,6 +191,11 @@ while true; do
         if [[ $COVERAGE_COMMIT_HASH == 0 ]]; then
           COVERAGE_COMMIT_HASH=${base_hash}
         fi
+        # If not a number, it's the branch name
+        re='^[0-9]+$'
+        if ! [[ $pr_number =~ $re ]] ; then
+          unset $pr_number
+        fi
         $TIMEOUT_CMD bash <(curl --max-time 600 -s https://codecov.io/bash) -y .codecov.yml \
                                                 -R $COVERAGE_SOURCES                        \
                                                 -f coverage.info                            \

--- a/list-branch-pr
+++ b/list-branch-pr
@@ -174,6 +174,9 @@ def _do_process_main_branch(branch, cgh, args):
     all_statuses = get_all_statuses(args.repo_name, branch["commit"]["sha"])
     item = {"number": args.branch_ref, "sha": branch["commit"]["sha"]}
     item.update(getStatusInfo(all_statuses, args))
+    # We consider main branches as always reviewed, since they are already in
+    # the main repository.
+    item["reviewed"] = True
     return item
 
 


### PR DESCRIPTION
This changes two things in continuous builder to make coverage
report also for branches.

First of all commits on branches in the main repository are always
considered "trusted" since someone must have merged them before.

Secondly, in the case of branches the PR number is actually the branch
name, so we do not pass that to codecov, since it seems to be confused
by it and drops the report.