### PR TITLE
Remove old workarounds

### DIFF
--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -45,20 +45,9 @@ function clean_env () {
 }
 
 function pipinst () {
-  # Use pip2 --user if required.
-  local pip_user=
-  if [ -z "$VIRTUAL_ENV" ] && [ "$(whoami)" != root ]; then
-    # Use repo-specific PYTHONUSERBASEs if we're installing for this user.
-    pip_user=--user
-    export PYTHONUSERBASE=$PWD/python_local
-    export PATH=$PYTHONUSERBASE/bin${PATH+:$PATH}
-    export LD_LIBRARY_PATH=$PYTHONUSERBASE/lib${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}
-    mkdir -p "$PYTHONUSERBASE"
-  fi
-
   # Sometimes pip gets stuck when cloning the ali-bot or alibuild repos. In
   # that case: time out, skip and try again later.
-  short_timeout pip install $pip_user --upgrade --upgrade-strategy only-if-needed "git+https://github.com/$1"
+  short_timeout pip install --upgrade --upgrade-strategy only-if-needed "git+https://github.com/$1"
 }
 
 # Allow overriding a number of variables by fly, so that we can change the

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -159,7 +159,7 @@ FETCH_REPOS="$(aliBuild build --help | grep fetch-repos || true)"
 
 if ALIBUILD_HEAD_HASH=$PR_HASH ALIBUILD_BASE_HASH=$base_hash             \
                      clean_env long_timeout aliBuild                     \
-                     -j "${JOBS:-$JOBS_DEFAULT}" -z "$BUILD_IDENTIFIER"  \
+                     -j "${JOBS:-$(nproc)}" -z "$BUILD_IDENTIFIER"       \
                      ${FETCH_REPOS:+--fetch-repos}                       \
                      ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS} \
                      ${MIRROR:+--reference-sources $MIRROR}              \

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -32,16 +32,11 @@ if [ "$1" != --skip-setup ]; then
   touch ~/.config/alibuild/disable-analytics
 
   # Set up common global environment
-  # Get the number of processors on this system, in case JOBS= isn't given.
-  JOBS_DEFAULT=$(nproc 2>/dev/null ||
-                   sysctl -n hw.ncpu 2>/dev/null ||
-                   grep -c bogomips /proc/cpuinfo 2>/dev/null ||
-                   echo 4)
   # Mesos DNSes
   : "${MESOS_DNS:=alimesos01.cern.ch,alimesos02.cern.ch,alimesos03.cern.ch}"
+  export MESOS_DNS
   # Explicitly set UTF-8 support (Python needs it!)
   export {LANG{,UAGE},LC_{CTYPE,NUMERIC,TIME,COLLATE,MONETARY,PAPER,MESSAGES,NAME,ADDRESS,TELEPHONE,MEASUREMENT,IDENTIFICATION,ALL}}=en_US.UTF-8
-  export JOBS_DEFAULT MESOS_DNS
 
   # GitLab credentials for private ALICE repositories
   printf 'protocol=https\nhost=gitlab.cern.ch\nusername=%s\npassword=%s\n' "$GITLAB_USER" "$GITLAB_PASS" |


### PR DESCRIPTION
These are left-over workarounds from the MacOS builder that don't apply any more.