### PR TITLE
Report PR timing to Google Analytics

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -80,15 +80,21 @@ function report_state() {
                                       --metric-name state                                                                    \
                                       --metric-value $CURRENT_STATE
   $TIMEOUT_CMD report-analytics screenview --cd $CURRENT_STATE
+  # Calculate PR statistics
+  TIME_NOW=$(date -u +%s)
+  PRTIME=
+  [[ $CURRENT_STATE == pr_processing ]] && TIME_PR_STARTED=$TIME_NOW
+  [[ $CURRENT_STATE == pr_processing_done ]] && PRTIME="$((TIME_NOW-TIME_PR_STARTED))"
+
   # Push to InfluxDB if configured
   if [[ $INFLUXDB_WRITE_URL ]]; then
-    TIME_NOW=$(date -u +%s)
-    TIME_NOW_NS=$((TIME_NOW*1000000000))
-    PRTIME=
-    [[ $CURRENT_STATE == pr_processing ]] && TIME_PR_STARTED=$TIME_NOW
-    [[ $CURRENT_STATE == pr_processing_done ]] && PRTIME=",prtime=$((TIME_NOW-TIME_PR_STARTED))"
-    DATA="prcheck,checkname=$CHECK_NAME/$WORKER_INDEX host=\"$(hostname -s)\",state=\"$CURRENT_STATE\",cihash=\"$CI_HASH\",uptime=$((TIME_NOW-TIME_STARTED))${PRTIME}${LAST_PR:+,prid=\"$LAST_PR\"}${LAST_PR_OK:+,prok=$LAST_PR_OK} $TIME_NOW_NS"
+    DATA="prcheck,checkname=$CHECK_NAME/$WORKER_INDEX host=\"$(hostname -s)\",state=\"$CURRENT_STATE\",cihash=\"$CI_HASH\",uptime=$((TIME_NOW-TIME_STARTED))${PRTIME:+,prtime=${PRTIME}}${LAST_PR:+,prid=\"$LAST_PR\"}${LAST_PR_OK:+,prok=$LAST_PR_OK} $((TIME_NOW*1000000000))"
     curl $INFLUX_INSECURE --max-time 20 -XPOST "$INFLUXDB_WRITE_URL" --data-binary "$DATA" || true
+  fi
+
+  # Push to Google Analytics if configured
+  if [ X${ALIBOT_ANALYTICS_ID:+1} = X1 ]; then
+    [ ! X$PRTIME = X ] && $TIMEOUT_CMD report-analytics timing --utc "PR Building" --utv "time" --utt $((PRTIME * 1000)) --utl $CHECK_NAME/$WORKER_INDEX
   fi
 }
 


### PR DESCRIPTION
Plan is to deprecate and remove our own InfluxDB / Grafana instance
as we do not have manpower to maintain it.