### PR TITLE
Fix queue messages for CI workers

### DIFF
--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -30,15 +30,14 @@ host_id=$(echo "$MESOS_EXECUTOR_ID" |
 : "${host_id:=$(hostname --fqdn)}"
 
 # Update all PRs in the queue with their number before we start building.
-echo "$HASHES" | tail -n "+$((BUILD_SEQ + 1))" | cat -n | while read -r ahead btype num hash envf; do
+echo "$HASHES" | tail -n "+$((BUILD_SEQ + 1))" | cat -n | while read -r ahead btype PR_NUMBER PR_HASH envf; do
   # Only report progress for a PR if it's never been built before.
   if [ "$btype" = untested ]; then
     # Run this in a subshell as report_pr_errors uses $PR_REPO but we don't want
     # to overwrite the outer for loop's variables, as they are needed for the
     # subsequent build.
-    pr_repo=$(cd .. && source_env_files "$envf" && echo "$PR_REPO") &&
-      # The --pr here will override the one specified in report_pr_errors.
-      report_pr_errors --pr "$pr_repo#$num@$hash" --pending -m "Build queued ($ahead ahead) on $host_id"
+    source_env_files "$envf"
+    report_pr_errors --pending -m "Build queued ($ahead ahead) on $host_id"
   fi
 done
 


### PR DESCRIPTION
Just give up and source the .env file to get all the variables right.