### PR TITLE
Don't print file names of logs where no messages are found.

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -184,7 +184,8 @@ class Logs(object):
                 if err:
                     print("Error while parsing logs", out, sep="\n", file=sys.stderr)
                     continue
-                blocks.append(log + "\n" + out)
+                if out:
+                    blocks.append(log + "\n" + out)
             if blocks:
                 return "\n\n\n".join(blocks).strip(" \n\t")
             return "(No messages found)"


### PR DESCRIPTION
`grep` exits with an error if nothing is found, so this doesn't apply to those commands, but `sed` needs this extra check.