### PR TITLE
[WIP] macOS Catalina + launchd

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -238,12 +238,12 @@ while true; do
     mkdir -p "$SLOG_DIR"
 
     # Restore fds 1, 2 from 3, 4. If this is the first run, it may fail and this is fine
-    exec 1>&3 3>&- || true
-    exec 2>&4 4>&- || true
+    #exec 1>&3 3>&- || true
+    #exec 2>&4 4>&- || true
 
     # Back up file descriptors 1, 2 to 3, 4 (will restore them later)
-    exec 3>&1
-    exec 4>&2
+    #exec 3>&1
+    #exec 4>&2
 
     # Redirecting all output to current stdout/stderr, plus separate logfile
     # Mitigate zombie processes
@@ -430,8 +430,8 @@ while true; do
   done  # end processing a single PR
 
   # Restore fds 1, 2 in case of premature exit from the loop (may fail: it's fine)
-  exec 1>&3 3>&- || true
-  exec 2>&4 4>&- || true
+  #exec 1>&3 3>&- || true
+  #exec 2>&4 4>&- || true
 
   report_state looping_done
   # Mark the fact we have run at least once.

--- a/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
+++ b/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
@@ -17,9 +17,9 @@
 	<string>/Users/alibuild/build/</string>
 
 	<key>StandardOutPath</key>
-	<string>/Users/alibuild/build/alidist_o2-0/logs/stdout</string>
+	<string>/Users/alibuild/build/ci_checks/alidist_ckecker_macos_o2_ci_0/logs/stdout</string>
 	<key>StandardErrorPath</key>
-	<string>/Users/alibuild/build/alidist_o2-0/logs/stderr</string>
+	<string>/Users/alibuild/build/ci_checks/alidist_ckecker_macos_o2_ci_0/logs/stderr</string>
 
 	<key>RunAtLoad</key>
 	<true/>

--- a/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
+++ b/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
@@ -23,7 +23,7 @@
 
 	<key>RunAtLoad</key>
 	<true/>
-	<key>KeepAlive</key>
-	<true/>
+	<!---<key>KeepAlive</key>
+	<true/>-->
 </dict>
 </plist>

--- a/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
+++ b/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
@@ -22,7 +22,7 @@
 	<string>/Users/alibuild/build/ci_checks/alidist_checker_macos_o2_ci_0/logs/stderr</string>
 
 	<key>RunAtLoad</key>
-	<true/>
+	<false/>
 	<key>KeepAlive</key>
 	<false/>
 </dict>

--- a/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
+++ b/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
@@ -17,9 +17,9 @@
 	<string>/Users/alibuild/build/</string>
 
 	<key>StandardOutPath</key>
-	<string>/Users/alibuild/build/ci_checks/alidist_ckecker_macos_o2_ci_0/logs/stdout</string>
+	<string>/Users/alibuild/build/ci_checks/alidist_checker_macos_o2_ci_0/logs/stdout</string>
 	<key>StandardErrorPath</key>
-	<string>/Users/alibuild/build/ci_checks/alidist_ckecker_macos_o2_ci_0/logs/stderr</string>
+	<string>/Users/alibuild/build/ci_checks/alidist_checker_macos_o2_ci_0/logs/stderr</string>
 
 	<key>RunAtLoad</key>
 	<true/>

--- a/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
+++ b/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
@@ -14,7 +14,7 @@
 	<key>GroupName</key>
 	<string>staff</string>
 	<key>WorkingDirectory</key>
-	<string>/Users/alibuild/build/</string>
+	<string>/Users/alibuild/build/ali-bot</string>
 
 	<key>StandardOutPath</key>
 	<string>/Users/alibuild/build/ci_checks/alidist_checker_macos_o2_ci_0/logs/stdout</string>
@@ -24,6 +24,6 @@
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>
-	<true/>
+	<false/>
 </dict>
 </plist>

--- a/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
+++ b/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>ch.cern.alice.continous-builder.o2-0</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/alibuild/build/ali-bot/ci/run-continuous-builder.sh</string>
+		<string>alidist_o2-0</string>
+	</array>
+	<key>UserName</key>
+	<string>alibuild</string>
+	<key>GroupName</key>
+	<string>staff</string>
+	<key>WorkingDirectory</key>
+	<string>/Users/alibuild/build/</string>
+
+	<key>StandardOutPath</key>
+	<string>/Users/alibuild/build/alidist_o2-0/logs/stdout</string>
+	<key>StandardErrorPath</key>
+	<string>/Users/alibuild/build/alidist_o2-0/logs/stderr</string>
+
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+</dict>
+</plist>

--- a/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
+++ b/ci/launchd/ch.cern.alice.continous-builder.o2-0.plist
@@ -23,7 +23,7 @@
 
 	<key>RunAtLoad</key>
 	<true/>
-	<!---<key>KeepAlive</key>
-	<true/>-->
+	<key>KeepAlive</key>
+	<true/>
 </dict>
 </plist>

--- a/ci/newsyslog.d/ch.cern.alice.continous-builder.o2-0.conf
+++ b/ci/newsyslog.d/ch.cern.alice.continous-builder.o2-0.conf
@@ -1,0 +1,3 @@
+# logfilename          														[owner:group]	mode count size when  flags [/pid_file] [sig_num]
+/Users/alibuild/build/ci_checks/alidist_checker_macos_o2_ci_0/logs/stdout	alibuild:staff	644  	5   *	$D0   J
+/Users/alibuild/build/ci_checks/alidist_checker_macos_o2_ci_0/logs/stderr	alibuild:staff	644	 	5	*	$D0   J

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -74,8 +74,9 @@ export CI_NAME=$(echo $PR_REPO_CHECKOUT|tr '[[:upper:]]' '[[:lower:]]')_checker_
 ALIBOT="$(cd ..;pwd)"
 CI_WORK_DIR=/Users/alibuild/build/ci_checks/${CI_NAME}_${WORKER_INDEX}
 BREW_PATH=/usr/local/bin
+ALIBOT_PATH=/Users/alibuild/build/ali-bot
 export PYTHONUSERBASE="$CI_WORK_DIR/python_local"
-export PATH="$PYTHONUSERBASE/bin:$BREW_PATH:$PATH"
+export PATH="$PYTHONUSERBASE/bin:$BREW_PATH:$ALIBOT_PATH:$PATH"
 export LD_LIBRARY_PATH="$PYTHONUSERBASE/lib:$LD_LIBRARY_PATH"
 mkdir -p "$CI_WORK_DIR" "$PYTHONUSERBASE" "$CI_WORK_DIR/logs"
 

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -92,15 +92,6 @@ type aliBuild
 set -x
 cd "$CI_WORK_DIR"
 
-if [[ $RUN_CI ]]; then
-  # Production command
-  while ! bash -ex "$ALIBOT"/ci/continuous-builder.sh; do
-    echo Something failed in the continuous builder script, restarting in 10 seconds...
-    sleep 10
-  done
-  exit 0
-fi
-
 [[ -d alidist/.git ]]             || git clone https://github.com/alisw/alidist
 [[ -d "$PR_REPO_CHECKOUT/.git" ]] || git clone "https://github.com/$PR_REPO" "$PR_REPO_CHECKOUT"
 
@@ -159,4 +150,4 @@ case "$2" in
 
 esac
 
-exec "$PROG" "$@"
+bash -ex "$ALIBOT"/ci/continuous-builder.sh

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -61,7 +61,7 @@ export MONALISA_PORT=8885
 export MAX_DIFF_SIZE=20000000
 export DELAY=20
 export DEBUG=true
-export MIRROR=/User/alibuild/build/mirror
+export MIRROR=/Users/alibuild/build/mirror
 
 # Disable aliBuild analytics prompt
 mkdir -p $HOME/.config/alibuild
@@ -72,7 +72,7 @@ export CI_NAME=$(echo $PR_REPO_CHECKOUT|tr '[[:upper:]]' '[[:lower:]]')_checker_
 
 # Setup working directory and local Python installation
 ALIBOT="$(cd ..;pwd)"
-CI_WORK_DIR=/User/alibuild/build/ci_checks/${CI_NAME}_${WORKER_INDEX}
+CI_WORK_DIR=/Users/alibuild/build/ci_checks/${CI_NAME}_${WORKER_INDEX}
 export PYTHONUSERBASE="$CI_WORK_DIR/python_local"
 export PATH="$PYTHONUSERBASE/bin:$PATH"
 export LD_LIBRARY_PATH="$PYTHONUSERBASE/lib:$LD_LIBRARY_PATH"

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -92,6 +92,15 @@ type aliBuild
 set -x
 cd "$CI_WORK_DIR"
 
+if [[ $RUN_CI ]]; then
+  # Production command
+  while ! bash -ex "$ALIBOT"/ci/continuous-builder.sh; do
+    echo Something failed in the continuous builder script, restarting in 10 seconds...
+    sleep 10
+  done
+  exit 0
+fi
+
 [[ -d alidist/.git ]]             || git clone https://github.com/alisw/alidist
 [[ -d "$PR_REPO_CHECKOUT/.git" ]] || git clone "https://github.com/$PR_REPO" "$PR_REPO_CHECKOUT"
 
@@ -150,4 +159,5 @@ case "$2" in
 
 esac
 
-bash -ex "$ALIBOT"/ci/continuous-builder.sh
+export RUN_CI=1
+exec "$PROG" "$@"

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -75,8 +75,9 @@ ALIBOT="$(cd ..;pwd)"
 CI_WORK_DIR=/Users/alibuild/build/ci_checks/${CI_NAME}_${WORKER_INDEX}
 BREW_PATH=/usr/local/bin
 ALIBOT_PATH=/Users/alibuild/build/ali-bot
+ALIBOT_SUBDIRS=$( find $ALIBOT_PATH -type d -printf "%p:" )
 export PYTHONUSERBASE="$CI_WORK_DIR/python_local"
-export PATH="$PYTHONUSERBASE/bin:$BREW_PATH:$ALIBOT_PATH:$PATH"
+export PATH="$PYTHONUSERBASE/bin:$BREW_PATH:$ALIBOT_PATH:$ALIBOT_SUBDIRS:$PATH"
 export LD_LIBRARY_PATH="$PYTHONUSERBASE/lib:$LD_LIBRARY_PATH"
 mkdir -p "$CI_WORK_DIR" "$PYTHONUSERBASE" "$CI_WORK_DIR/logs"
 

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -85,7 +85,7 @@ ALIBUILD_BRANCH=${ALIBUILD_SLUG#*@}
 [[ $ALIBUILD_REPO == $ALIBUILD_SLUG ]] && ALIBUILD_BRANCH= || true
 
 # Install aliBuild through pip (ensures dependencies are installed as well)
-pip install ${PIP_USER} --ignore-installed --upgrade git+https://github.com/${ALIBUILD_REPO}${ALIBUILD_BRANCH:+@$ALIBUILD_BRANCH}
+/usr/local/bin/pip install ${PIP_USER} --ignore-installed --upgrade git+https://github.com/${ALIBUILD_REPO}${ALIBUILD_BRANCH:+@$ALIBUILD_BRANCH}
 type aliBuild
 
 set -x

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -73,8 +73,9 @@ export CI_NAME=$(echo $PR_REPO_CHECKOUT|tr '[[:upper:]]' '[[:lower:]]')_checker_
 # Setup working directory and local Python installation
 ALIBOT="$(cd ..;pwd)"
 CI_WORK_DIR=/Users/alibuild/build/ci_checks/${CI_NAME}_${WORKER_INDEX}
+BREW_PATH=/usr/local/bin
 export PYTHONUSERBASE="$CI_WORK_DIR/python_local"
-export PATH="$PYTHONUSERBASE/bin:$PATH"
+export PATH="$PYTHONUSERBASE/bin:$BREW_PATH:$PATH"
 export LD_LIBRARY_PATH="$PYTHONUSERBASE/lib:$LD_LIBRARY_PATH"
 mkdir -p "$CI_WORK_DIR" "$PYTHONUSERBASE" "$CI_WORK_DIR/logs"
 
@@ -85,7 +86,7 @@ ALIBUILD_BRANCH=${ALIBUILD_SLUG#*@}
 [[ $ALIBUILD_REPO == $ALIBUILD_SLUG ]] && ALIBUILD_BRANCH= || true
 
 # Install aliBuild through pip (ensures dependencies are installed as well)
-/usr/local/bin/pip install ${PIP_USER} --ignore-installed --upgrade git+https://github.com/${ALIBUILD_REPO}${ALIBUILD_BRANCH:+@$ALIBUILD_BRANCH}
+pip install ${PIP_USER} --ignore-installed --upgrade git+https://github.com/${ALIBUILD_REPO}${ALIBUILD_BRANCH:+@$ALIBUILD_BRANCH}
 type aliBuild
 
 set -x

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -93,15 +93,6 @@ type aliBuild
 set -x
 cd "$CI_WORK_DIR"
 
-if [[ $RUN_CI ]]; then
-  # Production command
-  while ! bash -ex "$ALIBOT"/ci/continuous-builder.sh; do
-    echo Something failed in the continuous builder script, restarting in 10 seconds...
-    sleep 10
-  done
-  exit 0
-fi
-
 [[ -d alidist/.git ]]             || git clone https://github.com/alisw/alidist
 [[ -d "$PR_REPO_CHECKOUT/.git" ]] || git clone "https://github.com/$PR_REPO" "$PR_REPO_CHECKOUT"
 
@@ -160,5 +151,8 @@ case "$2" in
 
 esac
 
-export RUN_CI=1
-exec "$PROG" "$@"
+set -x
+cd "$CI_WORK_DIR"
+bash -ex "$ALIBOT"/ci/continuous-builder.sh
+echo `date` : Something failed in the continuous builder script, terminating.
+exit 1

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -75,9 +75,8 @@ ALIBOT="$(cd ..;pwd)"
 CI_WORK_DIR=/Users/alibuild/build/ci_checks/${CI_NAME}_${WORKER_INDEX}
 BREW_PATH=/usr/local/bin
 ALIBOT_PATH=/Users/alibuild/build/ali-bot
-ALIBOT_SUBDIRS=$( find $ALIBOT_PATH -type d -printf "%p:" )
 export PYTHONUSERBASE="$CI_WORK_DIR/python_local"
-export PATH="$PYTHONUSERBASE/bin:$BREW_PATH:$ALIBOT_PATH:$ALIBOT_SUBDIRS:$PATH"
+export PATH="$PYTHONUSERBASE/bin:$BREW_PATH:$ALIBOT_PATH:$ALIBOT_PATH/analytics:$ALIBOT_PATH/ci:$PATH"
 export LD_LIBRARY_PATH="$PYTHONUSERBASE/lib:$LD_LIBRARY_PATH"
 mkdir -p "$CI_WORK_DIR" "$PYTHONUSERBASE" "$CI_WORK_DIR/logs"
 

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -158,3 +158,5 @@ case "$2" in
   ;;
 
 esac
+
+exec "$PROG" "$@"

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -61,7 +61,7 @@ export MONALISA_PORT=8885
 export MAX_DIFF_SIZE=20000000
 export DELAY=20
 export DEBUG=true
-export MIRROR=/build/mirror
+export MIRROR=/User/alibuild/build/mirror
 
 # Disable aliBuild analytics prompt
 mkdir -p $HOME/.config/alibuild
@@ -72,19 +72,11 @@ export CI_NAME=$(echo $PR_REPO_CHECKOUT|tr '[[:upper:]]' '[[:lower:]]')_checker_
 
 # Setup working directory and local Python installation
 ALIBOT="$(cd ..;pwd)"
-CI_WORK_DIR=/build/ci_checks/${CI_NAME}_${WORKER_INDEX}
+CI_WORK_DIR=/User/alibuild/build/ci_checks/${CI_NAME}_${WORKER_INDEX}
 export PYTHONUSERBASE="$CI_WORK_DIR/python_local"
 export PATH="$PYTHONUSERBASE/bin:$PATH"
 export LD_LIBRARY_PATH="$PYTHONUSERBASE/lib:$LD_LIBRARY_PATH"
-mkdir -p "$CI_WORK_DIR" "$PYTHONUSERBASE"
-
-# We need a workaround to install ali-bot on Python 2.6
-if [[ ! $RUN_CI ]]; then
-  python -c 'import platform;print(platform.python_version())' | grep -qE '^2\.6' \
-    && { pip install ${PIP_USER} --ignore-installed --upgrade setuptools==22.0.2 importlib==1.0.4 || exit 1; } \
-    || true
-  pip install ${PIP_USER} --ignore-installed --upgrade -e "$ALIBOT"
-fi
+mkdir -p "$CI_WORK_DIR" "$PYTHONUSERBASE" "$CI_WORK_DIR/logs"
 
 # aliBuild repository slug: <group>/<repo>[@<branch>]
 ALIBUILD_SLUG=${ALIBUILD_SLUG:-alisw/alibuild}
@@ -165,8 +157,3 @@ case "$2" in
   ;;
 
 esac
-
-# Not in a screen? Switch to a screen if appropriate!
-export RUN_CI=1
-[[ $STY ]] || exec screen -dmS ${CI_NAME}_${WORKER_INDEX} "$PROG" "$@"
-exec "$PROG" "$@"


### PR DESCRIPTION
Changes to continuous builder scripts to allow migration of CI to macOS Catalina

* read only root file system requires moving `/build` to `/home/alibuild/build`
* `launchd` scripts to run continuous builders and log rotation.
* changes in `run-continous-builder.sh` to adapt to being used by `launchd`
