### PR TITLE
Unified CI builder

### DIFF
--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -73,6 +73,7 @@ function get_config () {
   SILENT=$(get_config_value silent)
   DEBUG=$(get_config_value debug)
   REINSTALL_ALIBOT=$(get_config_value reinstall-alibot)
+  RECHECK_PRS=$(get_config_value recheck-prs)
 }
 
 function reset_git_repository () {

--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -72,6 +72,7 @@ function get_config () {
   # to the empty string.
   SILENT=$(get_config_value silent)
   DEBUG=$(get_config_value debug)
+  REINSTALL_ALIBOT=$(get_config_value reinstall-alibot)
 }
 
 function reset_git_repository () {

--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -22,7 +22,7 @@ function report_state() {
   if [ X${ALIBOT_ANALYTICS_ID:+1} = X1 ]; then
     # Report first PR and the rest in a separate category
     if [ ! X$PRTIME = X ]; then
-      $TIMEOUT_CMD report-analytics timing --utc "${ONESHOT:+First }PR Building" --utv "time" --utt $((PRTIME * 1000)) --utl $CHECK_NAME/$WORKER_INDEX
+      $TIMEOUT_CMD report-analytics timing --utc 'PR Building' --utv time --utt $((PRTIME * 1000)) --utl "$CHECK_NAME/$WORKER_INDEX"
     fi
   fi
 }

--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -49,8 +49,17 @@ function clean_env () {
 # This comes handy when scaling up / down a job, so that we do not quit the
 # currently running workers simply to adapt to the new ensemble.
 function get_config_value () {
-  # Prints the value in config/$1, or prints $2 in case of failure.
-  head -1 "config/$1" 2>/dev/null || echo "$2"
+  # Looks for a config/ directory here or in any parent dir and prints the
+  # contents of the file called $1 in the closest config/ found. If no config/
+  # is found, prints $2.
+  (
+    while [ "$(pwd)" != / ]; do
+      head -1 "config/$1" 2>/dev/null &&
+        exit
+      cd ..
+    done
+    echo "$2"
+  )
 }
 
 function get_config () {

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -8,6 +8,10 @@
 
 get_config
 
+if [ -n "$REINSTALL_ALIBOT" ]; then
+  pip2 install --upgrade --ignore-installed git+https://github.com/alisw/ali-bot@master
+fi
+
 # A few common environment variables when reporting status to analytics.
 # In analytics we use screenviews to indicate different states of the
 # processing and events to indicate all the things we would consider as

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -1,85 +1,57 @@
 #!/bin/bash -x
-# A simple script which keeps building using the latest aliBuild,
-# alidist and AliRoot / AliPhysics.
-# Notice this will do an incremental build, not a full build, so it
-# really to catch errors earlier.
+# This is the inner loop of continuous-builder.sh. This script builds one pull
+# request for one repository. Which repo is checked depends on the environment
+# variables passed to this script; they are set in continuous-builder.sh from
+# environment definitions in repo-config/.
+#
+# Some functions used here are defined in continuous-builder.sh.
+
+get_config
 
 report_state looping
-# Allow overriding a number of variables by fly, so that we can change the
-# behavior of the job without restarting it.
-# This comes handy when scaling up / down a job, so that we do not quit the
-# currently running workers simply to adapt to the new ensamble.
-[ -f config/workers-pool-size ] && WORKERS_POOL_SIZE=`cat config/workers-pool-size 2>/dev/null | head -n 1`
-[ -f config/worker-index ] && WORKER_INDEX=`cat config/worker-index 2>/dev/null | head -n 1`
-[ -f config/debug ] && DEBUG=`cat config/debug 2>/dev/null | head -n 1`
-[ -f config/profile ] && PROFILE=`cat config/profile 2>/dev/null | head -n 1`
-[ -f config/jobs ] && JOBS=`cat config/jobs 2>/dev/null | head -n 1`
-[ -f config/timeout ] && TIMEOUT=`cat config/timeout 2>/dev/null | head -n 1`
-[ -f config/long-timeout ] && LONG_TIMEOUT=`cat config/long-timeout 2>/dev/null | head -n 1`
-[ -f config/silent ] && SILENT=`cat config/silent 2>/dev/null | head -n 1`
-# In case the files are gone, unset some of the variables so that we can
-# revert the state.
-[ ! -f config/silent ] && unset SILENT
-[ ! -f config/debug ] && unset DEBUG
-[ ! -f config/profile ] && unset PROFILE
 
 # Run preliminary cleanup command
 aliBuild clean ${DEBUG:+--debug}
 
 # Update and cleanup all Git repositories (except ali-bot)
-for d in $(find . -maxdepth 2 -name .git -exec dirname {} \; | grep -v ali-bot); do
-  pushd $d
-    LOCAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-    if [[ $LOCAL_BRANCH != HEAD ]]; then
-      # Cleanup first (if more than 4h passed after last gc)
-      if [ -d .git/refs/remotes/origin/pr ]; then
-        find .git -path '.git/refs/remotes/origin/pr/*' | sed -e 's|^.git/||g' | xargs -n 1 git update-ref -d
-      fi
-      if [[ $(( $(date -u +%s) - $LAST_GIT_GC )) -gt 14400 ]]; then
-        git reflog expire --expire=now --all || true
-        git gc --prune=now || true
-        LAST_GIT_GC=$(date -u +%s)
-      fi
-      # Try to reset to corresponding remote branch (assume it's origin/<branch>)
-      $TIMEOUT_CMD git fetch origin +$LOCAL_BRANCH:refs/remotes/origin/$LOCAL_BRANCH
-      git reset --hard origin/$LOCAL_BRANCH
-      git clean -fxd
-    fi
-  popd
+find . -mindepth 2 -maxdepth 2 -name .git | while read -r d; do
+  [ "$d" = ./ali-bot/.git ] && continue
+  reset_git_repository "$(dirname "$d")"
 done
 
 # Remove logs older than 5 days
 find separate_logs/ -type f -mtime +5 -delete || true
 find separate_logs/ -type d -empty -delete || true
 
-if [[ "$PR_REPO" != "" ]]; then
-  HASHES=$(cat force-hashes | grep -vE '^#' 2> /dev/null || true)
-  if [[ ! $HASHES ]]; then
-    HASHES=`$TIMEOUT_CMD list-branch-pr --show-main-branch --check-name $CHECK_NAME ${TRUST_COLLABORATORS:+--trust-collaborators} ${TRUSTED_USERS:+--trusted $TRUSTED_USERS} $PR_REPO@$PR_BRANCH ${WORKERS_POOL_SIZE:+--workers-pool-size $WORKERS_POOL_SIZE} ${WORKER_INDEX:+--worker-index $WORKER_INDEX} ${DELAY:+--max-wait $DELAY} || $TIMEOUT_CMD report-analytics exception --desc "list-branch-pr failed"`
+if [ -z "$PR_REPO" ]; then
+  echo 'No PR_REPO given; skipping' >&2
+  exit 1
+else
+  HASHES=$(grep -vE '^[[:blank:]]*(#|$)' force-hashes 2>/dev/null || true)
+  if [ -z "$HASHES" ]; then
+    HASHES=$(short_timeout list-branch-pr --show-main-branch "$PR_REPO@$PR_BRANCH" \
+                           --check-name "$CHECK_NAME" \
+                           ${TRUST_COLLABORATORS:+--trust-collaborators} \
+                           ${TRUSTED_USERS:+--trusted $TRUSTED_USERS} \
+                           ${WORKERS_POOL_SIZE:+--workers-pool-size $WORKERS_POOL_SIZE} \
+                           ${WORKER_INDEX:+--worker-index $WORKER_INDEX} \
+                           ${DELAY:+--max-wait $DELAY}) ||
+        short_timeout report-analytics exception --desc 'list-branch-pr failed'
   else
     echo "Note: using hashes from $PWD/force-hashes, here is the list:"
     cat $PWD/force-hashes
     echo
   fi
-else
-  HASHES="0@0"
 fi
-
-for pr_id in $HASHES; do
-  [ -f config/debug ] && DEBUG=`cat config/debug 2>/dev/null | head -n 1`
-  [ -f config/profile ] && PROFILE=`cat config/profile 2>/dev/null | head -n 1`
-  [ -f config/jobs ] && JOBS=`cat config/jobs 2>/dev/null | head -n 1`
-  [ -f config/silent ] && SILENT=`cat config/silent 2>/dev/null | head -n 1`
-  # In case the files are gone, unset some of the variables so that we can
-  # revert the state.
-  [ ! -f config/silent ] && unset SILENT
-  [ ! -f config/debug ] && unset DEBUG
-  [ ! -f config/profile ] && unset PROFILE
 
   DOCTOR_ERROR=""
   BUILD_ERROR=""
-  pr_number=${pr_id%@*}
-  pr_hash=${pr_id#*@}
+for PR_ID in $HASHES; do
+  . build-helpers.sh
+  get_config
+
+  pr_number=${PR_ID%@*}
+  pr_hash=${PR_ID#*@}
   LAST_PR=$pr_number
   LAST_PR_OK=
 
@@ -93,7 +65,7 @@ for pr_id in $HASHES; do
       CANNOT_MERGE=0
       git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
       # Only fetch destination branch for PRs (for merging), and the PR we are checking now
-      $TIMEOUT_CMD git fetch origin +$PR_BRANCH:refs/remotes/origin/$PR_BRANCH
+      short_timeout git fetch origin "+$PR_BRANCH:refs/remotes/origin/$PR_BRANCH"
       [[ $pr_number =~ ^[0-9]*$ ]] && $TIMEOUT_CMD git fetch origin +pull/$pr_number/head
       git reset --hard origin/$PR_BRANCH  # reset to branch target of PRs
       git clean -fxd
@@ -109,35 +81,32 @@ for pr_id in $HASHES; do
     if [[ $CANNOT_MERGE == 1 ]]; then
       # We do not want to kill the system is github is not working
       # so we ignore the result code for now
-      $TIMEOUT_CMD set-github-status ${SILENT:+-n} -c ${PR_REPO:-alisw/alidist}@${PR_REF:-$ALIDIST_REF} -s $CHECK_NAME/error -m "Cannot merge PR into test area" || $TIMEOUT_CMD report-analytics exception --desc "set-github-status fail on cannot merge"
+      short_timeout set-github-status ${SILENT:+-n} -c "${PR_REPO:-alisw/alidist}@${PR_REF:-$ALIDIST_REF}" -s "$CHECK_NAME/error" -m 'Cannot merge PR into test area' ||
+        short_timeout report-analytics exception --desc 'set-github-status fail on cannot merge'
       continue
     fi
     if [[ $(($NEW_SIZE - $OLD_SIZE)) -gt ${MAX_DIFF_SIZE:-5} ]]; then
       # We do not want to kill the system is github is not working
       # so we ignore the result code for now
-      $TIMEOUT_CMD set-github-status ${SILENT:+-n} -c ${PR_REPO:-alisw/alidist}@${PR_REF:-$ALIDIST_REF} -s $CHECK_NAME/error -m "Diff too big. Rejecting." || $TIMEOUT_CMD report-analytics exception --desc "set-github-status fail on merge too big"
-      $TIMEOUT_CMD report-pr-errors --default $BUILD_SUFFIX                            \
-                                    ${SILENT:+--dry-run}                               \
-                                    --logs-dest s3://alice-build-logs.s3.cern.ch       \
-                                    --log-url https://ali-ci.cern.ch/alice-build-logs/ \
-                                    --pr "${PR_REPO:-alisw/alidist}#${pr_id}"          \
-                                    -s $CHECK_NAME -m "Your pull request exceeded the allowed size. If you need to commit large files, [have a look here](http://alisw.github.io/git-advanced/#how-to-use-large-data-files-for-analysis)." || $TIMEOUT_CMD report-analytics exception --desc "report-pr-errors fail on merge diff too big"
+      short_timeout set-github-status ${SILENT:+-n} -c "${PR_REPO:-alisw/alidist}@${PR_REF:-$ALIDIST_REF}" -s "$CHECK_NAME/error" -m 'Diff too big. Rejecting.' ||
+        short_timeout report-analytics exception --desc 'set-github-status fail on merge too big'
+      report_pr_errors -m 'Your pull request exceeded the allowed size. If you need to commit large files, [have a look here](http://alisw.github.io/git-advanced/#how-to-use-large-data-files-for-analysis).' ||
+        short_timeout report-analytics exception --desc 'report-pr-errors fail on merge diff too big'
       continue
     fi
   fi
 
-  GITLAB_USER= GITLAB_PASS= GITHUB_TOKEN= INFLUXDB_WRITE_URL= CODECOV_TOKEN= \
-  AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY=                                  \
-  $TIMEOUT_CMD aliDoctor ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS} $PACKAGE || DOCTOR_ERROR=$?
   STATUS_REF=${PR_REPO:-alisw/alidist}@${PR_REF:-$ALIDIST_REF}
-  if [[ $DOCTOR_ERROR != '' ]]; then
+  if ! clean_env short_timeout aliDoctor ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS} "$PACKAGE"; then
     # We do not want to kill the system is github is not working
     # so we ignore the result code for now
-    $TIMEOUT_CMD set-github-status ${SILENT:+-n} -c ${STATUS_REF} -s $CHECK_NAME/error -m 'aliDoctor error' || $TIMEOUT_CMD report-analytics exception --desc "set-github-status fail on aliDoctor error"
+    short_timeout set-github-status ${SILENT:+-n} -c "$STATUS_REF" -s "$CHECK_NAME/error" -m 'aliDoctor error' ||
+      short_timeout report-analytics exception --desc 'set-github-status fail on aliDoctor error'
     # If doctor fails, we can move on to the next PR, since we know it will not work.
     # We do not report aliDoctor being ok, because that's really a granted.
     continue
   fi
+
   # Each round we delete the "latest" symlink, to avoid reporting errors
   # from a previous one. In any case they will be recreated if needed when
   # we build.
@@ -161,45 +130,35 @@ for pr_id in $HASHES; do
   if [ ! X$REMOTE_STORE = X ]; then ping -c1 `echo $REMOTE_STORE | awk -F/ '{print $3}'`; fi
 
   FETCH_REPOS="$(aliBuild build --help | grep fetch-repos || true)"
-  ALIBUILD_HEAD_HASH=$pr_hash ALIBUILD_BASE_HASH=$base_hash                    \
-  GITLAB_USER= GITLAB_PASS= GITHUB_TOKEN= INFLUXDB_WRITE_URL= CODECOV_TOKEN=   \
-  AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY=                                    \
-  $LONG_TIMEOUT_CMD                                                            \
-  aliBuild -j ${JOBS:-`nproc`}                                                 \
-           ${FETCH_REPOS:+--fetch-repos}                                       \
-           ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS}                 \
-           -z $BUILD_IDENTIFIER                                                \
-           ${MIRROR:+--reference-sources $MIRROR}                              \
-           ${REMOTE_STORE:+--remote-store $REMOTE_STORE}                       \
-           ${DEBUG:+--debug}                                                   \
-           build $PACKAGE || BUILD_ERROR=$?
 
-  if [[ $BUILD_ERROR != '' ]]; then
-    # We do not want to kill the system if GitHub is not working
-    # so we ignore the result code for now
-    $TIMEOUT_CMD report-pr-errors --default $BUILD_SUFFIX                            \
-                                  ${SILENT:+--dry-run}                               \
-                                  ${DONT_USE_COMMENTS:+--no-comments}                \
-                                  --logs-dest s3://alice-build-logs.s3.cern.ch       \
-                                  --log-url https://ali-ci.cern.ch/alice-build-logs/ \
-                                  --pr "${PR_REPO:-alisw/alidist}#${pr_id}" -s $CHECK_NAME || $TIMEOUT_CMD report-analytics exception --desc "report-pr-errors fail on build error"
-  else
+  if ALIBUILD_HEAD_HASH=$pr_hash ALIBUILD_BASE_HASH=$base_hash \
+                       clean_env long_timeout aliBuild -j "${JOBS:-$(nproc)}" \
+                       ${FETCH_REPOS:+--fetch-repos}                       \
+                       ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS} \
+                       -z "$BUILD_IDENTIFIER"                              \
+                       ${MIRROR:+--reference-sources $MIRROR}              \
+                       ${REMOTE_STORE:+--remote-store $REMOTE_STORE}       \
+                       ${DEBUG:+--debug}                                   \
+                       build "$PACKAGE"
+  then
     # We do not want to kill the system is github is not working
     # so we ignore the result code for now
     if [[ $(( $pr_number + 0 )) == $pr_number ]]; then
       # This is a PR. Use the error function (with --success) to still provide logs
-      $TIMEOUT_CMD report-pr-errors --default $BUILD_SUFFIX                            \
-                                    ${SILENT:+--dry-run}                               \
-                                    --success                                          \
-                                    --logs-dest s3://alice-build-logs.s3.cern.ch       \
-                                    --log-url https://ali-ci.cern.ch/alice-build-logs/ \
-                                    --pr "${PR_REPO:-alisw/alidist}#${pr_id}" -s $CHECK_NAME || $TIMEOUT_CMD report-analytics exception --desc "report-pr-errors fail on build success"
+      report_pr_errors --success
     else
       # This is a branch
-      $TIMEOUT_CMD set-github-status ${SILENT:+-n} -c ${STATUS_REF} -s $CHECK_NAME/success || $TIMEOUT_CMD report-analytics exception --desc "set-github-status fail on build success"
-    fi
+      short_timeout set-github-status ${SILENT:+-n} -c "$STATUS_REF" -s "$CHECK_NAME/success"
+    fi ||
+      short_timeout report-analytics exception --desc 'report-pr-errors fail on build success'
+    LAST_PR_OK=1
+  else
+    # We do not want to kill the system if GitHub is not working
+    # so we ignore the result code for now
+    report_pr_errors ${DONT_USE_COMMENTS:+--no-comments} ||
+      short_timeout report-analytics exception --desc 'report-pr-errors fail on build error'
+    LAST_PR_OK=0
   fi
-  [[ $BUILD_ERROR ]] && LAST_PR_OK=0 || LAST_PR_OK=1
 
   # Run post-build cleanup command
   aliBuild clean ${DEBUG:+--debug}
@@ -208,23 +167,21 @@ for pr_id in $HASHES; do
   # it to codecov.io
   COVERAGE_SOURCES=$PWD/${PR_REPO_CHECKOUT:-$(basename $PR_REPO)}
   COVERAGE_INFO_DIR=$(find sw/BUILD/ -maxdepth 4 -name coverage.info | head -1 | xargs dirname || true)
-  if [[ ${COVERAGE_INFO_DIR} ]]; then
-    pushd ${COVERAGE_INFO_DIR}
-      COVERAGE_COMMIT_HASH=${pr_hash}
-      if [[ $COVERAGE_COMMIT_HASH == 0 ]]; then
-        COVERAGE_COMMIT_HASH=${base_hash}
-      fi
-      # If not a number, it's the branch name
-      re='^[0-9]+$'
-      if ! [[ $pr_number =~ $re ]] ; then
-        unset pr_number
-      fi
-      $TIMEOUT_CMD bash <(curl --max-time 600 -s https://codecov.io/bash)                 \
-                                              -R $COVERAGE_SOURCES                        \
-                                              -f coverage.info                            \
-                                              -C ${COVERAGE_COMMIT_HASH}                  \
-                                              ${PR_BRANCH:+-B $PR_BRANCH}                 \
-                                              ${pr_number:+-P $pr_number} || true
+  if [ -n "$COVERAGE_INFO_DIR" ] && pushd "$COVERAGE_INFO_DIR"; then
+    COVERAGE_COMMIT_HASH=$pr_hash
+    if [ "$COVERAGE_COMMIT_HASH" = 0 ]; then
+      COVERAGE_COMMIT_HASH=$base_hash
+    fi
+    # If not a number, it's the branch name
+    if ! [[ $pr_number =~ ^[0-9]+$ ]]; then
+      unset pr_number
+    fi
+    short_timeout bash <(curl --max-time 600 -s https://codecov.io/bash) \
+                  -R "$COVERAGE_SOURCES"      \
+                  -f coverage.info            \
+                  -C "$COVERAGE_COMMIT_HASH"  \
+                  ${PR_BRANCH:+-B $PR_BRANCH} \
+                  ${pr_number:+-P $pr_number} || true
     popd
   fi
   report_state pr_processing_done

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -80,7 +80,7 @@ else
                            ${TRUSTED_USERS:+--trusted $TRUSTED_USERS} \
                            ${WORKERS_POOL_SIZE:+--workers-pool-size $WORKERS_POOL_SIZE} \
                            ${WORKER_INDEX:+--worker-index $WORKER_INDEX} \
-                           ${DELAY:+--max-wait $DELAY}) ||
+                           ${RECHECK_PRS:+--tested-only}) ||
         short_timeout report-analytics exception --desc 'list-branch-pr failed'
   else
     echo "Note: using hashes from $PWD/force-hashes, here is the list:"

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -55,7 +55,7 @@ find separate_logs/ -type d -empty -delete || true
 if [[ "$PR_REPO" != "" ]]; then
   HASHES=$(cat force-hashes | grep -vE '^#' 2> /dev/null || true)
   if [[ ! $HASHES ]]; then
-    HASHES=`$TIMEOUT_CMD list-branch-pr ${LIST_BRANCH_PR_TIMEOUT:+--timeout $LIST_BRANCH_PR_TIMEOUT} --show-main-branch --check-name $CHECK_NAME ${TRUST_COLLABORATORS:+--trust-collaborators} ${TRUSTED_USERS:+--trusted $TRUSTED_USERS} $PR_REPO@$PR_BRANCH ${WORKERS_POOL_SIZE:+--workers-pool-size $WORKERS_POOL_SIZE} ${WORKER_INDEX:+--worker-index $WORKER_INDEX} ${DELAY:+--max-wait $DELAY} || $TIMEOUT_CMD report-analytics exception --desc "list-branch-pr failed"`
+    HASHES=`$TIMEOUT_CMD list-branch-pr --show-main-branch --check-name $CHECK_NAME ${TRUST_COLLABORATORS:+--trust-collaborators} ${TRUSTED_USERS:+--trusted $TRUSTED_USERS} $PR_REPO@$PR_BRANCH ${WORKERS_POOL_SIZE:+--workers-pool-size $WORKERS_POOL_SIZE} ${WORKER_INDEX:+--worker-index $WORKER_INDEX} ${DELAY:+--max-wait $DELAY} || $TIMEOUT_CMD report-analytics exception --desc "list-branch-pr failed"`
   else
     echo "Note: using hashes from $PWD/force-hashes, here is the list:"
     cat $PWD/force-hashes
@@ -63,11 +63,6 @@ if [[ "$PR_REPO" != "" ]]; then
   fi
 else
   HASHES="0@0"
-fi
-
-if [ X$ONESHOT = Xtrue ]; then
-  echo "Called with ONESHOT=true. Only one PR tested."
-  HASHES=`echo $HASHES | head -n 1`
 fi
 
 for pr_id in $HASHES; do
@@ -236,10 +231,3 @@ for pr_id in $HASHES; do
 done  # end processing a single PR
 
 report_state looping_done
-# Mark the fact we have run at least once.
-mkdir -p state
-touch state/ready
-if [[ $ONESHOT = true ]]; then
-  echo "Called with ONESHOT=true. Exiting."
-  exit 0
-fi

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -3,27 +3,6 @@
 # AliRoot / AliPhysics. Notice this will do an incremental build, not a full
 # build, so it really to catch errors earlier.
 
-# A few common environment variables when reporting status to analytics.
-# In analytics we use screenviews to indicate different states of the
-# processing and events to indicate all the things we would consider as
-# fatal in a non deamon process but that here simly make us go to the
-# next step.
-echo ALIBUILD_O2_FORCE_GPU: $ALIBUILD_O2_FORCE_GPU
-echo AMDAPPSDKROOT: $AMDAPPSDKROOT
-echo CMAKE_PREFIX_PATH: $CMAKE_PREFIX_PATH
-export ALIBOT_ANALYTICS_ID=$ALIBOT_ANALYTICS_ID
-export ALIBOT_ANALYTICS_USER_UUID=`hostname -s`-$WORKER_INDEX${CI_NAME:+-$CI_NAME}
-# Hardcode for now
-export ALIBOT_ANALYTICS_ARCHITECTURE=slc7_x86-64
-export ALIBOT_ANALYTICS_APP_NAME="continuous-builder.sh"
-
-# Mesos DNSes
-: ${MESOS_DNS:=alimesos01.cern.ch,alimesos02.cern.ch,alimesos03.cern.ch}
-export MESOS_DNS
-
-TIME_STARTED=$(date -u +%s)
-CI_HASH=$(cd "$(dirname "$0")" && git rev-parse HEAD)
-
 # timeout vs. gtimeout (macOS with Homebrew)
 TIMEOUT_EXEC=timeout
 type $TIMEOUT_EXEC > /dev/null 2>&1 || TIMEOUT_EXEC=gtimeout
@@ -32,60 +11,21 @@ function long_timeout () { $TIMEOUT_EXEC -s9 "$(get_config_value long-timeout "$
 
 . build-helpers.sh
 
-MIRROR=${MIRROR:-/build/mirror}
-PACKAGE=${PACKAGE:-AliPhysics}
-LAST_PR=
-PR_REPO_CHECKOUT=${PR_REPO_CHECKOUT:-$(basename "$PR_REPO")}
-
-# If INFLUXDB_WRITE_URL starts with insecure_https://, then strip "insecure" and
-# set the proper option to curl
-INFLUX_INSECURE=
-[[ $INFLUXDB_WRITE_URL == insecure_https:* ]] && { INFLUX_INSECURE=-k; INFLUXDB_WRITE_URL=${INFLUXDB_WRITE_URL:9}; }
-
-# Last time `git gc` was run
-LAST_GIT_GC=0
-
-# This is the check name. If CHECK_NAME is in the environment, use it. Otherwise
-# default to, e.g., build/AliRoot/release (build/<Package>/<Defaults>)
-CHECK_NAME=${CHECK_NAME:=build/$PACKAGE${ALIBUILD_DEFAULTS:+/$ALIBUILD_DEFAULTS}}
-
-# Worker index, zero-based. Set to 0 if unset (i.e. when not running on Aurora)
-WORKER_INDEX=${WORKER_INDEX:-0}
-
-pushd alidist
-  ALIDIST_REF=`git rev-parse --verify HEAD`
-popd
-# Generate example of force-hashes file. This is used to override what to check for testing
-if [[ ! -e force-hashes ]]; then
-  cat > force-hashes <<EOF
-# Example (this is a comment):
-# pr_number@hash
-# You can also use:
-# branch_name@hash
-EOF
-fi
 
 
+# Set up common global environment
+# Mesos DNSes
+: "${MESOS_DNS:=alimesos01.cern.ch,alimesos02.cern.ch,alimesos03.cern.ch}"
+export MESOS_DNS
 # Explicitly set UTF-8 support (Python needs it!)
-export LANG="en_US.UTF-8"
-export LANGUAGE="en_US.UTF-8"
-export LC_CTYPE="en_US.UTF-8"
-export LC_NUMERIC="en_US.UTF-8"
-export LC_TIME="en_US.UTF-8"
-export LC_COLLATE="en_US.UTF-8"
-export LC_MONETARY="en_US.UTF-8"
-export LC_MESSAGES="en_US.UTF-8"
-export LC_PAPER="en_US.UTF-8"
-export LC_NAME="en_US.UTF-8"
-export LC_ADDRESS="en_US.UTF-8"
-export LC_TELEPHONE="en_US.UTF-8"
-export LC_MEASUREMENT="en_US.UTF-8"
-export LC_IDENTIFICATION="en_US.UTF-8"
-export LC_ALL="en_US.UTF-8"
+export {LANG{,UAGE},LC_{CTYPE,NUMERIC,TIME,COLLATE,MONETARY,PAPER,MESSAGES,NAME,ADDRESS,TELEPHONE,MEASUREMENT,IDENTIFICATION,ALL}}=en_US.UTF-8
 
 report_state started
+# GitLab credentials for private ALICE repositories
+printf 'protocol=https\nhost=gitlab.cern.ch\nusername=%s\npassword=%s\n' "$GITLAB_USER" "$GITLAB_PASS" |
+  git credential-store --file ~/.git-creds store
+git config --global credential.helper 'store --file ~/.git-creds'
 
-mkdir -p config
 
 while true; do
   source `which build-helpers.sh || echo ci/build-helpers.sh`

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -25,13 +25,6 @@ export MESOS_DNS
 TIME_STARTED=$(date -u +%s)
 CI_HASH=$(cd "$(dirname "$0")" && git rev-parse HEAD)
 
-# Timeout between calls of list-branch-pr
-LIST_BRANCH_PR_TIMEOUT=
-if [[ $ONESHOT == true ]]; then
-  LIST_BRANCH_PR_TIMEOUT=1
-  DELAY=1
-fi
-
 # timeout vs. gtimeout (macOS with Homebrew)
 TIMEOUT_EXEC=timeout
 type timeout > /dev/null 2>&1 || TIMEOUT_EXEC=gtimeout

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -66,8 +66,7 @@ while true; do
 
         # Make a directory for this repo's dependencies so they don't conflict
         # with other repos'
-        repo=${env_file#repo-config/$cur_container/}
-        repo=${repo%.env}
+        repo=$(basename "${env_file%.env}")
         mkdir -p "$repo"
         cd "$repo" || exit 10
 

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -11,7 +11,17 @@ function long_timeout () { $TIMEOUT_EXEC -s9 "$(get_config_value long-timeout "$
 
 . build-helpers.sh
 
+# In one-repo-only mode, environment definition files aren't read, and we assume
+# e.g. aurora has already given us the required environment for the one specific
+# build we should do.
+ONE_REPO_ONLY=
+for arg in "$@"; do
+  if [ "$arg" = --one-repo-only ]; then
+    ONE_REPO_ONLY=true
+  fi
+done
 
+git clone https://github.com/alisw/ali-bot
 
 # Set up common global environment
 # Mesos DNSes
@@ -20,16 +30,58 @@ export MESOS_DNS
 # Explicitly set UTF-8 support (Python needs it!)
 export {LANG{,UAGE},LC_{CTYPE,NUMERIC,TIME,COLLATE,MONETARY,PAPER,MESSAGES,NAME,ADDRESS,TELEPHONE,MEASUREMENT,IDENTIFICATION,ALL}}=en_US.UTF-8
 
-report_state started
 # GitLab credentials for private ALICE repositories
 printf 'protocol=https\nhost=gitlab.cern.ch\nusername=%s\npassword=%s\n' "$GITLAB_USER" "$GITLAB_PASS" |
   git credential-store --file ~/.git-creds store
 git config --global credential.helper 'store --file ~/.git-creds'
 
+report_state started
 
 while true; do
-  source `which build-helpers.sh || echo ci/build-helpers.sh`
-  # We source the actual build loop, so that whenever we repeat it,
-  # we can get a new version.
-  source `which build-loop.sh || echo ci/build-loop.sh`
+  if [ -n "$ONE_REPO_ONLY" ]; then
+    # All the environment variables we need are already set by aurora, so just
+    # run the build.
+    (. build-loop.sh)
+  else
+    cur_container=${CONTAINER_IMAGE#*/}
+    cur_container=${cur_container%-builder:*}
+    # If there is no repo we can build in this container, wait; maybe something
+    # will turn up.
+    if ! [ -d "ali-bot/ci/repo-config/$cur_container" ]; then
+      sleep 600
+      continue
+    fi
+
+    # Loop through repositories we can build (i.e. that need the docker
+    # container we are in).
+    for env_file in "ali-bot/ci/repo-config/$cur_container"/*.env; do
+      # Run iterations in a subshell so environment variables are not kept
+      # across potentially different repos. This is an issue as env files are
+      # allowed to define arbitrary variables that other files (or the defaults
+      # file) might not override.
+      (
+        # Set up environment
+        . "ali-bot/ci/repo-config/defaults.env" || exit
+        . "$env_file"                           || exit   # in case there are no env files
+
+        # Make a directory for this repo's dependencies so they don't conflict
+        # with other repos'
+        repo=${env_file#repo-config/$cur_container/}
+        repo=${repo%.env}
+        mkdir -p "$repo"
+        cd "$repo" || exit 10
+
+        # Get dependency development packages
+        echo "$DEVEL_PKGS" | while read -r gh_url branch checkout_name; do
+          git clone "https://github.com/$gh_url" ${branch:+--branch "$branch"} ${checkout_name:+"$checkout_name"}
+        done
+
+        # Run the build
+        . build-loop.sh
+      )
+    done
+  fi
+
+  # Get updates to ali-bot
+  reset_git_repository ali-bot
 done

--- a/list-branch-pr
+++ b/list-branch-pr
@@ -246,18 +246,10 @@ def parseArgs():
                         help=("If no untested PRs are found, return "
                               "already-tested ones"))
 
-    parser.add_argument("--poll-time", "--timeout",
-                        dest="poll_time",
-                        default=30,
-                        type=int,
-                        help="Timeout between one run and the other")
-
-    parser.add_argument("--max-wait",
-                        default=1200,
-                        dest="maxWait",
-                        type=int,
-                        help=("Max seconds to wait before returning "
-                              "whatever PRs we have (default: 1200)"))
+    parser.add_argument("--tested-only", "--no-untested",
+                        dest="tested_only",
+                        action="store_true",
+                        help="Test only PRs that have been tested previously")
 
     parser.add_argument("--trusted",
                         default="review",
@@ -334,20 +326,15 @@ if __name__ == "__main__":
             pulls = process(cgh, args)
             grouped = group_pulls(pulls)
 
-            if grouped["not_tested"]:
+            if grouped["not_tested"] and not args.tested_only:
                 sendToStdOut(grouped["not_tested"])
                 break
-            elif args.fallback_to_tested:
-                m = "No untested PRs, sleeping for {0}s".format(args.poll_time)
-                print(m, file=sys.stderr)
-
-                err, out = getstatusoutput("sleep {0}".format(args.poll_time))
-                if err or timeSince(start) >= args.maxWait:
-                    # return whatever we have (may be empty)
-                    if grouped["not_successful"] or grouped["tested"]:
-                        sendToStdOut([random.choice(grouped["not_successful"] + grouped["tested"])])
-                    elif grouped["reviewed"]:
-                        sendToStdOut([random.choice(grouped["reviewed"])])
-                    break
+            elif args.tested_only or args.fallback_to_tested:
+                # return whatever we have (may be empty)
+                if grouped["not_successful"] or grouped["tested"]:
+                    sendToStdOut([random.choice(grouped["not_successful"] + grouped["tested"])])
+                elif grouped["reviewed"]:
+                    sendToStdOut([random.choice(grouped["reviewed"])])
+                break
             else:
                 break


### PR DESCRIPTION
This PR should be merged together with the corresponding GitLab merge request.

This PR changes the CI build script to poll multiple repositories for PRs to build, instead of just one.

Repo-specific configuration is kept in `ci/repo-config/<docker-image>/*.env` files; the worker clones the ali-bot repository to get those files.