### PR TITLE
Fix alienv + aliDoctor from PATH too

### DIFF
--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -124,14 +124,14 @@ case "$2" in
   --test-build)
     set -x
     PACKAGE=${3-$PACKAGE}
-    alibuild/aliBuild init $PACKAGE --defaults $ALIBUILD_DEFAULTS --reference-source $MIRROR
-    exec alibuild/aliBuild build $PACKAGE --defaults $ALIBUILD_DEFAULTS ${DEBUG:+--debug} --reference-source $MIRROR
+    aliBuild init $PACKAGE --defaults $ALIBUILD_DEFAULTS --reference-source $MIRROR
+    exec aliBuild build $PACKAGE --defaults $ALIBUILD_DEFAULTS ${DEBUG:+--debug} --reference-source $MIRROR
   ;;
 
   --test-doctor)
     set -x
     PACKAGE=${3-$PACKAGE}
-    exec alibuild/aliDoctor $PACKAGE --defaults $ALIBUILD_DEFAULTS ${DEBUG:+--debug}
+    exec aliDoctor $PACKAGE --defaults $ALIBUILD_DEFAULTS ${DEBUG:+--debug}
   ;;
 
   "")

--- a/daq-da-rpms.sh
+++ b/daq-da-rpms.sh
@@ -79,7 +79,7 @@ aliBuild --reference-sources $MIRROR \
          --defaults $DEFAULTS        \
          init AliRoot
 
-FETCH_REPOS="$(alibuild/aliBuild build --help | grep fetch-repos || true)"
+FETCH_REPOS="$(aliBuild build --help | grep fetch-repos || true)"
 aliBuild --reference-sources $MIRROR          \
          --debug                              \
          --work-dir $WORKAREA/$WORKAREA_INDEX \
@@ -93,5 +93,5 @@ aliBuild --reference-sources $MIRROR          \
 rm -f $WORKAREA/$WORKAREA_INDEX/current_slave
 [[ "$BUILDERR" != '' ]] && exit $BUILDERR
 
-ALIROOT_PREFIX=`alibuild/alienv -w $WORKAREA/$WORKAREA_INDEX setenv AliRoot/latest -c sh -c 'echo $ALICE_ROOT'`
+ALIROOT_PREFIX=$(alienv -w $WORKAREA/$WORKAREA_INDEX setenv AliRoot/latest -c sh -c 'echo $ALICE_ROOT')
 rsync -av $ALIROOT_PREFIX/darpms/x86_64/ $REMOTE_STORE/RPMS/DAQ/$ARCHITECTURE/


### PR DESCRIPTION
Complements #589 and #590. Fix:

* aliBuild + alienv from PATH in DA RPMs
* aliBuild + aliDoctor from PATH in manual CI runner (does not affect prod)