### PR TITLE
Only upgrade ali-bot and alidist if needed

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -85,8 +85,8 @@ else
         fi
       done
 
-      pip2 install --upgrade --ignore-installed "git+https://github.com/$INSTALL_ALIBOT"
-      pip2 install --upgrade --ignore-installed "git+https://github.com/$INSTALL_ALIBUILD"
+      pip2 install --upgrade --upgrade-strategy only-if-needed "git+https://github.com/$INSTALL_ALIBOT"
+      pip2 install --upgrade --upgrade-strategy only-if-needed "git+https://github.com/$INSTALL_ALIBUILD"
 
       # Run the build
       . build-loop.sh


### PR DESCRIPTION
This avoids pointless reinstalls and fixes an issue with pip trying to install incompatible versions of PyGithub.