### PR TITLE
Don't duplicate errors from o2checkcode

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -176,9 +176,13 @@ class Logs(object):
             error_log_lines.extend(out.split("\n"))
         self.error_log = "\n".join(error_log_lines[:self.limit]).strip(" \n\t")
 
-        def chunk_command_output_by_log(command):
+        def chunk_command_output_by_log(command, ignore_log_files=()):
+            ignore_log_files = [join(self.work_dir, 'BUILD', log, 'log')
+                                for log in ignore_log_files]
             blocks = []
             for log in self.logs:
+                if log in ignore_log_files:
+                    continue
                 err, out = getstatusoutput(command % log)
                 if err:
                     print("Error while parsing logs", out, sep="\n", file=sys.stderr)
@@ -188,7 +192,11 @@ class Logs(object):
             return "\n\n\n".join(blocks).strip(" \n\t")
 
         self.errors_only_log = chunk_command_output_by_log(
-            "grep -he ': error:' -e ': warning:' -A 3 -B 3 -- %s")
+            "grep -he ': error:' -e ': warning:' -A 3 -B 3 -- %s",
+            # Errors from this log are reported in o2checkcode_messages
+            # already, so don't report them twice. This log also contains false
+            # positives, so o2checkcode_messages is better.
+            ignore_log_files=['o2checkcode-latest'])
         self.o2checkcode_messages = chunk_command_output_by_log(
             "sed -n '/=== List of errors found ===/,$p' %s")
         self.failed_unit_tests = chunk_command_output_by_log(


### PR DESCRIPTION
Remove the o2checkcode log from the general "errors and warnings" output, as it contains false positives and the important errors are already reproduced in the o2checkcode section.