### PR TITLE
RPM publishing: force chown of destination files & reduce chances of leaking secrets to log

### DIFF
--- a/publish/run-all-rpms.sh
+++ b/publish/run-all-rpms.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-# Check if variables are provided
-if [[ ! $SYNC_USER || ! $SYNC_PASS ]]; then
-  echo "Variables SYNC_USER and SYNC_PASS are required, aborting" >&2
-  exit 1
-fi
+# Check if variables are provided.
+[ X${SYNC_USER:+1} = X ] && { echo "Variables SYNC_USER missing, aborting"; exit 1; } 
+[ X${SYNC_PASS:+1} = X ] && { echo "Variables SYNC_PASS missing, aborting"; exit 1; } 
 
 for CONF in aliPublish*-rpms.conf; do
 
@@ -13,13 +11,14 @@ for CONF in aliPublish*-rpms.conf; do
   printf "\n\n\n\n" >&2
 
   echo === $(LANG=C date) :: syncing to CERN IT EOS repo === >&2
-  timeout -s 9 1800 \
-    rsync --progress \
-          --update \
-          --delete \
+  timeout -s 9 1800                                                                                                   \
+    rsync --progress                                                                                                  \
+          --update                                                                                                    \
+          --delete                                                                                                    \
+          --chown $SYNC_USER:z2                                                                                       \
           --rsh="sshpass -p '$SYNC_PASS' ssh -oUserKnownHostsFile=/dev/null -oStrictHostKeyChecking=no -l $SYNC_USER" \
-          -rv \
-          /repo/*RPMS --exclude '**/DAQ/' --exclude '**/createrepo_cachedir/' --exclude '**/el5.x86_64/' \
+          -rv                                                                                                         \
+          /repo/*RPMS --exclude '**/DAQ/' --exclude '**/createrepo_cachedir/' --exclude '**/el5.x86_64/'              \
           lxplus.cern.ch:/eos/user/a/alibot/www/ >&2
   printf "\n\n\n\n" >&2
 


### PR DESCRIPTION
* This is required so that we can run the script with a different user and still be able to rsync files to destination with the proper ownership.
* Also slightly change check for environment variables so that we do not leak secrets to the logs.