### PR TITLE
Improvements to CI builder

### DIFF
--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -68,12 +68,13 @@ function get_config () {
   WORKERS_POOL_SIZE=$(get_config_value workers-pool-size "$WORKERS_POOL_SIZE")
   WORKER_INDEX=$(get_config_value worker-index "$WORKER_INDEX")
   JOBS=$(get_config_value jobs "$JOBS")
+  TIMEOUT=$(get_config_value timeout "$TIMEOUT")
+  LONG_TIMEOUT=$(get_config_value long-timeout "$LONG_TIMEOUT")
+  RECHECK_PRS=$(get_config_value recheck-prs "$RECHECK_PRS")
   # If the files have been deleted in the meantime, this will set the variables
   # to the empty string.
   SILENT=$(get_config_value silent)
   DEBUG=$(get_config_value debug)
-  REINSTALL_ALIBOT=$(get_config_value reinstall-alibot)
-  RECHECK_PRS=$(get_config_value recheck-prs)
 }
 
 function reset_git_repository () {

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -8,10 +8,6 @@
 
 get_config
 
-if [ -n "$REINSTALL_ALIBOT" ]; then
-  pip2 install --upgrade --ignore-installed git+https://github.com/alisw/ali-bot@master
-fi
-
 # A few common environment variables when reporting status to analytics.
 # In analytics we use screenviews to indicate different states of the
 # processing and events to indicate all the things we would consider as
@@ -86,6 +82,10 @@ else
     echo "Note: using hashes from $PWD/force-hashes, here is the list:"
     cat force-hashes
   fi
+fi
+
+if [ -z "$HASHES" ]; then
+  echo "$CHECK_NAME" >> ../nothing-to-do
 fi
 
 for PR_ID in $HASHES; do

--- a/list-branch-pr
+++ b/list-branch-pr
@@ -110,6 +110,7 @@ def process_pull(pull, cgh, args):
         print("Processing: %s" % pn, file=sys.stderr)
         try:
             item = _do_process_pull(pull, cgh, args)
+            print(item, file=sys.stderr)
             print("Processing: %s. Done." % pn, file=sys.stderr)
         except RuntimeError as e:
             print(e, file=sys.stderr)
@@ -305,25 +306,23 @@ def send(script, pulls):
 if __name__ == "__main__":
     args = parseArgs()
 
-    cache = PickledCache(".cached_github_client_cache")
+    cache = PickledCache("../.cached_github_client_cache")
     with GithubCachedClient(token=github_token(), cache=cache) as cgh:
         start = now()
         # runOnce = not args.script
         sendToStdOut = functools.partial(send, args.script)
 
-        while True:
-            pulls = process(cgh, args)
-            grouped = group_pulls(pulls)
+        pulls = process(cgh, args)
+        grouped = group_pulls(pulls)
 
-            if grouped["not_tested"] and not args.tested_only:
-                sendToStdOut(grouped["not_tested"])
-                break
-            elif args.tested_only or args.fallback_to_tested:
-                # return whatever we have (may be empty)
-                if grouped["not_successful"] or grouped["tested"]:
-                    sendToStdOut([random.choice(grouped["not_successful"] + grouped["tested"])])
-                elif grouped["reviewed"]:
-                    sendToStdOut([random.choice(grouped["reviewed"])])
-                break
-            else:
-                break
+        print(pulls, file=sys.stderr)
+        print(grouped, file=sys.stderr)
+
+        if grouped["not_tested"] and not args.tested_only:
+          sendToStdOut(grouped["not_tested"])
+        elif args.tested_only or args.fallback_to_tested:
+          # return whatever we have (may be empty)
+          if grouped["not_successful"] or grouped["tested"]:
+            sendToStdOut([random.choice(grouped["not_successful"] + grouped["tested"])])
+          elif grouped["reviewed"]:
+            sendToStdOut([random.choice(grouped["reviewed"])])


### PR DESCRIPTION
This PR:

- exec's continuous-builder.sh instead of looping, so updates to that script are picked up
- sleeps if there are no PRs to build in any repository, so GitHub API calls aren't used up too quickly
- gets rid of a pointless loop in list-branch-pr
- uses a common GitHub API cache for list-branch-pr