### PR TITLE
Simplify daily builds script

### DIFF
--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -1,88 +1,35 @@
 #!/bin/bash -ex
-
-set -o pipefail
-
-# Turn on printout of every build command
-if [[ $EXTENDED_DEBUG ]]; then
-  set -x
-fi
-
-# Swallows errors
-function swallow() {
-  local T=$(mktemp)
-  local MSG=$1
-  local ERR=0
-  shift
-  echo "$MSG..."
-  echo "+ $*" > $T
-  "$@" >> $T 2>&1 || ERR=$?
-  if [[ $ERR != 0 ]]; then
-    echo "Failed with exitcode $ERR, log follows"
-    cat $T
-    rm -f $T
-    return 1
-  fi
-  rm -f $T
-  return 0
-}
+set -x
 
 # Check for required variables
-for V in ALIDIST_REPO ALIBUILD_REPO PACKAGE_NAME AUTOTAG_PATTERN NODE_NAME; do
-  [[ $(eval echo \$$V) ]] || { echo "Required variable $V not defined!"; ERR=1; continue; }
-  eval "export $V"
-done
-[[ $ERR == 1 ]] && exit 1 || true
-
-# Print some preliminary debug information
-pushd "$(dirname "$0")" &> /dev/null
-  echo "This is the daily-tags.sh script version $(git rev-parse HEAD)"
-popd &> /dev/null
-echo "Current date/time: $(date)"
-echo "Current directory: $PWD"
-echo "Running on host $(hostname -f), $(uname -a)"
-echo "Output of lsb_release -a follows:"
-type lsb_release &> /dev/null && lsb_release -a
+ALIDIST_SLUG=${ALIDIST_SLUG:-alisw/alidist@master}
+[ ! -z "$PACKAGE_NAME" ]
+[ ! -z "$AUTOTAG_PATTERN" ]
+[ ! -z "$NODE_NAME" ]
 
 # Clean up old stuff
-rm -rf alibuild/ alidist/
+rm -rf alidist/
 
-# Determine branch from slug string: group/repo[@ref] (one can use both @ and :)
-ALIBUILD_REPO=${ALIBUILD_REPO/:/@} # replace : with @
-ALIDIST_REPO=${ALIDIST_REPO/:/@}   # replace : with @
-ALIBUILD_BRANCH="${ALIBUILD_REPO##*@}"
-ALIBUILD_REPO="${ALIBUILD_REPO%@*}"
-[[ $ALIBUILD_REPO == $ALIBUILD_BRANCH ]] && ALIBUILD_BRANCH=
-ALIDIST_BRANCH="${ALIDIST_REPO##*@}"
-ALIDIST_REPO="${ALIDIST_REPO%@*}"
-[[ $ALIDIST_REPO == $ALIDIST_BRANCH ]] && ALIDIST_BRANCH=
+# Determine branch from slug string: group/repo@ref
+ALIDIST_BRANCH="${ALIDIST_SLUG##*@}"
+ALIDIST_REPO="${ALIDIST_SLUG%@*}"
 
 # Correctly interpret <latest> in alidist version specification
-swallow "Cloning alidist" git clone https://github.com/$ALIDIST_REPO alidist/
 if [[ $ALIDIST_BRANCH == *'<latest>'* ]]; then
   ALIDIST_BRANCH=${ALIDIST_BRANCH/<latest>/[0-9a-zA-Z_-]\+}
-  ALIDIST_BRANCH=$(cd alidist; git log --date-order --graph --tags --simplify-by-decoration --pretty=format:'%d' | sed -e 's/tag://g' | grep -oE "$ALIDIST_BRANCH" | head -n1)
+  ALIDIST_BRANCH=$(GIT_DIR=alidist/.git git log --date-order --graph --tags --simplify-by-decoration --pretty=format:'%d' | sed -e 's/tag://g' | grep -m 1 -oE "$ALIDIST_BRANCH")
   [[ $ALIDIST_BRANCH ]] || { echo "Cannot find latest tag matching expression!"; exit 1; }
-  echo "alidist <latest> tag is $ALIDIST_BRANCH"
 fi
-pushd alidist &> /dev/null
-  swallow "Checking out alidist branch $ALIDIST_BRANCH" git checkout $ALIDIST_BRANCH
-popd &> /dev/null
 
-echo "Will be using alidist from $ALIDIST_REPO${ALIDIST_BRANCH:+, branch $ALIDIST_BRANCH}"
-echo "Will be using aliBuild from $ALIBUILD_REPO${ALIBUILD_BRANCH:+, branch $ALIBUILD_BRANCH}"
+git clone -b $ALIDIST_BRANCH https://github.com/$ALIDIST_REPO alidist/
 
-# Get aliBuild with pip in a temporary directory. Gets all dependencies too
-export PYTHONUSERBASE=$(mktemp -d)
-export PATH=$PYTHONUSERBASE/bin:$PATH
-export LD_LIBRARY_PATH=$PYTHONUSERBASE/lib:$LD_LIBRARY_PATH
-swallow "Installing aliBuild" pip install --user --ignore-installed --upgrade git+https://github.com/${ALIBUILD_REPO}${ALIBUILD_BRANCH:+@$ALIBUILD_BRANCH}
-type aliBuild
+# Install the latest release if ALIBUILD_SLUG is not provided
+pip install --user --ignore-installed --upgrade ${ALIBUILD_SLUG:-alibuild}${ALIBUILD_SLUG:+git+https://github.com/$ALIBUILD_SLUG}
 
 PACKAGE_LOWER=$(echo $PACKAGE_NAME | tr '[[:upper:]]' '[[:lower:]]')
 RECIPE=alidist/$PACKAGE_LOWER.sh
 AUTOTAG_REMOTE=$(grep -E '^(source:|write_repo:)' $RECIPE | sort -r | head -n1 | cut -d: -f2- | xargs echo)
 AUTOTAG_MIRROR=$MIRROR/$PACKAGE_LOWER
-[[ $AUTOTAG_PATTERN ]] || { echo "FATAL: A tag pattern (AUTOTAG_PATTERN) must be defined."; exit 1; }
 AUTOTAG_TAG=$(LANG=C TZ=Europe/Rome date +"$AUTOTAG_PATTERN")
 [[ "$TEST_TAG" == "true" ]] && AUTOTAG_TAG=TEST-IGNORE-$AUTOTAG_TAG
 echo "A Git tag will be created, upon success and if not existing, with the name $AUTOTAG_TAG"
@@ -95,11 +42,10 @@ rm -rf $AUTOTAG_CLONE
 mkdir $AUTOTAG_CLONE
 pushd $AUTOTAG_CLONE &> /dev/null
   [[ -e ../git-creds ]] || git config --global credential.helper "store --file ~/git-creds-autotag"  # backwards compat
-  swallow "Cloning $PACKAGE_NAME from ${AUTOTAG_REMOTE}${AUTOTAG_MIRROR:+, using mirror from $AUTOTAG_MIRROR}" \
   git clone --bare                                         \
             ${AUTOTAG_MIRROR:+--reference=$AUTOTAG_MIRROR} \
             $AUTOTAG_REMOTE .
-  AUTOTAG_HASH=$( (git ls-remote 2> /dev/null | grep refs/tags/$AUTOTAG_TAG || true) | tail -n1 | awk '{print $1}' )
+  AUTOTAG_HASH=$( (git ls-remote 2> /dev/null | grep refs/tags/$AUTOTAG_TAG || true) | awk 'END{print $1}' )
   if [[ "$AUTOTAG_HASH" != '' ]]; then
     echo "Tag $AUTOTAG_TAG exists already as $AUTOTAG_HASH, using it"
     AUTOTAG_ORIGIN=tag
@@ -112,18 +58,18 @@ pushd $AUTOTAG_CLONE &> /dev/null
   else
     # Tag does not exist. Create release candidate branch, if not existing.
 
-    AUTOTAG_HASH=$( (git ls-remote 2> /dev/null | grep refs/heads/$AUTOTAG_BRANCH || true) | tail -n1 | awk '{print $1}' )
+    AUTOTAG_HASH=$( (git ls-remote 2> /dev/null | grep refs/heads/$AUTOTAG_BRANCH || true) | awk 'END{print $1}' )
     AUTOTAG_ORIGIN=rcbranch
 
     if [[ "$AUTOTAG_HASH" != '' && "$REMOVE_RC_BRANCH_FIRST" == true ]]; then
       # Remove branch first if requested. Error is fatal.
-      swallow "Removing existing release candidate branch $AUTOTAG_BRANCH first" git push origin :refs/heads/$AUTOTAG_BRANCH
+      git push origin :refs/heads/$AUTOTAG_BRANCH
       AUTOTAG_HASH=
     fi
 
     if [[ ! $AUTOTAG_HASH ]]; then
       # Let's point it to HEAD
-      AUTOTAG_HASH=$( (git ls-remote 2> /dev/null | sed -e 's/\t/ /g' | grep -E ' HEAD$' || true) | tail -n1 | awk '{print $1}' )
+      AUTOTAG_HASH=$( (git ls-remote 2> /dev/null | sed -e 's/\t/ /g' | grep -E ' HEAD$' || true) | awk 'END{print $1}' )
       [[ $AUTOTAG_HASH ]] || { echo "FATAL: Cannot find any hash pointing to HEAD (repo's default branch)!" >&2; exit 1; }
       echo "Head of $AUTOTAG_REMOTE will be used, it's at $AUTOTAG_HASH"
       AUTOTAG_ORIGIN=HEAD
@@ -133,8 +79,7 @@ pushd $AUTOTAG_CLONE &> /dev/null
 
   # At this point, we have $AUTOTAGH_HASH for sure. It might come from HEAD, an existing rc/* branch,
   # or an existing tag. We always create a new branch out of it
-  swallow "Creating remote branch $AUTOTAG_BRANCH from $AUTOTAG_HASH (hash coming from $AUTOTAG_ORIGIN)" \
-    git push origin +$AUTOTAG_HASH:refs/heads/$AUTOTAG_BRANCH
+  git push origin +$AUTOTAG_HASH:refs/heads/$AUTOTAG_BRANCH
 
 popd &> /dev/null  # exit Git repo
 
@@ -177,42 +122,31 @@ if v:
 open(f, "w").write(yaml.dump(d)+"\n---\n")
 EOF
 
-echo "Listing differences applied to the selected default $DEFAULTS"
-DEFAULTS_LOWER=$(echo $DEFAULTS | tr '[[:upper:]]' '[[:lower:]]')
-ERR=0
-diff -rupN alidist/defaults-${DEFAULTS_LOWER}.sh.old alidist/defaults-${DEFAULTS_LOWER}.sh || ERR=$?
-[[ $ERR == 0 || $ERR == 1 ]] || { echo "FATAL: cannot run diff"; exit 1; }
+diff -rupN alidist/defaults-${DEFAULTS_LOWER}.sh.old alidist/defaults-${DEFAULTS_LOWER}.sh | cat
 
-REMOTE_STORE="rsync://repo.marathon.mesos/store/::rw"
-FETCH_REPOS="$(aliBuild build --help 2> /dev/null | grep fetch-repos || true)"
+REMOTE_STORE="${REMOTE_STORE:-rsync://repo.marathon.mesos/store/::rw}"
 JOBS=8
 [[ $MESOS_QUEUE_SIZE == huge ]] && JOBS=30
 echo "Now running aliBuild on $JOBS parallel workers"
-[[ $EXTENDED_DEBUG ]] || set -x
 aliBuild --reference-sources $MIRROR                   \
          --debug                                       \
          --work-dir $WORKAREA/$WORKAREA_INDEX          \
          ${ARCHITECTURE:+--architecture $ARCHITECTURE} \
          --jobs 16                                     \
-         ${FETCH_REPOS:+--fetch-repos}                 \
+         --fetch-repos                                 \
          --remote-store $REMOTE_STORE                  \
          ${DEFAULTS:+--defaults $DEFAULTS}             \
          build $PACKAGE_NAME || BUILDERR=$?
-[[ $EXTENDED_DEBUG ]] || set +x
 
-echo "Cleaning up temporary directory and unloking working directory"
-rm -f $WORKAREA/$WORKAREA_INDEX/current_slave
-rm -rf $PYTHONUSERBASE
+rm -rf $WORKAREA/$WORKAREA_INDEX/current_slave
 [[ "$BUILDERR" != '' ]] && { echo "Exiting with an error ($BUILDERR), not tagging"; exit $BUILDERR; }
 
 # Now we tag, in case we should
 pushd $AUTOTAG_CLONE &> /dev/null
   if [[ $AUTOTAG_ORIGIN != tag ]]; then
-    swallow "Tagging $AUTOTAG_TAG from $AUTOTAG_HASH" git push origin +$AUTOTAG_HASH:refs/tags/$AUTOTAG_TAG
+    git push origin +$AUTOTAG_HASH:refs/tags/$AUTOTAG_TAG
   else
     echo "Not tagging: tag $AUTOTAG_TAG exists already as $AUTOTAG_HASH"
   fi
-  swallow "Removing working branch $AUTOTAG_BRANCH" git push origin :refs/heads/$AUTOTAG_BRANCH || true  # error is not a big deal here
+  git push origin :refs/heads/$AUTOTAG_BRANCH || true  # error is not a big deal here
 popd &> /dev/null
-
-echo All OK

--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -87,25 +87,25 @@ node ("slc7_x86-64-light") {
       stage "Create daily"
       retry (3) {
         timeout (240) {
-          withEnv(["ALIBUILD_REPO=${ALIBUILD_REPO}",
-                   "ALIDIST_REPO=${ALIDIST_REPO}",
-                   "ALIBOT_REPO=${ALIBOT_REPO}",
+          withEnv(["ALIBUILD_SLUG=${ALIBUILD_SLUG}",
+                   "ALIDIST_SLUG=${ALIDIST_SLUG}",
+                   "ALIBOT_SLUG=${ALIBOT_SLUG}",
                    "ARCHITECTURE=${ARCHITECTURE}",
                    "PACKAGE_NAME=${PACKAGE_NAME}",
                    "DEFAULTS=${DEFAULTS}",
                    "TEST_TAG=${TEST_TAG}",
+                   "REMOTE_STORE=${REMOTE_STORE}",
                    "AUTOTAG_PATTERN=${AUTOTAG_PATTERN}",
                    "AUTOTAG_OVERRIDE_VERSION=${AUTOTAG_OVERRIDE_VERSION}",
                    "MESOS_QUEUE_SIZE=${MESOS_QUEUE_SIZE}",
                    "REMOVE_RC_BRANCH_FIRST=${REMOVE_RC_BRANCH_FIRST}"]) {
             sh '''
-              set -e
-              set -o pipefail
-              ALIBOT_BRANCH="${ALIBOT_REPO##*:}"
-              ALIBOT_REPO="${ALIBOT_REPO%:*}"
-              rm -rf ali-bot/
-              git clone "https://github.com/$ALIBOT_REPO" -b "$ALIBOT_BRANCH" ali-bot/
-              ali-bot/daily-tags.sh
+              set -ex
+              export PYTHONUSERBASE=${PWD}/python-bin
+              export PATH=${PYTHONUSERBASE}/bin:$PATH
+              export LD_LIBRARY_PATH=${PYTHONUSERBASE}/lib:${LD_LIBRARY_PATH}
+              pip install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG
+              daily-tags.sh
             '''
           }
         }

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ setup(
                "monitor-github-api-monalisa.sh",
                # Check daily tags
                "check-daily-slack",
+               "daily-tags.sh",
                # Wait for open Pull Requests before daily tags
                "ci/check-open-pr",
                # Process PR permissions


### PR DESCRIPTION
* Run with -x -e always. Drop printouts which are really debug statements
* Always assume a slug is given in the form `<org>/<repo>[@<branch>]`
* Use GIT_DIR rather than pushd when possible
* Do not rely on pipefail. Rework code which assumes it
* Use `grep -m1` option in place of `| head -n1`
* Use `awk END{...}` rather than `tail -n 1`
* Always use `--fetch-tags`
* Allow `REMOTE_STORE` to be set from the outside