### PR TITLE
Extract errors from CMake

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -178,7 +178,8 @@ class Logs(object):
                     continue
                 err, out = getstatusoutput(command % log)
                 if err:
-                    print("Error while parsing logs", out, sep="\n", file=sys.stderr)
+                    # Most likely caused by grep not finding the search term.
+                    print("error while parsing logs:", out, file=sys.stderr)
                     continue
                 if out:
                     blocks.append(log + "\n" + out)
@@ -196,6 +197,8 @@ class Logs(object):
             r"grep -he 'Test *#[0-9]*: .*\*\*\*Failed' -e '%% tests passed' -- %s")
         self.compiler_killed = chunk_command_output_by_log(
             "grep -he 'fatal error: Killed signal terminated program' -- %s")
+        self.cmake_errors = chunk_command_output_by_log(
+            "sed -En '/^CMake (Error|Warning)/,/^Call Stack/p' %s")
 
     def generate_pretty_log(self):
         '''Extract error messages from logs.
@@ -219,10 +222,13 @@ class Logs(object):
                 'unit_display': display(self.failed_unit_tests),
                 'errors': htmlescape(self.errors_only_log),
                 'err_display': display(self.errors_only_log),
+                'cmake': htmlescape(self.cmake_errors),
+                'cmake_display': display(self.cmake_errors),
                 'killed_display': display(self.compiler_killed),
                 'noerrors_display': display(not any((
                     self.o2checkcode_messages, self.failed_unit_tests,
-                    self.errors_only_log, self.compiler_killed))),
+                    self.errors_only_log, self.compiler_killed,
+                    self.cmake_errors))),
             })
 
     def cat(self, tgtFile, no_delete=False):
@@ -393,6 +399,7 @@ PRETTY_LOG_TEMPLATE = '''\
    #o2checkcode, #o2checkcode-toc { display: %(o2c_display)s; }
    #tests, #tests-toc { display: %(unit_display)s; }
    #errors, #errors-toc { display: %(err_display)s; }
+   #cmake, #cmake-toc { display: %(cmake_display)s; }
   </style>
 </head>
 <body class="%(status)s">
@@ -403,6 +410,7 @@ PRETTY_LOG_TEMPLATE = '''\
   <p><nav><ol>
     <li id="noerrors-toc"><a href="#noerrors">No errors found</a></li>
     <li id="compiler-killed-toc"><a href="#compiler-killed">Error: the compiler process was killed</a></li>
+    <li id="cmake-toc"><a href="#cmake">CMake errors and warnings</a></li>
     <li id="o2checkcode-toc"><a href="#o2checkcode"><code>o2checkcode</code> results</a></li>
     <li id="tests-toc"><a href="#tests">Unit test results</a></li>
     <li id="errors-toc"><a href="#errors">Error messages</a></li>
@@ -410,6 +418,10 @@ PRETTY_LOG_TEMPLATE = '''\
   <section id="noerrors">
     <h2>No errors found</h2>
     <p>Check the <a href="%(log_url)s">full build log</a> to see all compilation messages.</p>
+  </section>
+  <section id="cmake">
+    <h2>CMake errors and warnings</h2>
+    <p><pre><code>%(cmake)s</code></pre></p>
   </section>
   <section id="compiler-killed">
     <h2>Error: the compiler process was killed</h2>


### PR DESCRIPTION
Add a rule to `report-pr-errors` to find CMake errors and warnings and add them to the HTML log.