### PR TITLE
Don't hardcode pip version

### DIFF
--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -58,7 +58,7 @@ function pipinst () {
 
   # Sometimes pip gets stuck when cloning the ali-bot or alibuild repos. In
   # that case: time out, skip and try again later.
-  short_timeout pip2 install $pip_user --upgrade --upgrade-strategy only-if-needed "git+https://github.com/$1"
+  short_timeout pip install $pip_user --upgrade --upgrade-strategy only-if-needed "git+https://github.com/$1"
 }
 
 # Allow overriding a number of variables by fly, so that we can change the


### PR DESCRIPTION
According to <https://alisw.github.io/infrastructure-macos>, we use `pip3` on MacOS. The `pip` binary does the right thing on Linux and MacOS in this case, selecting the right version.