### PR TITLE
(O2-1532) Revert renaming for ALIROOT macOS CI

### DIFF
--- a/ci/conf/aliroot_aliroot-guntest_next-root6_macos.sh
+++ b/ci/conf/aliroot_aliroot-guntest_next-root6_macos.sh
@@ -10,7 +10,8 @@ PR_REPO_CHECKOUT=AliRoot
 PACKAGE=AliRoot-guntest
 
 # How to name the check
-CHECK_NAME=build/AliRoot/AliRoot-guntest/next-root6/macOS
+CHECK_NAME=build/AliRoot/macos
+#CHECK_NAME=build/AliRoot/AliRoot-guntest/next-root6/macOS
 
 # PRs are made to this branch
 PR_BRANCH=master


### PR DESCRIPTION
In #746 macOS builders have been renamed.
After the renaming of the macOS builders, the ALIROOT builder keeps asking for a mandatory passing build by `/build/Aliroot/macos` which has been decommissioned, despite the new builder being in place.

The quickest solution seems to be to go back to the old name until we find out why it keeps asking for the the old builder.