### PR TITLE
O2 946 feature macos catalina

### DIFF
--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -72,9 +72,10 @@ export CI_NAME=$(echo $PR_REPO_CHECKOUT|tr '[[:upper:]]' '[[:lower:]]')_checker_
 
 # Setup working directory and local Python installation
 ALIBOT="$(cd ..;pwd)"
+ALIBOT_PATH=/usr/local/build/ali-bot
 CI_WORK_DIR=/usr/local/build/ci_checks/${CI_NAME}_${WORKER_INDEX}
 export PYTHONUSERBASE="$CI_WORK_DIR/python_local"
-export PATH="$PYTHONUSERBASE/bin:$ALIBOT:$ALIBOT/analytics:$ALIBOT/ci:$PATH"
+export PATH="$PYTHONUSERBASE/bin:$ALIBOT_PATH:$ALIBOT_PATH/analytics:$ALIBOT_PATH/ci:$PATH"
 export LD_LIBRARY_PATH="$PYTHONUSERBASE/lib:$LD_LIBRARY_PATH"
 mkdir -p "$CI_WORK_DIR" "$PYTHONUSERBASE"
 

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -74,7 +74,7 @@ export CI_NAME=$(echo $PR_REPO_CHECKOUT|tr '[[:upper:]]' '[[:lower:]]')_checker_
 ALIBOT="$(cd ..;pwd)"
 CI_WORK_DIR=/usr/local/build/ci_checks/${CI_NAME}_${WORKER_INDEX}
 export PYTHONUSERBASE="$CI_WORK_DIR/python_local"
-export PATH="$PYTHONUSERBASE/bin:$PATH"
+export PATH="$PYTHONUSERBASE/bin:$ALIBOT:$ALIBOT/analytics:$ALIBOT/ci:$PATH"
 export LD_LIBRARY_PATH="$PYTHONUSERBASE/lib:$LD_LIBRARY_PATH"
 mkdir -p "$CI_WORK_DIR" "$PYTHONUSERBASE"
 

--- a/ci/run-continuous-builder.sh
+++ b/ci/run-continuous-builder.sh
@@ -61,7 +61,7 @@ export MONALISA_PORT=8885
 export MAX_DIFF_SIZE=20000000
 export DELAY=20
 export DEBUG=true
-export MIRROR=/build/mirror
+export MIRROR=/usr/local/build/mirror
 
 # Disable aliBuild analytics prompt
 mkdir -p $HOME/.config/alibuild
@@ -72,19 +72,11 @@ export CI_NAME=$(echo $PR_REPO_CHECKOUT|tr '[[:upper:]]' '[[:lower:]]')_checker_
 
 # Setup working directory and local Python installation
 ALIBOT="$(cd ..;pwd)"
-CI_WORK_DIR=/build/ci_checks/${CI_NAME}_${WORKER_INDEX}
+CI_WORK_DIR=/usr/local/build/ci_checks/${CI_NAME}_${WORKER_INDEX}
 export PYTHONUSERBASE="$CI_WORK_DIR/python_local"
 export PATH="$PYTHONUSERBASE/bin:$PATH"
 export LD_LIBRARY_PATH="$PYTHONUSERBASE/lib:$LD_LIBRARY_PATH"
 mkdir -p "$CI_WORK_DIR" "$PYTHONUSERBASE"
-
-# We need a workaround to install ali-bot on Python 2.6
-if [[ ! $RUN_CI ]]; then
-  python -c 'import platform;print(platform.python_version())' | grep -qE '^2\.6' \
-    && { pip install ${PIP_USER} --ignore-installed --upgrade setuptools==22.0.2 importlib==1.0.4 || exit 1; } \
-    || true
-  pip install ${PIP_USER} --ignore-installed --upgrade -e "$ALIBOT"
-fi
 
 # aliBuild repository slug: <group>/<repo>[@<branch>]
 ALIBUILD_SLUG=${ALIBUILD_SLUG:-alisw/alibuild}


### PR DESCRIPTION
Incorperate minimal changes for macOS Catalina in run-continous-builder. This will break compatibility with current mac builders as it changes the location of `/build` to `/usr/local/build`