### PR TITLE
Improve stability of continuous integration

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -76,6 +76,9 @@ report_state started
 while true; do
   report_state looping
 
+  # Run preliminary cleanup command
+  alibuild/aliBuild clean ${DEBUG:+--debug}
+
   # Update all Git repositories (except ali-bot)
   for d in $(find . -maxdepth 2 -name .git -exec dirname {} \; | grep -v ali-bot); do
     pushd $d
@@ -191,6 +194,9 @@ while true; do
       $TIMEOUT_CMD set-github-status -c ${STATUS_REF} -s $CHECK_NAME/success || $TIMEOUT_CMD report-analytics exception --desc "set-github-status fail on build success"
     fi
     [[ $BUILD_ERROR ]] && LAST_PR_OK=0 || LAST_PR_OK=1
+
+    # Run post-build cleanup command
+    alibuild/aliBuild clean ${DEBUG:+--debug}
 
     # Look for any code coverage file for the given commit and push
     # it to codecov.io

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -95,7 +95,7 @@ while true; do
           LAST_GIT_GC=$(date -u +%s)
         fi
         # Try to reset to corresponding remote branch (assume it's origin/<branch>)
-        $TIMEOUT_CMD git fetch origin
+        $TIMEOUT_CMD git fetch origin $PR_BRANCH
         git reset --hard origin/$LOCAL_BRANCH
         git clean -fxd
       fi
@@ -127,7 +127,8 @@ while true; do
       pushd ${PR_REPO_CHECKOUT:-$(basename $PR_REPO)}
         CANNOT_MERGE=0
         git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
-        $TIMEOUT_CMD git fetch origin
+        $TIMEOUT_CMD git fetch origin $PR_BRANCH
+        [[ $pr_number =~ ^[0-9]*$ ]] && $TIMEOUT_CMD git fetch origin pull/$pr_number/head
         git reset --hard origin/$PR_BRANCH  # reset to branch target of PRs
         git clean -fxd
         OLD_SIZE=`$DU --exclude=.git -sb . | awk '{print $1}'`

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -90,7 +90,14 @@ while true; do
   done
 
   if [[ "$PR_REPO" != "" ]]; then
-    HASHES=`$TIMEOUT_CMD list-branch-pr --show-main-branch --check-name $CHECK_NAME ${TRUST_COLLABORATORS:+--trust-collaborators} ${TRUSTED_USERS:+--trusted $TRUSTED_USERS} $PR_REPO@$PR_BRANCH ${WORKERS_POOL_SIZE:+--workers-pool-size $WORKERS_POOL_SIZE} ${WORKER_INDEX:+--worker-index $WORKER_INDEX} ${DELAY:+--max-wait $DELAY} || $TIMEOUT_CMD report-analytics exception --desc "list-branch-pr failed"`
+    HASHES=$(cat force-hashes 2> /dev/null || true)
+    if [[ ! $HASHES ]]; then
+      HASHES=`$TIMEOUT_CMD list-branch-pr --show-main-branch --check-name $CHECK_NAME ${TRUST_COLLABORATORS:+--trust-collaborators} ${TRUSTED_USERS:+--trusted $TRUSTED_USERS} $PR_REPO@$PR_BRANCH ${WORKERS_POOL_SIZE:+--workers-pool-size $WORKERS_POOL_SIZE} ${WORKER_INDEX:+--worker-index $WORKER_INDEX} ${DELAY:+--max-wait $DELAY} || $TIMEOUT_CMD report-analytics exception --desc "list-branch-pr failed"`
+    else
+      echo "Note: using hashes from $PWD/force-hashes, here is the list:"
+      cat $PWD/force-hashes
+      echo
+    fi
   else
     HASHES="0@0"
   fi

--- a/report-pr-errors
+++ b/report-pr-errors
@@ -6,6 +6,7 @@ import atexit
 from commands import getstatusoutput
 from glob import glob
 from os.path import dirname, join
+import re
 import os
 import sys
 
@@ -74,6 +75,7 @@ class Logs(object):
         self.work_dir = args.workDir
         self.develPrefix = args.develPrefix
         self.limit = args.limit
+        self.norm_status = re.sub('[^a-zA-Z0-9_-]', '_', args.status)
         self.full_log = self.constructFullLogName(args.pr)
         self.rsync_dest = args.logsDest
         self.url = join(args.logsUrl, self.full_log)
@@ -87,7 +89,7 @@ class Logs(object):
     def constructFullLogName(self, pr):
         # file to which we cat all the individual logs
         pr = parse_pr(pr)
-        return join(pr.repo_name, pr.id, pr.commit, "fullLog.txt")
+        return join(pr.repo_name, pr.id, pr.commit, self.norm_status, "fullLog.txt")
 
     def find(self):
         search_path = join(self.work_dir, "BUILD/*latest*/log")


### PR DESCRIPTION
* Clean build directories to avoid space usage explosion and inconsistent build results due to previous artifacts
* Clean dead Git references growing indefinitetly
* Add ability to force-test only given commits for debug