### PR TITLE
ci/continuous-builder.sh: ONESHOT only test a single PR

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -185,6 +185,11 @@ while true; do
     HASHES="0@0"
   fi
 
+  if [ X$ONESHOT = Xtrue ]; then
+    echo "Called with ONESHOT=true. Only one PR tested."
+    HASHES=`echo $HASHES | head -n 1`
+  fi
+
   for pr_id in $HASHES; do
     [ -f config/debug ] && DEBUG=`cat config/debug 2>/dev/null | head -n 1`
     [ -f config/profile ] && PROFILE=`cat config/profile 2>/dev/null | head -n 1`


### PR DESCRIPTION
Rather than testing all the PRs before we start reporting results,
we test one and then we move to the "hot" mode.