### PR TITLE
Improve reliability of the CI

### DIFF
--- a/ci/conf/alidist_o2-0.sh
+++ b/ci/conf/alidist_o2-0.sh
@@ -1,0 +1,2 @@
+source conf/alidist_o2.sh
+export WORKER_INDEX=0

--- a/ci/conf/alidist_o2-1.sh
+++ b/ci/conf/alidist_o2-1.sh
@@ -1,0 +1,2 @@
+source conf/alidist_o2.sh
+export WORKER_INDEX=1

--- a/ci/conf/alidist_o2.sh
+++ b/ci/conf/alidist_o2.sh
@@ -1,16 +1,19 @@
-# Continuous builder configuration for O2 CI
+# Continuous builder configuration for alidist
 
 # GitHub slug of the repository accepting PRs
-PR_REPO=AliceO2Group/AliceO2
+PR_REPO=alisw/alidist
+
+# Where to checkout the PR repo (mandatory, otherwise will use PACKAGE)
+PR_REPO_CHECKOUT=alidist
 
 # What is the package to rebuild
-PACKAGE=O2
+PACKAGE=O2Suite
 
 # How to name the check
-CHECK_NAME=build/o2/macos
+CHECK_NAME=build/O2Suite/alidist_macOS
 
 # PRs are made to this branch
-PR_BRANCH=dev
+PR_BRANCH=master
 
 # What is the default to use
 ALIBUILD_DEFAULTS=o2
@@ -23,6 +26,9 @@ TRUST_COLLABORATORS=true
 
 # Do not use comments in PRs (use Details instead)
 DONT_USE_COMMENTS=1
+
+# Extra repositories to download
+EXTRA_REPOS=( "repo=AliceO2Group/AliceO2 branch=dev checkout=O2" )
 
 # How many workers we have
 WORKERS_POOL_SIZE=2

--- a/ci/conf/o2-0.sh
+++ b/ci/conf/o2-0.sh
@@ -1,0 +1,2 @@
+source conf/o2.sh
+export WORKER_INDEX=0

--- a/ci/conf/o2-1.sh
+++ b/ci/conf/o2-1.sh
@@ -1,0 +1,2 @@
+source conf/o2.sh
+export WORKER_INDEX=1

--- a/mesos-dns-lookup
+++ b/mesos-dns-lookup
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# Configure envvar MESOS_DNS with a list of comma-separated Mesos masters replying on port 8123 on
+# plain HTTP. Returns a single IP address resolving the single command-line parameter.
+import os, sys
+from random import random, choice
+from requests import get
+dns = os.environ["MESOS_DNS"].split(",")
+what = sys.argv[1]
+for d in sorted(dns, key=lambda k: random()):
+    try:
+        ips = [ item["ip"] for item in get("http://%s:8123/v1/hosts/%s" % (d, what)).json() ]
+        break
+    except:
+        ips = []
+if ips:
+    print(choice(ips))

--- a/report-pr-errors
+++ b/report-pr-errors
@@ -101,9 +101,13 @@ class Logs(object):
         return join(pr.repo_name, pr.id, "latest" if latest else pr.commit, self.norm_status, "fullLog.txt")
 
     def find(self):
-        search_path = join(self.work_dir, "BUILD/*latest*/log")
-        print("Searching all logs matching: %s" % search_path, file=sys.stderr)
-        globbed = glob(search_path)
+        # Python's glob * matches at least one char
+        search_paths = [join(self.work_dir, "BUILD/*latest*/log"),
+                        join(self.work_dir, "BUILD/*latest/log")]
+        print("Searching all logs matching: %s" % ", ".join(search_paths), file=sys.stderr)
+        globbed = []
+        for sp in search_paths:
+            globbed.extend(glob(sp))
 
         suffix = ("latest" + "-" + self.develPrefix).strip("-")
         logs = [x for x in globbed if dirname(x).endswith(suffix)]

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,8 @@ setup(
                "ci/sync-egroups.py",
                "ci/sync-mapusers.py",
                # Get PR information
-               "ci/prinfo"
+               "ci/prinfo",
+               # Resolve Mesos DNS
+               "mesos-dns-lookup"
               ]
 )


### PR DESCRIPTION
* Add new O2 macOS builders: 2 for O2, 2 for O2Suite on alidist
* Support fetching of extra repositories along with the PR one and alidist
* Document `force-hashes` for debugging purposes
* Create separate logfiles for each PR/branch build, identified by PR/branch
  name and timestamp
* Fix `glob()` behaviour in `report-pr-errors`, now catches both `*latest*` and
  `*latest` (it was the case with `AliRoot-guntest`)
* Make warm up phase faster (no sleep)
* Add builtin support for Mesos DNS API (no need to change the host DNSes)
* Allow support for virtualenv (do not use `pip install --user` in that case)

See also O2-436