### PR TITLE
Exclude .cvmfscatalog from OADB dir comparison

### DIFF
--- a/publish/publish-data.sh
+++ b/publish/publish-data.sh
@@ -99,7 +99,7 @@ touch $DEST
 while read FILE; do
   mv -v $FILE ${FILE%*.no_access}
 done < <(find $DEST -name *.no_access)
-if diff --brief -r $SRC_YESTERDAY/ $DEST/ &> /dev/null; then
+if diff -x .cvmfscatalog --brief -r $SRC_YESTERDAY/ $DEST/ &> /dev/null; then
   # Nothing changed from yesterday: replace directory with a symlink.
   # If yesterday's source is already a symlink, resolve it first
   LINKDEST=$(readlink $SRC_YESTERDAY 2> /dev/null || true)


### PR DESCRIPTION
`.cvmfsdirtab` is configured to create a catalog in each data directory, however
prior to publishing the base diff directory already contains the catalog file
placeholder, and the new one does not contain it yet, causing `diff` to report
the two directories to be different when in fact they are not