### PR TITLE
Speed up repo-s3-upload

### DIFF
--- a/repo-s3-mirror
+++ b/repo-s3-mirror
@@ -1,9 +1,10 @@
-#!/bin/sh -x
-# Script to create a mirror of alibuild repository in an S3 bucket.
+#!/bin/sh
 
 help () {
   cat <<EOF
 usage: repo-s3-mirror [-h] [-b BUCKET] [-p PREFIX] [-r REPO]
+
+Script to create a mirror of alibuild repository in an S3 bucket.
 
   -b BUCKET, --bucket BUCKET   the S3 bucket to upload packages to
   -p PREFIX, --prefix PREFIX   the local path where the repository is stored
@@ -39,12 +40,17 @@ rclone_sync () {
 # support real symlinks, make them regular files containing the path they point
 # to instead.
 symlink_tree=/tmp/repo-symlinks
-find $prefix/$repo -type l | while read -r sym; do
-  lpath=$symlink_tree/${sym#$prefix/$repo/}
-  mkdir -p "$(dirname "$lpath")"
-  readlink "$sym" > "$lpath"
+printf 'Replicating symlinks to %s' "$symlink_tree" >&2
+find "$prefix/$repo" -type l -printf '%P\t%l\n' | while IFS='	' read -r symlink target; do
+  mkdir -p "$(dirname "$symlink_tree/$symlink")"
+  printf %s "$target" > "$symlink_tree/$symlink"
+  printf . >&2
 done
+printf ' done.\n' >&2
 rclone_sync "local:$symlink_tree/" "rpms3:$bucket/$repo/"
+rm -rf "$symlink_tree" &
 
 # Sync tarballs from the repo to S3.
 rclone_sync "local:$prefix/$repo/store/" "rpms3:$bucket/$repo/store/"
+
+wait  # for rm

--- a/repo-s3-mirror
+++ b/repo-s3-mirror
@@ -31,9 +31,9 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-rclone_sync () {
+rclone_defaults () {
   # Simple wrapper for rclone, specifying common default options.
-  rclone sync --config /secrets/alibuild_rclone_config --transfers=10 --progress --delete-before "$@"
+  rclone --config /secrets/alibuild_rclone_config --transfers=10 --progress --delete-before "$@"
 }
 
 # Create a separate filesystem tree, with symlinks only. However, as S3 doesn't
@@ -41,16 +41,23 @@ rclone_sync () {
 # to instead.
 symlink_tree=/tmp/repo-symlinks
 printf 'Replicating symlinks to %s' "$symlink_tree" >&2
-find "$prefix/$repo" -type l -printf '%P\t%l\n' | while IFS='	' read -r symlink target; do
-  mkdir -p "$(dirname "$symlink_tree/$symlink")"
-  printf %s "$target" > "$symlink_tree/$symlink"
-  printf . >&2
-done
+{
+  # We only copy symlinks in directories that have changed since the last run to
+  # save on disk accesses.
+  find "$prefix/$repo" -path "$prefix/$repo/store" -prune -o \
+       -type d -newer "$symlink_tree" -prune -print0 ||
+    # If this is the first run on this machine, recreate the entire hierarchy.
+    # (In that case, $symlink_tree won't exist yet, so find will error.)
+    printf '%s\0' "$prefix/$repo"
+} |
+  xargs -0rI {} find {} -path "$prefix/$repo/store" -prune -o -type l -printf '%P\t%l\n' |
+  while IFS='	' read -r symlink target; do
+    mkdir -p "$(dirname "$symlink_tree/$symlink")"
+    printf %s "$target" > "$symlink_tree/$symlink"
+    printf . >&2
+  done
 printf ' done.\n' >&2
-rclone_sync "local:$symlink_tree/" "rpms3:$bucket/$repo/"
-rm -rf "$symlink_tree" &
+rclone_defaults move --delete-empty-src-dirs "local:$symlink_tree/" "rpms3:$bucket/$repo/"
 
 # Sync tarballs from the repo to S3.
-rclone_sync "local:$prefix/$repo/store/" "rpms3:$bucket/$repo/store/"
-
-wait  # for rm
+rclone_defaults sync "local:$prefix/$repo/store/" "rpms3:$bucket/$repo/store/"


### PR DESCRIPTION
This makes find read the link target directly, which is hopefully faster than using readlink. The script is now designed to be run without `set -x` (which gives far too much output).