### PR TITLE
Cleanup code for build-package

### DIFF
--- a/build-package
+++ b/build-package
@@ -122,6 +122,3 @@ aliBuild --reference-sources $MIRROR                    \
 rm -f $WORKAREA/$WORKAREA_INDEX/current_slave
 [[ "$BUILDERR" != '' ]] && exit $BUILDERR
 
-ALIDIST_HASH=$(cd $WORKSPACE/alidist && git rev-parse HEAD)
-ALIBUILD_HASH=$(aliBuild version 2> /dev/null || true)
-rm -rf $PYTHONUSERBASE


### PR DESCRIPTION
* drop unneeded reports about alidist / alibuild
* Do not remove installation of alibuild