### PR TITLE
Make testing different ali-bot and alibuild versions easier

### DIFF
--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -44,6 +44,23 @@ function clean_env () {
   GITLAB_USER='' GITLAB_PASS='' GITHUB_TOKEN='' INFLUXDB_WRITE_URL='' CODECOV_TOKEN='' AWS_ACCESS_KEY_ID='' AWS_SECRET_ACCESS_KEY='' "$@"
 }
 
+function pipinst () {
+  # Use pip2 --user if required.
+  local pip_user=
+  if [ -z "$VIRTUAL_ENV" ] && [ "$(whoami)" != root ]; then
+    # Use repo-specific PYTHONUSERBASEs if we're installing for this user.
+    pip_user=--user
+    export PYTHONUSERBASE=$PWD/python_local
+    export PATH=$PYTHONUSERBASE/bin${PATH+:$PATH}
+    export LD_LIBRARY_PATH=$PYTHONUSERBASE/lib${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}
+    mkdir -p "$PYTHONUSERBASE"
+  fi
+
+  # Sometimes pip gets stuck when cloning the ali-bot or alibuild repos. In
+  # that case: time out, skip and try again later.
+  short_timeout pip2 install $pip_user --upgrade --upgrade-strategy only-if-needed "git+https://github.com/$1"
+}
+
 # Allow overriding a number of variables by fly, so that we can change the
 # behavior of the job without restarting it.
 # This comes handy when scaling up / down a job, so that we do not quit the

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -99,22 +99,10 @@ if [ -n "$HASHES" ]; then
     mkdir -p "$env_name"
     cd "$env_name" || exit 10
 
-    # Use pip2 --user if required.
-    if [ -n "$VIRTUAL_ENV" ] || [ "$(whoami)" = root ]; then
-      pip_user=
-    else
-      # Use repo-specific PYTHONUSERBASEs if we're installing for this user.
-      pip_user=--user
-      export PYTHONUSERBASE=$PWD/python_local
-      export PATH=$PYTHONUSERBASE/bin${PATH+:$PATH}
-      export LD_LIBRARY_PATH=$PYTHONUSERBASE/lib${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}
-      mkdir -p "$PYTHONUSERBASE"
-    fi
-
-    # Sometimes pip gets stuck when cloning the ali-bot or alibuild repos. In
-    # that case: time out, skip and try again later.
-    short_timeout pip2 install $pip_user --upgrade --upgrade-strategy only-if-needed "git+https://github.com/$INSTALL_ALIBOT"   || exit
-    short_timeout pip2 install $pip_user --upgrade --upgrade-strategy only-if-needed "git+https://github.com/$INSTALL_ALIBUILD" || exit
+    # Allow overriding the ali-bot/alibuild version to install -- this is useful
+    # for testing changes to those with a few workers before deploying widely.
+    pipinst "$(get_config_value install-alibot   "$INSTALL_ALIBOT")"   || exit 1
+    pipinst "$(get_config_value install-alibuild "$INSTALL_ALIBUILD")" || exit 1
 
     # Run the build
     . build-loop.sh


### PR DESCRIPTION
With this patch, the ali-bot and alibuild versions to install can be controlled on a per-worker basis. This makes it easier to test patches to those on a single worker before deploying.