### PR TITLE
Improve alienv for AliEn integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 ---
 sudo: required
+cache:
+  directories:
+    - $HOME/cached
 script:
   - |
     git diff --name-only $TRAVIS_COMMIT_RANGE | grep -q ^riemann || return 0
@@ -29,6 +32,27 @@ script:
   - |
     git diff --name-only $TRAVIS_COMMIT_RANGE | grep -q ^cvmfs/ || return 0
     set -ex
+    # Install and configure an old bash
+    function get_bash() {
+      rm -rf $HOME/cached $HOME/scratch
+      mkdir -p $HOME/cached $HOME/scratch
+      pushd $HOME/scratch
+        wget -q https://ftp.gnu.org/gnu/bash/bash-3.2.48.tar.gz
+        tar xzf bash-3.2.48.tar.gz
+        pushd bash-3.2.48
+          ./configure --prefix=$HOME/cached
+          make -j4
+          make install
+        popd
+      popd
+    }
+    $HOME/cached/bin/bash --version || get_bash
+    # Patch alienv and make it use our own, old, bash
+    pushd cvmfs
+      sed -i.deleteme -e "1 s|^#!/bin/bash\(.*\)$|#!$HOME/cached/bin/bash\1|" alienv
+      rm -f *.deleteme
+      git diff
+    popd
     # Install and configure CVMFS
     wget -q https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
     sudo dpkg -i cvmfs-release-latest_all.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,25 @@ script:
         ./aliPublish test-rules --conf $CONF --test-conf $TEST --debug || { echo Testing $CONF against $TEST failed. >&2 ; return 1; }
       done
     popd
+  - |
+    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -q ^cvmfs/ || return 0
+    set -ex
+    # Install and configure CVMFS
+    wget -q https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+    sudo dpkg -i cvmfs-release-latest_all.deb
+    rm -f cvmfs-release-latest_all.deb
+    sudo apt-get update
+    sudo apt-get install cvmfs-dev cvmfs libtcl8.5 libx11-6
+    sudo mkdir -p /cvmfs/alice.cern.ch
+    sudo chown -R cvmfs:cvmfs /cvmfs
+    sudo bash -c 'echo CVMFS_HTTP_PROXY=DIRECT > /etc/cvmfs/default.local'
+    sudo mount alice.cern.ch /cvmfs/alice.cern.ch -t cvmfs -o allow_other,grab_mountpoint
+    ls -l /cvmfs/alice.cern.ch
+    # Override remote alienv with ours
+    md5sum /cvmfs/alice.cern.ch/bin/alienv
+    md5sum $PWD/cvmfs/alienv
+    sudo mount --bind $PWD/cvmfs/alienv /cvmfs/alice.cern.ch/bin/alienv
+    md5sum /cvmfs/alice.cern.ch/bin/alienv
+    cmp /cvmfs/alice.cern.ch/bin/alienv $PWD/cvmfs/alienv
+    # Run the actual test
+    cvmfs/test-alienv.sh

--- a/cvmfs/alienv
+++ b/cvmfs/alienv
@@ -150,8 +150,9 @@ then
 fi
 
 unset MODULESHOME
+export ALIEN_ORGANISATION=$(tr "[:lower:]" "[:upper:]" <<< "${ALIEN_ORGANISATION:=ALICE}")
 
-function modulepath {
+function modulepath() {
   local dir
   local colon
   local subdir
@@ -167,7 +168,7 @@ function modulepath {
   printf "\n"
 }
 
-function test_toolchain {
+function test_toolchain() {
   local TMPPREF=/tmp/alienv_helloworld
   cat > $TMPPREF.cpp <<EOF
 #include <iostream>
@@ -192,7 +193,7 @@ EOF
 
 # Old modulefiles were not loading AliEn automatically as a dependency. For
 # those packages we must do it manually.
-function load_alien_if_missing {
+function load_alien_if_missing() {
   echo $MODULEPATH | grep 'x86_64-2.6-gnu-4.1.2/Modules/modulefiles' -q || return 0  # load AliEn only on SLC5
   local REQ_ALIEN="ROOT GEANT3 GEANT4 AliRoot AliPhysics"
   if ! $moduleenv $modulecmd bash -t list 2>&1 | grep -q AliEn-Runtime; then
@@ -208,6 +209,36 @@ function load_alien_if_missing {
     done
   fi
   return 0
+}
+
+# Transform a comma-separated packages list from "ALICE format" to modulecmd
+# format, i.e.:
+#
+#   VO_ALICE@Package::v1.0.0 ==> Package/v1.0.0
+#
+# Returned list (on stdout) is also sorted: packages with a certain priority
+# are moved at the beginning of the list.
+function normalize_sort_packages() {
+  local PRIO ORIG NORM P J K
+  PRIO=( O2 AliPhysics AliRoot ROOT AliGenerators )
+  ORIG=( $(echo $1 | sed -e "s%VO_$ALIEN_ORGANISATION@%%g" -e 's%::%/%g' -e 's%,% %g') )
+  NORM=()
+  for P in "${PRIO[@]}"; do
+    for J in "${ORIG[@]}"; do
+      if [[ $J == $P/* ]]; then
+        # Remove $J from ${ORIG[@]}
+        ORIG=( $(for K in "${ORIG[@]}"; do
+          [[ $K == $J ]] && continue
+          echo $K
+        done) )
+        # Push to sorted
+        NORM+=("$J")
+      fi
+    done
+  done
+  NORM+=("${ORIG[@]}")
+  [[ $ALIENV_DEBUG == 1 ]] && printf "NOTICE: list of packages normalized to ${NORM[*]}\n" >&2
+  echo ${NORM[*]}
 }
 
 export PATH=$PATH:$path
@@ -237,11 +268,7 @@ fi
 
 tclsh <<EOF >/dev/null 2>&1
 EOF
-
-if [ $? -eq 0 ]
-then
-  moduleenv=""
-fi
+[[ $? == 0 ]] && moduleenv=
 
 command=""
 
@@ -253,8 +280,6 @@ else
 fi
 alien="AliEn"
 
-export ALIEN_ORGANISATION=$(tr "[:lower:]" "[:upper:]" <<< "${ALIEN_ORGANISATION:=ALICE}")
-
 # We cannot cross-pick pacakages among different platforms but we have to
 # pick all packages consistently from a certain platform tree. When listing
 # packages we show them all, when we load a package e define a priority list and
@@ -265,7 +290,7 @@ PACKAGES=
 EXPECT_PACKAGES=
 for ARG in "$@"; do
   if [[ $EXPECT_PACKAGES == 1 ]]; then
-    PACKAGES=`echo $ARG | sed -e "s%VO_$ALIEN_ORGANISATION@%%g" -e 's%::%/%g' -e 's%,% %g'`
+    PACKAGES=$(normalize_sort_packages "$ARG")
     break
   elif [[ "$ARG" == enter || "$ARG" == printenv || "$ARG" == setenv ]]; then
     EXPECT_PACKAGES=1
@@ -273,7 +298,7 @@ for ARG in "$@"; do
     EXPECT_PACKAGES=
   fi
 done
-if [[ x"$PACKAGES" != x ]]; then
+if [[ $PACKAGES ]]; then
   for P in $PLATFORM_PRIORITY; do
     [[ "${P:0:3}" == el5 ]] && P="$cvmfsdir/x86_64-2.6-gnu-4.1.2
                                   $cvmfsdir/x86_64-2.6-gnu-4.7.2
@@ -290,7 +315,7 @@ if [[ x"$PACKAGES" != x ]]; then
       # this is not the case then fallback on the next platform.
       echo $LOADED | grep -q $X || { OK=0; break; }
     done
-    [ x$OK == x1 ] && break || { [ x$ALIENV_DEBUG == x1 ] && printf "WARNING: cannot find packages with MODULEPATH set to $MODULEPATH\n"; }
+    [[ $OK == 1 ]] && break || { [[ $ALIENV_DEBUG == 1 ]] && printf "WARNING: cannot find packages with MODULEPATH set to $MODULEPATH\n"; }
   done
 else
   # PACKAGES is empty, meaning we are executing list operations. Use all paths
@@ -313,7 +338,7 @@ do
   case $1 in
      enter)
        shift 1
-       args=`echo $1 | sed -e "s%VO_$ALIEN_ORGANISATION@%%g" -e 's%::%/%g' -e 's%,% %g'`
+       args=$(normalize_sort_packages "$1")
        before=`printenv`
        Eval $moduleenv $modulecmd bash load $args || exit 1
        load_alien_if_missing || exit 1
@@ -338,7 +363,7 @@ do
        ;;
      setenv)
        shift 1
-       args=`echo $1 | sed -e "s%VO_$ALIEN_ORGANISATION@%%g" -e 's%::%/%g' -e 's%,% %g'`
+       args=$(normalize_sort_packages "$1")
        Eval $moduleenv $modulecmd bash load $args || exit 1
        load_alien_if_missing || exit 1
        [ x$ALIENV_DEBUG == x1 ] && test_toolchain
@@ -346,7 +371,7 @@ do
        ;;
      checkenv)
        shift 1
-       args=`echo $1 | sed -e "s%VO_$ALIEN_ORGANISATION@%%g" -e 's%::%/%g' -e 's%,% %g'`
+       args=$(normalize_sort_packages "$1")
        Eval $moduleenv $modulecmd bash load $args || exit 1
        load_alien_if_missing || exit 1
        PREV_PKG=
@@ -373,7 +398,7 @@ do
        then
           echo $_LM_ENV
        fi
-       args=`echo $1 | sed -e "s%VO_$ALIEN_ORGANISATION@%%g" -e 's%::%/%g' -e 's%,% %g'`
+       args=$(normalize_sort_packages "$1")
        $moduleenv $modulecmd bash load $args \
          $(Eval $moduleenv $modulecmd bash load $args > /dev/null 2>&1 && \
            load_alien_if_missing --print-alien-package) || exit 1

--- a/cvmfs/alienv
+++ b/cvmfs/alienv
@@ -391,8 +391,7 @@ do
        ;;
      -c)
        shift 1
-       args=`echo $1 | sed -e "s%VO_$ALIEN_ORGANISATION@%%g" -e 's%::%/%g' -e 's%,% %g'`
-       exec env PS1="[$args] \W > " bash -c "$*"
+       exec bash -c "$*"
        ;;
      -alien-version|--alien-version)
        shift 1

--- a/cvmfs/alienv
+++ b/cvmfs/alienv
@@ -344,6 +344,29 @@ do
        [ x$ALIENV_DEBUG == x1 ] && test_toolchain
        shift 1
        ;;
+     checkenv)
+       shift 1
+       args=`echo $1 | sed -e "s%VO_$ALIEN_ORGANISATION@%%g" -e 's%::%/%g' -e 's%,% %g'`
+       Eval $moduleenv $modulecmd bash load $args || exit 1
+       load_alien_if_missing || exit 1
+       PREV_PKG=
+       PREV_VER=
+       PKG_ERR=
+       while read LMF; do
+         VER=${LMF##*/}
+         PKG=${LMF%/*}
+         PKG=${PKG##*/}
+         if [[ $PKG == $PREV_PKG && $VER != $PREV_VER ]]; then
+           printf "ERROR: attempting to load $PKG $VER when conflicting version $PREV_VER already loaded\n" >&2
+           PKG_ERR=1
+         fi
+         PREV_PKG=$PKG
+         PREV_VER=$VER
+       done < <(echo $_LMFILES_ | sed -e 's/:/\n/g' | sort)
+       [[ $PKG_ERR ]] && exit 1
+       [[ $ALIENV_DEBUG == 1 ]] && printf "NOTICE: all packages loaded successfully\n" >&2
+       exit 0
+       ;;
      printenv)
        shift 1
        if [ x$1 = x ]

--- a/cvmfs/test-alienv.sh
+++ b/cvmfs/test-alienv.sh
@@ -37,6 +37,10 @@ pt "run alienv from a non-standard path (/tmp/alienv_symlink/bin) with relative 
 export PATH=/cvmfs/alice.cern.ch/bin:$PATH
 [[ `which alienv` == /cvmfs/alice.cern.ch/bin/alienv ]]
 
+pt "test package reordering"
+ALIENV_DEBUG=1 alienv setenv VO_ALICE@AliEn-Runtime::v2-19-le-21,VO_ALICE@ROOT::v5-34-30-alice7-2,VO_ALICE@AliPhysics::vAN-20170301-1 -c true 2>&1 | \
+  grep 'normalized to AliPhysics/vAN-20170301-1 ROOT/v5-34-30-alice7-2 AliEn-Runtime/v2-19-le-21'
+
 pt "test checkenv command with a successful combination"
 EC=0
 alienv checkenv AliPhysics/vAN-20170301-1,AliRoot/v5-08-22-1 || EC=$?

--- a/cvmfs/test-alienv.sh
+++ b/cvmfs/test-alienv.sh
@@ -1,0 +1,95 @@
+#!/bin/bash -e
+set -o pipefail
+
+function pe() { printf "\033[31mERROR:\033[m $1\n" >&2; }
+function pi() { printf "\033[34mINFO:\033[m $1\n" >&2; }
+function pt() { printf "\n\033[35m*** TEST: $1 ***\033[m\n" >&2; }
+function pg() { printf "\033[32mSUCCESS:\033[m $1\n" >&2; }
+
+# Check if required conditions to run the test are met
+[[ -d .git ]] || { pe "you must run from the Git repository root"; }
+[[ $FATAL ]] && exit 1 || true
+
+# Define an "old" and "new" version of AliPhysics to check for. "new" has AliEn
+# as dependency, "old" does not
+OLD_VER="AliPhysics/vAN-20150131"
+NEW_VER="AliPhysics/vAN-20170301-1"
+
+# Overriding platform (not important for our tests)
+export ALIENV_OVERRIDE_PLATFORM="el6-x86_64"
+pi "Overriding platform to $ALIENV_OVERRIDE_PLATFORM"
+
+for NP in /tmp/alienv_bin /tmp/alienv_path/bin; do
+  pt "run alienv from a non-standard path ($NP) with full symlink"
+  ( mkdir -p $NP
+    ln -nfs /cvmfs/alice.cern.ch/bin/alienv $NP/alienv
+    export PATH=$NP:$PATH
+    ALIENV_DEBUG=1 alienv q | grep AliPhysics | tail -n1
+  )
+done
+
+pt "run alienv from a non-standard path (/tmp/alienv_symlink/bin) with relative symlink"
+( mkdir -p /tmp/alienv_symlink/bin
+  ln -nfs ../../../cvmfs/alice.cern.ch/bin/alienv /tmp/alienv_symlink/bin/alienv
+  export PATH=/tmp/alienv_symlink/bin:$PATH
+  ALIENV_DEBUG=1 alienv q | grep AliPhysics | tail -n1
+)
+export PATH=/cvmfs/alice.cern.ch/bin:$PATH
+[[ `which alienv` == /cvmfs/alice.cern.ch/bin/alienv ]]
+
+pt "test checkenv command with a successful combination"
+EC=0
+alienv checkenv AliPhysics/vAN-20170301-1,AliRoot/v5-08-22-1 || EC=$?
+[[ $EC == 0 ]] || { pe "expected 0, returned $EC"; exit 1; }
+
+pt "test checkenv command with a faulty combination"
+EC=0
+{ alienv checkenv AliPhysics/vAN-20170301-1,AliPhysics/vAN-20170201-1 2>&1 | tee log.txt; } || EC=$?
+[[ $EC == 1 ]] || { pe "expected 1, returned $EC"; rm -f log.txt; exit 1; }
+grep -q 'conflicting version' log.txt || { pe "could not find expected output message"; rm -f log.txt; exit 1; }
+rm -f log.txt
+
+pt "list AliPhysics packages"
+alienv q | grep AliPhysics | tail -n5
+function alienv_test() {
+  local METHOD=$1
+  local PACKAGE=$2
+  local COMMAND=$3
+  local OVERRIDE_ENV=$4
+  case $METHOD in
+    setenv)   env $OVERRIDE_ENV alienv setenv $PACKAGE -c "$COMMAND"                                                    ;;
+    printenv) ( eval `env $OVERRIDE_ENV alienv printenv $PACKAGE`; $COMMAND )                                           ;;
+    enter)    ( echo 'echo TEST=`'"$COMMAND"'`' | env $OVERRIDE_ENV alienv enter $PACKAGE | grep ^TEST= | cut -d= -f2-) ;;
+  esac
+}
+
+pt "check that the legacy AliEn package can be loaded"
+for METHOD in setenv printenv enter; do
+  [[ `alienv_test $METHOD AliEn "which aliensh"` == *'/AliEn/'* ]]
+done
+for OVERRIDE_PLATFORM in el6 el7 ubuntu1404; do
+  for METHOD in setenv printenv enter; do
+    for VER in $NEW_VER $OLD_VER; do
+      for TEST in cxx aliroot alien; do
+        case $TEST in
+          cxx)
+            pt "check g++ with $VER on $OVERRIDE_PLATFORM"
+            [[ $VER == $NEW_VER ]] && EXPECT="/cvmfs/alice.cern.ch/$OVERRIDE_PLATFORM" || EXPECT="/usr/"
+            [[ `alienv_test $METHOD $VER "which g++" ALIENV_OVERRIDE_PLATFORM=$OVERRIDE_PLATFORM` == "$EXPECT"* ]]
+            ;;
+          aliroot)
+            pt "check aliroot with $VER on $OVERRIDE_PLATFORM"
+            [[ `alienv_test $METHOD $VER "which aliroot" ALIENV_OVERRIDE_PLATFORM=$OVERRIDE_PLATFORM` == "/cvmfs/alice.cern.ch/"*"bin/aliroot" ]]
+            ;;
+          alien)
+            pt "check AliEn-Runtime with $VER on $OVERRIDE_PLATFORM"
+            [[ $VER == $NEW_VER ]] && EXPECT="/AliEn-Runtime/" || EXPECT="/AliEn/"
+            [[ `alienv_test $METHOD $VER "which aliensh" ALIENV_OVERRIDE_PLATFORM=$OVERRIDE_PLATFORM` == "/cvmfs/alice.cern.ch/"*"$EXPECT"* ]]
+            ;;
+        esac
+      done
+    done
+  done
+done
+
+pg "all tests successful"


### PR DESCRIPTION
As discussed with @mimarpe.

- [x] Add `checkenv` returning nonzero if deps are conflicting
- [x] Order packages by prioritizing O2, AliPhysics, AliRoot, ROOT and AliGenerators
- [x] Add unittest for `alienv` in Travis CI (start from Jenkinsfile)
- [x] Add ability to switch to "nightlies" (we've decided not to)

