### PR TITLE
Show timezone in pending build status

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -250,7 +250,7 @@ def handle_branch(cgh, pr, logs, args):
         ns = Namespace(commit=args.pr,
                        status=args.status + "/pending",
                        message=' '.join(("Building on", platform.node() or "unknown machine",
-                                         "since", datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))),
+                                         "since", datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC"))),
                        url="")
     else:
         ns = Namespace(commit=args.pr,
@@ -288,7 +288,7 @@ def handle_pr_id(cgh, pr, logs, args):
         ns = Namespace(commit=args.pr,
                        status=args.status + "/pending",
                        message=' '.join(("Building on", platform.node() or "unknown machine",
-                                         "since", datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))),
+                                         "since", datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC"))),
                        url="")
     setGithubStatus(cgh, ns)
 


### PR DESCRIPTION
The docker containers are set to UTC anyway, and converting times to Europe/Zurich would probably require the pytz library, which is more faff.