### PR TITLE
Fix environment variable scoping

### DIFF
--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -70,7 +70,6 @@ function get_config () {
   JOBS=$(get_config_value jobs "$JOBS")
   TIMEOUT=$(get_config_value timeout "${TIMEOUT:-600}")
   LONG_TIMEOUT=$(get_config_value long-timeout "${LONG_TIMEOUT:-36000}")
-  RECHECK_PRS=$(get_config_value recheck-prs "$RECHECK_PRS")
   # If the files have been deleted in the meantime, this will set the variables
   # to the empty string.
   SILENT=$(get_config_value silent)

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -82,6 +82,6 @@ else
 fi
 
 # Get updates to ali-bot
-reset_git_repository ali-bot
+TIMEOUT=$(get_config_value timeout "${TIMEOUT:-600}") reset_git_repository ali-bot
 
 exec continuous-builder.sh


### PR DESCRIPTION
- `RECHECK_PRS` is not needed any more
- `reset_git_repository` needs `TIMEOUT` but it was only set in the build subshell