### PR TITLE
Store GitHub cache in $HOME

### DIFF
--- a/list-branch-pr
+++ b/list-branch-pr
@@ -2,6 +2,7 @@
 from __future__ import print_function
 
 import functools
+import os.path
 import random
 import sys
 import time
@@ -306,7 +307,7 @@ def send(script, pulls):
 if __name__ == "__main__":
     args = parseArgs()
 
-    cache = PickledCache("../.cached_github_client_cache")
+    cache = PickledCache(os.path.expanduser("~/.cached_github_client_cache"))
     with GithubCachedClient(token=github_token(), cache=cache) as cgh:
         start = now()
         # runOnce = not args.script

--- a/list-branch-pr
+++ b/list-branch-pr
@@ -2,7 +2,6 @@
 from __future__ import print_function
 
 import functools
-import os.path
 import random
 import sys
 import time
@@ -283,6 +282,10 @@ def parseArgs():
                         default=1,
                         help="Total number of workers")
 
+    parser.add_argument("--github-cache-file",
+                        default=os.path.expanduser("~/.cached_github_client_cache"),
+                        help="Where to cache GitHub API responses (default %(default)s)")
+
     args = parser.parse_args()
 
     args.repo_name = args.branch.split("@")[0]
@@ -307,7 +310,7 @@ def send(script, pulls):
 if __name__ == "__main__":
     args = parseArgs()
 
-    cache = PickledCache(os.path.expanduser("~/.cached_github_client_cache"))
+    cache = PickledCache(args.github_cache_file)
     with GithubCachedClient(token=github_token(), cache=cache) as cgh:
         start = now()
         # runOnce = not args.script

--- a/report-pr-errors
+++ b/report-pr-errors
@@ -8,7 +8,7 @@ try:
 except ImportError:
   from subprocess import getstatusoutput
 from glob import glob
-from os.path import dirname, join
+from os.path import dirname, join, expanduser
 import re
 import os
 import sys
@@ -79,6 +79,9 @@ def parse_args():
                         dest="logsUrl",
                         default="https://ali-ci.cern.ch/repo/logs",
                         help="Destination path for logs")
+
+    parser.add_argument("--github-cache-file", default=expanduser("~/.cached-commits"),
+                        help="Where to cache GitHub API responses (default %(default)s)")
 
     parser.add_argument("--debug", "-d",
                         action="store_true",
@@ -321,7 +324,7 @@ def main():
     if not args.message:
         logs.parse()
 
-    cache = PickledCache('.cached-commits')
+    cache = PickledCache(args.github_cache_file)
     with GithubCachedClient(token=github_token(), cache=cache) as cgh:
         # If the branch is not a PR, we should look for open issues
         # for the branch. This should really folded as a special case


### PR DESCRIPTION
This shares the cache between difference repositories in the unified CI builder (saving API requests), but doesn't rely on a specific directory structure (and therefore supports local testing more easily).