### PR TITLE
Extract error messages into separate HTML file

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -121,13 +121,15 @@ class Logs(object):
         self.full_log_latest = self.constructFullLogName(args.pr, latest=True)
         self.pretty_log = self.constructFullLogName(args.pr, pretty=True)
         self.dest = args.logsDest
-        self.url = join(args.logsUrl, self.constructFullLogName(args.pr, pretty=True))
+        self.url = join(args.logsUrl, self.pretty_log)
+        self.log_url = join(args.logsUrl, self.full_log)
+        self.build_successful = args.success
 
     def parse(self):
         self.find()
         self.grep()
-        self.generate_pretty_log()
         self.cat(self.full_log)
+        self.generate_pretty_log()
         if self.is_branch:
             self.cat(self.full_log_latest, no_delete=True)
         if self.dest.startswith("rsync:"):
@@ -161,23 +163,43 @@ class Logs(object):
     def grep(self):
         """Grep for errors in the build logs, or, if none are found,
         return the last N lines where N is the limit argument.
+
+        Also extract messages from failed unit tests and o2checkcode.
         """
-        error_log = ""
+        error_log_lines = []
         for log in self.logs:
-            cmd = "grep -he ': error:' -A 3 -B 3 -- %s " % log
-            cmd += "|| tail -n %s %s" % (self.limit, log)
-            err, out = getstatusoutput(cmd)
+            err, out = getstatusoutput("grep -he ': error:' -A 3 -B 3 -- %s "
+                                       "|| tail -n %s %s" % (log, self.limit, log))
             if err:
-                print("Error while parsing logs", file=sys.stderr)
-                print(out, file=sys.stderr)
+                print("Error while parsing logs", out, sep="\n", file=sys.stderr)
                 continue
+            error_log_lines.append(log)
+            error_log_lines.extend(out.split("\n"))
+        self.error_log = "\n".join(error_log_lines[:self.limit]).strip(" \n\t")
 
-            error_log += log + "\n"
-            error_log += out
+        o2checkcode_blocks = []
+        for log in self.logs:
+            err, out = getstatusoutput("sed -n '/^========== List of errors found ==========$/,$p' %s" % log)
+            if err:
+                print("Error while looking for o2checkcode output", out, sep="\n", file=sys.stderr)
+                continue
+            if out and not out.isspace():
+                o2checkcode_blocks.append(log + "\n" + out)
+        if o2checkcode_blocks:
+            self.o2checkcode_messages = "\n\n\n".join(o2checkcode_blocks).strip(" \n\t")
+        else:
+            self.o2checkcode_messages = "(No errors found)"
 
-        error_log = "\n".join(error_log.split("\n")[0:self.limit])
-        error_log.strip(" \n\t")
-        self.error_log = error_log
+        unittest_lines = []
+        for log in self.logs:
+            err, out = getstatusoutput("grep -he 'Test *#[0-9]*: .*\\*\\*\\*Failed' -e '% tests passed' -- " + log)
+            if err:
+                continue
+            unittest_lines.append(log + "\n" + out)
+        if unittest_lines:
+            self.failed_unit_tests = "\n\n\n".join(unittest_lines).strip(" \n\t")
+        else:
+            self.failed_unit_tests = "(No reports found)"
 
     def generate_pretty_log(self):
         '''Extract error messages from logs.
@@ -185,15 +207,50 @@ class Logs(object):
         The errors are presented on a user-friendly HTML page, to be uploaded
         alongside the full message log.
         '''
-        escaped_error_log = self.error_log.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+        def htmlescape(string):
+            return string.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
         with open(join('copy-logs', self.pretty_log), 'w') as f:
             print('''\
             <!DOCTYPE html>
-            <body>
-            <p>The following error messages were extracted from the <a href="%s">full build log</a>:</p>
-            <p><pre><code>%s</code></pre></p>
+            <head>
+              <title>Build results</title>
+              <style>
+               body { border-width: 0.5rem; border-style: solid; margin: 0; padding: 1rem; min-height: 100vh; box-sizing: border-box; }
+               pre { overflow-x: auto; }
+               .succeeded { border-color: #1b5e20; }
+               .succeeded h1 { color: #1b5e20; }
+               .failed { border-color: #b71c1c; }
+               .failed h1 { color: #b71c1c; }
+              </style>
+            </head>
+            <body class="%(status)s">
+              <h1>The build %(status)s</h1>
+              <p>The code that finds and extracts error messages may have missed some.</p>
+              <p>Check the <a href="%(log_url)s">full build log</a> if you suspect the build failed for reasons not listed below.</p>
+              <h3>Table of contents</h3>
+              <p><ol>
+                <li><a href="#o2checkcode"><code>o2checkcode</code> results</a></li>
+                <li><a href="#tests">Unit test results</a></li>
+                <li><a href="#errors">Error messages</a></li>
+              </ol></p>
+              <h2 id="o2checkcode"><code>o2checkcode</code> results</h2>
+              <p><pre><code>%(o2checkcode)s</code></pre></p>
+              <h2 id="tests">Unit test results</h2>
+              <p><pre><code>%(unittests)s</code></pre></p>
+              <h2 id="errors">Error messages</h2>
+              <p>Note that the following list may include false positives! Check the sections above first.</p>
+              <p>If no errors were found by this tool, the last %(limit)d lines of the log follow.</p>
+              <p><pre><code>%(errors)s</code></pre></p>
             </body>
-            ''' % (self.full_log, escaped_error_log), file=f)
+            ''' % {
+                'status': 'succeeded' if self.build_successful else 'failed',
+                'log_url': self.log_url,
+                'o2checkcode': htmlescape(self.o2checkcode_messages),
+                'unittests': htmlescape(self.failed_unit_tests),
+                'errors': htmlescape(self.error_log),
+                'limit': self.limit,
+            }, file=f)
 
     def cat(self, tgtFile, no_delete=False):
         run_cmd("%s && mkdir -p `dirname copy-logs/%s`" % ("true" if no_delete else "rm -rf copy-logs", tgtFile),

--- a/report-pr-errors
+++ b/report-pr-errors
@@ -119,14 +119,17 @@ class Logs(object):
         self.full_log = self.constructFullLogName(args.pr)
         self.is_branch = is_branch
         self.full_log_latest = self.constructFullLogName(args.pr, latest=True)
+        self.pretty_log = self.constructFullLogName(args.pr, pretty=True)
         self.dest = args.logsDest
-        self.url = join(args.logsUrl, self.full_log)
+        self.url = join(args.logsUrl, self.constructFullLogName(args.pr, pretty=True))
 
     def parse(self):
         self.find()
         self.grep()
+        self.generate_pretty_log()
         self.cat(self.full_log)
-        if self.is_branch: self.cat(self.full_log_latest, no_delete=True)
+        if self.is_branch:
+            self.cat(self.full_log_latest, no_delete=True)
         if self.dest.startswith("rsync:"):
             self.rsync(self.dest)
         elif self.dest.startswith("s3"):
@@ -134,10 +137,11 @@ class Logs(object):
         else:
             print("Unknown destination url %s" % self.dest)
 
-    def constructFullLogName(self, pr, latest=False):
+    def constructFullLogName(self, pr, latest=False, pretty=False):
         # file to which we cat all the individual logs
         pr = parse_pr(pr)
-        return join(pr.repo_name, pr.id, "latest" if latest else pr.commit, self.norm_status, "fullLog.txt")
+        return join(pr.repo_name, pr.id, "latest" if latest else pr.commit, self.norm_status,
+                    "pretty.html" if pretty else "fullLog.txt")
 
     def find(self):
         # Python's glob * matches at least one char
@@ -174,6 +178,22 @@ class Logs(object):
         error_log = "\n".join(error_log.split("\n")[0:self.limit])
         error_log.strip(" \n\t")
         self.error_log = error_log
+
+    def generate_pretty_log(self):
+        '''Extract error messages from logs.
+
+        The errors are presented on a user-friendly HTML page, to be uploaded
+        alongside the full message log.
+        '''
+        escaped_error_log = self.error_log.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+        with open(join('copy-logs', self.pretty_log), 'w') as f:
+            print('''\
+            <!DOCTYPE html>
+            <body>
+            <p>The following error messages were extracted from the <a href="%s">full build log</a>:</p>
+            <p><pre><code>%s</code></pre></p>
+            </body>
+            ''' % (self.full_log, escaped_error_log), file=f)
 
     def cat(self, tgtFile, no_delete=False):
         run_cmd("%s && mkdir -p `dirname copy-logs/%s`" % ("true" if no_delete else "rm -rf copy-logs", tgtFile),
@@ -217,8 +237,9 @@ class Logs(object):
         for src in matches:
             try:
                 dst = re.compile('^copy-logs/').sub('', src)
-                transfer.upload_file(src, bucket_name, dst, extra_args={'ContentType': 'text/plain',
-                                                                        'ContentDisposition': 'inline'})
+                transfer.upload_file(src, bucket_name, dst, extra_args={
+                    'ContentType': 'text/html' if src.endswith('.html') else 'text/plain',
+                    'ContentDisposition': 'inline'})
             except Exception as e:
                 print("Failed to upload %s to %s in bucket %s.%s" % (src, dst, bucket_name, server))
 

--- a/report-pr-errors
+++ b/report-pr-errors
@@ -4,9 +4,9 @@ from __future__ import print_function
 from argparse import ArgumentParser, Namespace
 import atexit
 try:
-  from commands import getstatusoutput
+    from commands import getstatusoutput
 except ImportError:
-  from subprocess import getstatusoutput
+    from subprocess import getstatusoutput
 from glob import glob
 from os.path import dirname, join, expanduser
 import re
@@ -103,6 +103,13 @@ def parse_args():
     return args
 
 
+def run_cmd(command, output_only_if_error=False):
+    print(command, file=sys.stderr)
+    err, out = getstatusoutput(command)
+    if not output_only_if_error or err:
+        print(out, file=sys.stderr)
+
+
 class Logs(object):
     def __init__(self, args, is_branch):
         self.work_dir = args.workDir
@@ -153,7 +160,7 @@ class Logs(object):
         """
         error_log = ""
         for log in self.logs:
-            cmd = "cat %s | grep -e ': error:' -A 3 -B 3 " % log
+            cmd = "grep -he ': error:' -A 3 -B 3 -- %s " % log
             cmd += "|| tail -n %s %s" % (self.limit, log)
             err, out = getstatusoutput(cmd)
             if err:
@@ -169,46 +176,23 @@ class Logs(object):
         self.error_log = error_log
 
     def cat(self, tgtFile, no_delete=False):
-        cmd = "%s && mkdir -p `dirname copy-logs/%s`" % ("true" if no_delete else "rm -rf copy-logs", tgtFile)
-        err, out = getstatusoutput(cmd)
-        if err:
-            print(out, file=sys.stderr)
+        run_cmd("%s && mkdir -p `dirname copy-logs/%s`" % ("true" if no_delete else "rm -rf copy-logs", tgtFile),
+                output_only_if_error=True)
 
-        cmd = "echo 'Builing on: '`hostname` at `date +%%Y-%%m-%%d-%%H:%%M:%%S` >> copy-logs/%s" % tgtFile
-        print(cmd, file=sys.stderr)
-        err, out = getstatusoutput(cmd)
-        print(out, file=sys.stderr)
+        run_cmd('echo "Builing on: $(hostname) at $(date +%Y-%m-%d-%H:%M:%S)" >> copy-logs/' + tgtFile)
 
         if len(self.logs):
-          cmd = "echo 'The following files are present in the log:' >> copy-logs/%s" % tgtFile
-          print(cmd, file=sys.stderr)
-          err, out = getstatusoutput(cmd)
-          print(out, file=sys.stderr)
+            run_cmd("echo 'The following files are present in the log:' >> copy-logs/%s" % tgtFile)
         else:
-          cmd = "echo 'No logs found. Please check actual builders log in aurora.\nSee http://alisw.github.io/infrastructure-pr-testing for more instructions.' >> copy-logs/%s" % tgtFile
-          print(cmd, file=sys.stderr)
-          err, out = getstatusoutput(cmd)
-          print(out, file=sys.stderr)
+            run_cmd("echo 'No logs found. Please check actual builders log in aurora.\n"
+                    "See http://alisw.github.io/infrastructure-pr-testing for more instructions.' >> copy-logs/%s" % tgtFile)
 
         for log in self.logs:
-            cmd = "echo '- %s' >> copy-logs/%s" % (log, tgtFile)
-            print(cmd, file=sys.stderr)
-            err, out = getstatusoutput(cmd)
-            print(out, file=sys.stderr)
+            run_cmd("echo '- %s' >> copy-logs/%s" % (log, tgtFile))
 
         for log in self.logs:
-            cmd = "echo '## Begin %s' >> copy-logs/%s" % (log, tgtFile)
-            print(cmd, file=sys.stderr)
-            err, out = getstatusoutput(cmd)
-            print(out, file=sys.stderr)
-            cmd = "cat %s >> copy-logs/%s" % (log, tgtFile)
-            print(cmd, file=sys.stderr)
-            err, out = getstatusoutput(cmd)
-            print(out, file=sys.stderr)
-            cmd = "echo '## End %s' >> copy-logs/%s" % (log, tgtFile)
-            print(cmd, file=sys.stderr)
-            err, out = getstatusoutput(cmd)
-            print(out, file=sys.stderr)
+            run_cmd(("{ echo '## Begin %(log)s'; cat %(log)s; echo '## End %(log)s'; }"
+                     " >> copy-logs/%(tgtFile)s") % {'log': log, 'tgtFile': tgtFile})
 
     def rsync(self, dest):
         err, out = getstatusoutput("cd copy-logs && rsync -av ./ %s" % dest)


### PR DESCRIPTION
This extracts the important messages out of the large log files, so users can find the more easily. The HTML file is uploaded to S3 alongside the full log file, and links to the latter so both are accessible. The GitHub status will link to the HTML file directly.

Untested so far; I'll work out how to do that sensibly tomorrow.