### PR TITLE
Publish build_requires

### DIFF
--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -176,6 +176,23 @@ architectures:
         - ^v4\.9\.3-alice3-1$
         - ^v7\.3\.0-alice1-1$
         - ^v7\.3\.0-alice1-9$
+      CMake: true
+      autotools: true
+      defaults-release: true
+      Python-modules-list: true
+      RapidJSON: true
+      double-conversion: true
+      re2: true
+      fmt: true
+      capstone: true
+      alibuild-recipe-tools: true
+      json-c: true
+      libwebsockets: true
+      Alice-GRID-Utils: true
+      GMP: true
+      MPFR: true
+      googlebenchmark: true
+      cub: true
       O2:
         - ^v[0-1]\.[0-9]+\.[0-9]+-[0-9]$
         - ^nightly-2019091[5-9]-1$


### PR DESCRIPTION
This way we can build O2 / AliPhysics using a preinstalled CVMFS area.