### PR TITLE
Remove obsolete workarounds in CI builder

### DIFF
--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -119,6 +119,10 @@ function source_env_files () {
   done
 }
 
+function is_numeric () {
+    [ $(($1 + 0)) = "$1" ]
+}
+
 # timeout vs. gtimeout (macOS with Homebrew)
 timeout_exec=timeout
 type $timeout_exec > /dev/null 2>&1 || timeout_exec=gtimeout

--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -120,7 +120,19 @@ function source_env_files () {
 }
 
 function is_numeric () {
-    [ $(($1 + 0)) = "$1" ]
+  [ $(($1 + 0)) = "$1" ]
+}
+
+function ensure_vars () {
+  # Make sure variables are defined, and export them.
+  for var in "$@"; do
+    if [ -z "${!var}" ]; then
+      echo "$(basename "$0"): error: required variable $var not defined!" >&2
+      exit 1
+    else
+      export "${var?}"
+    fi
+  done
 }
 
 # timeout vs. gtimeout (macOS with Homebrew)

--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -26,11 +26,10 @@ function report_state () {
         # If INFLUXDB_WRITE_URL starts with insecure_https://, then strip
         # "insecure_" and send the --insecure/-k option to curl.
         insecure_*)
-          curl --max-time 20 -XPOST "${INFLUXDB_WRITE_URL#insecure_}" -k --data-binary @-;;
+          curl --max-time 20 -XPOST "${INFLUXDB_WRITE_URL#insecure_}" -k --data-binary @- || true;;
         *)
-          curl --max-time 20 -XPOST "$INFLUXDB_WRITE_URL" --data-binary @-;;
-      esac ||
-      true
+          curl --max-time 20 -XPOST "$INFLUXDB_WRITE_URL" --data-binary @- || true;;
+      esac
   fi
 
   # Push to Google Analytics if configured

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -60,10 +60,6 @@ ALIBOT_ANALYTICS_ARCHITECTURE=${CUR_CONTAINER}_$(uname -m)
 export ALIBOT_ANALYTICS_USER_UUID ALIBOT_ANALYTICS_ARCHITECTURE
 export ALIBOT_ANALYTICS_APP_NAME=continuous-builder.sh
 
-# These variables are used by the report_state function
-TIME_STARTED=$(date -u +%s)
-CI_HASH=$(cd "$(dirname "$0")" && git rev-parse HEAD)
-
 # Get dependency development packages
 if [ -n "$DEVEL_PKGS" ]; then
   echo "$DEVEL_PKGS" | while read -r gh_url branch checkout_name; do
@@ -82,9 +78,6 @@ find separate_logs/ -type d -empty -delete || true
 
 # Run preliminary cleanup command
 aliBuild clean ${DEBUG:+--debug}
-
-LAST_PR=$PR_NUMBER
-LAST_PR_OK=
 
 # We are looping over several build hashes here. We will have one log per build.
 mkdir -p "separate_logs/$(date -u +%Y%m%d-%H%M%S)-$PR_NUMBER-$PR_HASH"
@@ -173,13 +166,13 @@ then
     short_timeout set-github-status ${SILENT:+-n} -c "$PR_REPO@$PR_HASH" -s "$CHECK_NAME/success"
   fi ||
     short_timeout report-analytics exception --desc 'report-pr-errors fail on build success'
-  LAST_PR_OK=1
+  PR_OK=1
 else
   # We do not want to kill the system if GitHub is not working
   # so we ignore the result code for now
   report_pr_errors ${DONT_USE_COMMENTS:+--no-comments} ||
     short_timeout report-analytics exception --desc 'report-pr-errors fail on build error'
-  LAST_PR_OK=0
+  PR_OK=0
 fi
 
 # Run post-build cleanup command

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -155,17 +155,13 @@ if [ $((PR_NUMBER + 0)) = "$PR_NUMBER" ]; then
   REMOTE_STORE=$BRANCH_REMOTE_STORE
 fi
 
-FETCH_REPOS="$(aliBuild build --help | grep fetch-repos || true)"
-
 if ALIBUILD_HEAD_HASH=$PR_HASH ALIBUILD_BASE_HASH=$base_hash             \
                      clean_env long_timeout aliBuild                     \
                      -j "${JOBS:-$(nproc)}" -z "$BUILD_IDENTIFIER"       \
-                     ${FETCH_REPOS:+--fetch-repos}                       \
                      ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS} \
                      ${MIRROR:+--reference-sources $MIRROR}              \
                      ${REMOTE_STORE:+--remote-store $REMOTE_STORE}       \
-                     ${DEBUG:+--debug}                                   \
-                     build "$PACKAGE"
+                     --fetch-repos ${DEBUG:+--debug} build "$PACKAGE"
 then
   # We do not want to kill the system is github is not working
   # so we ignore the result code for now

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -9,15 +9,7 @@
 . build-helpers.sh
 get_config
 
-for var in CI_NAME CHECK_NAME PR_REPO PR_BRANCH PACKAGE ALIBUILD_DEFAULTS; do
-  if [ -z "${!var}" ]; then
-    echo "$(basename "$0"): error: required variable $V not defined!" >&2
-    exit 1
-  else
-    export "${var?}"
-  fi
-done
-
+ensure_vars CI_NAME CHECK_NAME PR_REPO PR_BRANCH PACKAGE ALIBUILD_DEFAULTS
 : "${WORKERS_POOL_SIZE:=1}" "${WORKER_INDEX:=0}" "${PR_REPO_CHECKOUT:=$(basename "$PR_REPO")}"
 [ -d /build/mirror ] && : "${MIRROR:=/build/mirror}"
 

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -15,7 +15,7 @@ ensure_vars CI_NAME CHECK_NAME PR_REPO PR_BRANCH PACKAGE ALIBUILD_DEFAULTS
 
 # This is the check name. If CHECK_NAME is in the environment, use it. Otherwise
 # default to, e.g., build/AliRoot/release (build/<Package>/<Defaults>)
-: "${CHECK_NAME:=build/$PACKAGE${ALIBUILD_DEFAULTS:+/$ALIBUILD_DEFAULTS}}"
+: "${CHECK_NAME:=build/$PACKAGE/$ALIBUILD_DEFAULTS}"
 
 host_id=$(echo "$MESOS_EXECUTOR_ID" |
             sed -ne 's#^\(thermos-\)\?\([a-z]*\)-\([a-z]*\)-\([a-z0-9_-]*\)-\([0-9]*\)\(-[0-9a-f]*\)\{5\}$#\2/\4/\5#p')
@@ -113,7 +113,7 @@ if pushd "$PR_REPO_CHECKOUT"; then
   popd
 fi
 
-if ! clean_env short_timeout aliDoctor ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS} "$PACKAGE"; then
+if ! clean_env short_timeout aliDoctor --defaults "$ALIBUILD_DEFAULTS" "$PACKAGE"; then
   # We do not want to kill the system is github is not working
   # so we ignore the result code for now
   short_timeout set-github-status ${SILENT:+-n} -c "$PR_REPO@$PR_HASH" -s "$CHECK_NAME/error" -m 'aliDoctor error' ||
@@ -146,7 +146,7 @@ fi
 if ALIBUILD_HEAD_HASH=$PR_HASH ALIBUILD_BASE_HASH=$base_hash             \
                      clean_env long_timeout aliBuild                     \
                      -j "${JOBS:-$(nproc)}" -z "$build_identifier"       \
-                     ${ALIBUILD_DEFAULTS:+--defaults $ALIBUILD_DEFAULTS} \
+                     --defaults "$ALIBUILD_DEFAULTS"                     \
                      ${MIRROR:+--reference-sources $MIRROR}              \
                      ${REMOTE_STORE:+--remote-store $REMOTE_STORE}       \
                      --fetch-repos ${DEBUG:+--debug} build "$PACKAGE"

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -6,8 +6,6 @@
 . build-helpers.sh
 
 if [ "$1" != --skip-setup ]; then
-  export HOME
-
   if [ -r ~/.continuous-builder ]; then
     . ~/.continuous-builder
   fi

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -12,14 +12,9 @@ if [ "$1" != --skip-setup ]; then
     . ~/.continuous-builder
   fi
 
-  for var in GITHUB_TOKEN GITLAB_USER GITLAB_PASS AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY INFLUXDB_WRITE_URL ALIBOT_ANALYTICS_ID MONALISA_HOST MONALISA_PORT MESOS_ROLE CONTAINER_IMAGE; do
-    if [ -z "${!var}" ]; then
-      echo "$(basename "$0"): error: required variable $var not defined!" >&2
-      exit 1
-    else
-      export "${var?}"
-    fi
-  done
+  ensure_vars GITHUB_TOKEN GITLAB_USER GITLAB_PASS AWS_ACCESS_KEY_ID \
+              AWS_SECRET_ACCESS_KEY INFLUXDB_WRITE_URL ALIBOT_ANALYTICS_ID \
+              MONALISA_HOST MONALISA_PORT MESOS_ROLE CONTAINER_IMAGE
 
   if ! [ -d ali-bot ]; then
     # This is for *.env files. These should always be taken from ali-bot@master,

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -12,7 +12,8 @@ if [ "$1" != --skip-setup ]; then
 
   ensure_vars GITHUB_TOKEN GITLAB_USER GITLAB_PASS AWS_ACCESS_KEY_ID \
               AWS_SECRET_ACCESS_KEY INFLUXDB_WRITE_URL ALIBOT_ANALYTICS_ID \
-              MONALISA_HOST MONALISA_PORT MESOS_ROLE CONTAINER_IMAGE
+              MONALISA_HOST MONALISA_PORT MESOS_ROLE CONTAINER_IMAGE \
+              WORKER_INDEX WORKERS_POOL_SIZE
 
   if ! [ -d ali-bot ]; then
     # This is for *.env files. These should always be taken from ali-bot@master,

--- a/report-pr-errors
+++ b/report-pr-errors
@@ -145,19 +145,12 @@ class Logs(object):
                     "pretty.html" if pretty else "fullLog.txt")
 
     def find(self):
-        # Python's glob * matches at least one char
-        search_paths = [join(self.work_dir, "BUILD/*latest*/log"),
-                        join(self.work_dir, "BUILD/*latest/log")]
-        print("Searching all logs matching: %s" % ", ".join(search_paths), file=sys.stderr)
-        globbed = []
-        for sp in search_paths:
-            globbed.extend(glob(sp))
-
-        suffix = ("latest" + "-" + self.develPrefix).strip("-")
-        logs = {x for x in globbed if dirname(x).endswith(suffix)}
-
-        print("Found:\n%s" % "\n".join(logs), file=sys.stderr)
-        self.logs = logs
+        search_path = join(self.work_dir, "BUILD/*latest*/log")
+        print("Searching all logs matching: %s" % search_path, file=sys.stderr)
+        suffix = ("latest-" + self.develPrefix).rstrip("-")
+        self.logs = {x for x in glob(search_path)
+                     if dirname(x).endswith(suffix)}
+        print("Found:\n%s" % "\n".join(self.logs), file=sys.stderr)
 
     def grep(self):
         """Grep for errors in the build logs, or, if none are found,
@@ -238,7 +231,7 @@ class Logs(object):
 
         run_cmd('echo "Builing on: $(hostname) at $(date +%Y-%m-%d-%H:%M:%S)" >> copy-logs/' + tgtFile)
 
-        if len(self.logs):
+        if self.logs:
             run_cmd("echo 'The following files are present in the log:' >> copy-logs/%s" % tgtFile)
         else:
             run_cmd("echo 'No logs found. Please check actual builders log in aurora.\n"


### PR DESCRIPTION
Remove unneeded global variables, workarounds for old versions of aliBuild, and make the code a bit more maintainable.