### PR TITLE
Fix to avoid duplicate logs.

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -116,7 +116,7 @@ class Logs(object):
             globbed.extend(glob(sp))
 
         suffix = ("latest" + "-" + self.develPrefix).strip("-")
-        logs = { x for x in globbed if dirname(x).endswith(suffix) }
+        logs = {x for x in globbed if dirname(x).endswith(suffix)}
 
         print("Found:\n%s" % "\n".join(logs), file=sys.stderr)
         self.logs = logs

--- a/report-pr-errors
+++ b/report-pr-errors
@@ -116,7 +116,7 @@ class Logs(object):
             globbed.extend(glob(sp))
 
         suffix = ("latest" + "-" + self.develPrefix).strip("-")
-        logs = [x for x in globbed if dirname(x).endswith(suffix)]
+        logs = { x for x in globbed if dirname(x).endswith(suffix) }
 
         print("Found:\n%s" % "\n".join(logs), file=sys.stderr)
         self.logs = logs


### PR DESCRIPTION
As far as I can tell all the text logs available from the PR checks (in ali-ci.cern.ch/repo/logs/AliceO2Group/AliceO2 at least) are duplicated (because of "latest" links).
This should fix it. 