### PR TITLE
RPM publishing: address O2-852, O2-437, O2-849 and O2-853

### DIFF
--- a/publish/aliPublish-rpms.conf
+++ b/publish/aliPublish-rpms.conf
@@ -10,6 +10,7 @@ architectures:
   slc7_x86-64:
     RPM: el7.x86_64
     include:
+      rpm-test: True
       mesos-workqueue: True
       flpproto: True
       Monitoring: True

--- a/publish/pub-rpms-template.sh
+++ b/publish/pub-rpms-template.sh
@@ -169,6 +169,7 @@ pushd unpack_rpm
       --version "$RPM_VERSION"         \
       --iteration 1.$FLAVOUR           \
       --name "$RPM_PACKAGE"            \
+      --exclude compile_commands.json  \
       --after-install $AFTER_INSTALL   \
       --after-remove $AFTER_REMOVE     \
       "$RPM_UNPACK_DIR"

--- a/publish/test/test-repo.sh
+++ b/publish/test/test-repo.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
-REPO=${REPO:-http://ali-ci.cern.ch/repo/RPMS/el7.x86_64}
-PKG=${PKG:- alisw-O2Suite+1.0.0-16}
+REPO=${REPO:-https://alirepo.web.cern.ch/alirepo/RPMS/el7.x86_64}
+PKG=${PKG:-alisw-flpproto+v0.9.2-9.x86_64}
 
 curl -I $REPO/repodata/repomd.xml
 cat << EOF >/etc/yum.repos.d/alice-test.repo
@@ -11,5 +11,8 @@ enabled=1
 gpgcheck=0
 EOF
 yum update --disablerepo='*' --enablerepo=alice-test -y
-yum search ${PKG}
+yum list available | grep alisw
+yum search rpm-test
+yum search flpsuite
+yum install -y alisw-rpm-test+1.0-1.x86_64
 yum install -y ${PKG}


### PR DESCRIPTION
* Add test package to those being published.
* Exclude compile_commands.json from RPMS, so that they do not
  conflict in the updatable RPMS.