### PR TITLE
Whitelist O2 GSI specific test builds

### DIFF
--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -205,6 +205,7 @@ architectures:
         - ^nightly-2019093.-1$
         - ^nightly-20191...-1$
         - ^nightly-202.....-[1-9]$
+        - ^nightly-202....._GSI-[1-9]$
         - ^nightly-203.....-[1-9]$
         - ^nightly-204.....-[1-9]$
     exclude:


### PR DESCRIPTION
This PR should enable publishing of individual O2 builds with JAliEn-ROOT and TNetXNG file access backend to be tested at GSI. There might be more GSI specific test builds in the future so `_GSI` tag should be ok for this purpose.

cc @costing