### PR TITLE
Tag alidist when tagging packages as well

### DIFF
--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -100,11 +100,10 @@ case "$MESOS_QUEUE_SIZE" in
   *) JOBS=8;;
 esac
 echo "Now running aliBuild on $JOBS parallel workers"
-aliBuild --reference-sources mirror                                               \
-         --work-dir "$workarea"                                                   \
-         ${ARCHITECTURE:+--architecture "$ARCHITECTURE"}                          \
-         --remote-store "${REMOTE_STORE:-rsync://repo.marathon.mesos/store/::rw}" \
-         --defaults "$DEFAULTS" --fetch-repos --jobs "$JOBS" --debug              \
+aliBuild --reference-sources mirror --work-dir "$workarea"           \
+         ${ARCHITECTURE:+--architecture "$ARCHITECTURE"}             \
+         --remote-store "${REMOTE_STORE:-s3://alibuild-repo::rw}"    \
+         --defaults "$DEFAULTS" --fetch-repos --jobs "$JOBS" --debug \
          build "$PACKAGE_NAME" || {
   builderr=$?
   echo "Exiting with an error ($builderr), not tagging"

--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -1,105 +1,105 @@
 #!/bin/bash -ex
-set -x
+# -*- sh-basic-offset: 2 -*-
 
 # Check for required variables
-ALIDIST_SLUG=${ALIDIST_SLUG:-alisw/alidist@master}
-[ ! -z "$PACKAGE_NAME" ]
-[ ! -z "$AUTOTAG_PATTERN" ]
-[ ! -z "$NODE_NAME" ]
+: "${ALIDIST_SLUG:=alisw/alidist@master}" "${PACKAGE_NAME:?}" "${AUTOTAG_PATTERN:?}" "${NODE_NAME:?}"
 
 # Clean up old stuff
 rm -rf alidist/
 
 # Determine branch from slug string: group/repo@ref
-ALIDIST_BRANCH="${ALIDIST_SLUG##*@}"
-ALIDIST_REPO="${ALIDIST_SLUG%@*}"
+ALIDIST_BRANCH=${ALIDIST_SLUG##*@}
+ALIDIST_REPO=${ALIDIST_SLUG%@*}
 
-git clone -b $ALIDIST_BRANCH https://github.com/$ALIDIST_REPO alidist/
+git clone -b "$ALIDIST_BRANCH" "https://github.com/$ALIDIST_REPO" alidist
 
 # Install the latest release if ALIBUILD_SLUG is not provided
-pip install --user --ignore-installed --upgrade ${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild}
+pip install --user --ignore-installed --upgrade "git+https://github.com/$ALIBUILD_SLUG"
 
-PACKAGE_LOWER=$(echo $PACKAGE_NAME | tr '[[:upper:]]' '[[:lower:]]')
-RECIPE=alidist/$PACKAGE_LOWER.sh
-AUTOTAG_REMOTE=$(grep -E '^(source:|write_repo:)' $RECIPE | sort -r | head -n1 | cut -d: -f2- | xargs echo)
-AUTOTAG_MIRROR=$MIRROR/$PACKAGE_LOWER
-AUTOTAG_TAG=$(LANG=C TZ=Europe/Rome date +"$AUTOTAG_PATTERN")
-[[ "$TEST_TAG" == "true" ]] && AUTOTAG_TAG=TEST-IGNORE-$AUTOTAG_TAG
+AUTOTAG_REMOTE=$(grep -E '^(source:|write_repo:)' "alidist/${PACKAGE_NAME,,}.sh" |
+                   sort -r | head -1 | cut -d' ' -f2-)
+AUTOTAG_MIRROR=$MIRROR/${PACKAGE_NAME,,}
+AUTOTAG_TAG=$(LANG=C TZ=Europe/Zurich date "+$AUTOTAG_PATTERN")
+if [ "$TEST_TAG" = true ]; then
+  AUTOTAG_TAG=TEST-IGNORE-$AUTOTAG_TAG
+fi
 echo "A Git tag will be created, upon success and if not existing, with the name $AUTOTAG_TAG"
 AUTOTAG_BRANCH=rc/$AUTOTAG_TAG
 echo "A Git branch will be created to pinpoint the build operation, with the name $AUTOTAG_BRANCH"
-AUTOTAG_CLONE=$PWD/$PACKAGE_LOWER.git
+AUTOTAG_CLONE=$PWD/${PACKAGE_NAME,,}.git
 
-[[ -d $AUTOTAG_MIRROR ]] || AUTOTAG_MIRROR=
-rm -rf $AUTOTAG_CLONE
-mkdir $AUTOTAG_CLONE
-pushd $AUTOTAG_CLONE &> /dev/null
-  [[ -e ../git-creds ]] || git config --global credential.helper "store --file ~/git-creds-autotag"  # backwards compat
-  git clone --bare                                         \
-            ${AUTOTAG_MIRROR:+--reference=$AUTOTAG_MIRROR} \
-            $AUTOTAG_REMOTE .
-  AUTOTAG_HASH=$( (git ls-remote 2> /dev/null | grep refs/tags/$AUTOTAG_TAG || true) | awk 'END{print $1}' )
-  if [[ "$AUTOTAG_HASH" != '' ]]; then
-    echo "Tag $AUTOTAG_TAG exists already as $AUTOTAG_HASH, using it"
-    AUTOTAG_ORIGIN=tag
-  elif [[ $DO_NOT_CREATE_NEW_TAG == true ]]; then
-    # Tag does not exist, but we have requested this job to forcibly use an existing one.
-    # Will abort the job.
-    echo "Tag $AUTOTAG_TAG was not found, however we have been requested to not create a new one" \
-         "(DO_NOT_CREATE_NEW_TAG is true). Aborting with error"
-    exit 1
-  else
-    # Tag does not exist. Create release candidate branch, if not existing.
+[ -d "$AUTOTAG_MIRROR" ] || AUTOTAG_MIRROR=
+rm -rf "$AUTOTAG_CLONE"
+mkdir "$AUTOTAG_CLONE"
+pushd "$AUTOTAG_CLONE" &> /dev/null
+if ! [ -e ../git-creds ]; then
+  git config --global credential.helper "store --file ~/git-creds-autotag"  # backwards compat
+fi
+git clone --bare ${AUTOTAG_MIRROR:+--reference=$AUTOTAG_MIRROR} "$AUTOTAG_REMOTE" .
+AUTOTAG_HASH=$(git ls-remote 2>/dev/null | grep "refs/tags/$AUTOTAG_TAG" | awk 'END{print $1}' )
+if [ -n "$AUTOTAG_HASH" ]; then
+  echo "Tag $AUTOTAG_TAG exists already as $AUTOTAG_HASH, using it"
+  AUTOTAG_ORIGIN=tag
+elif [ "$DO_NOT_CREATE_NEW_TAG" = true ]; then
+  # Tag does not exist, but we have requested this job to forcibly use an
+  # existing one. Will abort the job.
+  echo "Tag $AUTOTAG_TAG was not found, however we have been requested to not create a new one" \
+       "(DO_NOT_CREATE_NEW_TAG is true). Aborting with error"
+  exit 1
+else
+  # Tag does not exist. Create release candidate branch, if not existing.
 
-    AUTOTAG_HASH=$( (git ls-remote 2> /dev/null | grep refs/heads/$AUTOTAG_BRANCH || true) | awk 'END{print $1}' )
-    AUTOTAG_ORIGIN=rcbranch
+  AUTOTAG_HASH=$(git ls-remote 2>/dev/null | grep "refs/heads/$AUTOTAG_BRANCH" | awk 'END{print $1}' )
+  AUTOTAG_ORIGIN=rcbranch
 
-    if [[ "$AUTOTAG_HASH" != '' && "$REMOVE_RC_BRANCH_FIRST" == true ]]; then
-      # Remove branch first if requested. Error is fatal.
-      git push origin :refs/heads/$AUTOTAG_BRANCH
-      AUTOTAG_HASH=
-    fi
-
-    if [[ ! $AUTOTAG_HASH ]]; then
-      # Let's point it to HEAD
-      AUTOTAG_HASH=$( (git ls-remote 2> /dev/null | sed -e 's/\t/ /g' | grep -E ' HEAD$' || true) | awk 'END{print $1}' )
-      [[ $AUTOTAG_HASH ]] || { echo "FATAL: Cannot find any hash pointing to HEAD (repo's default branch)!" >&2; exit 1; }
-      echo "Head of $AUTOTAG_REMOTE will be used, it's at $AUTOTAG_HASH"
-      AUTOTAG_ORIGIN=HEAD
-    fi
-
+  if [ -n "$AUTOTAG_HASH" ] && [ "$REMOVE_RC_BRANCH_FIRST" = true ]; then
+    # Remove branch first if requested. Error is fatal.
+    git push origin ":refs/heads/$AUTOTAG_BRANCH"
+    AUTOTAG_HASH=
   fi
 
-  # At this point, we have $AUTOTAGH_HASH for sure. It might come from HEAD, an existing rc/* branch,
-  # or an existing tag. We always create a new branch out of it
-  git push origin +$AUTOTAG_HASH:refs/heads/$AUTOTAG_BRANCH
+  if [ -z "$AUTOTAG_HASH" ]; then
+    # Let's point it to HEAD
+    AUTOTAG_HASH=$(git ls-remote 2> /dev/null | sed -e 's/\t/ /g' | grep -E ' HEAD$' | awk 'END{print $1}')
+    if [ -z "$AUTOTAG_HASH" ]; then
+      echo "FATAL: Cannot find any hash pointing to HEAD (repo's default branch)!" >&2
+      exit 1
+    fi
+    echo "Head of $AUTOTAG_REMOTE will be used, it's at $AUTOTAG_HASH"
+    AUTOTAG_ORIGIN=HEAD
+  fi
+fi
+
+# At this point, we have $AUTOTAGH_HASH for sure. It might come from HEAD, an existing rc/* branch,
+# or an existing tag. We always create a new branch out of it
+git push origin "+$AUTOTAG_HASH:refs/heads/$AUTOTAG_BRANCH"
 
 popd &> /dev/null  # exit Git repo
 
-# Select build directory in order to prevent conflicts and allow for cleanups. NODE_NAME is defined
-# by Jenkins
-BUILD_DATE=2015$(( $(date --utc +%s) / (86400 * 3) ))
-MIRROR=mirror
-WORKAREA=sw/$BUILD_DATE
+# Select build directory in order to prevent conflicts and allow for cleanups.
+# NODE_NAME is defined by Jenkins
+WORKAREA=sw/$(($(date --utc +%s) / 86400 / 3))
 WORKAREA_INDEX=0
 CURRENT_SLAVE=unknown
-while [[ "$CURRENT_SLAVE" != '' ]]; do
+while [ -n "$CURRENT_SLAVE" ]; do
   WORKAREA_INDEX=$((WORKAREA_INDEX+1))
-  CURRENT_SLAVE=$(cat $WORKAREA/$WORKAREA_INDEX/current_slave 2> /dev/null || true)
-  [[ "$CURRENT_SLAVE" == "$NODE_NAME" ]] && CURRENT_SLAVE=
+  CURRENT_SLAVE=$(cat "$WORKAREA/$WORKAREA_INDEX/current_slave" 2>/dev/null) || true
+  if [ "$CURRENT_SLAVE" = "$NODE_NAME" ]; then
+    CURRENT_SLAVE=
+  fi
 done
 mkdir -p $WORKAREA/$WORKAREA_INDEX
-echo $NODE_NAME > $WORKAREA/$WORKAREA_INDEX/current_slave
+echo "$NODE_NAME" > "$WORKAREA/$WORKAREA_INDEX/current_slave"
 echo "Locking current working directory for us: $WORKAREA/$WORKAREA_INDEX"
 
-: ${DEFAULTS:=release}
+: "${DEFAULTS:=release}"
 
 # Process overrides by changing in-place the given defaults. This requires some
 # YAML processing so we are better off with Python.
-env AUTOTAG_BRANCH=$AUTOTAG_BRANCH \
-    PACKAGE_NAME=$PACKAGE_NAME     \
-    DEFAULTS=$DEFAULTS             \
-python <<\EOF
+env "AUTOTAG_BRANCH=$AUTOTAG_BRANCH" \
+    "PACKAGE_NAME=$PACKAGE_NAME"     \
+    "DEFAULTS=$DEFAULTS"             \
+    python << EOF
 import yaml
 from os import environ
 f = "alidist/defaults-%s.sh" % environ["DEFAULTS"].lower()
@@ -115,31 +115,32 @@ if v:
 open(f, "w").write(yaml.dump(d)+"\n---\n")
 EOF
 
-diff -rupN alidist/defaults-${DEFAULTS_LOWER}.sh.old alidist/defaults-${DEFAULTS_LOWER}.sh | cat
+diff -rupN "alidist/defaults-${DEFAULTS,,}.sh.old" "alidist/defaults-${DEFAULTS,,}.sh" | cat
 
-REMOTE_STORE="${REMOTE_STORE:-rsync://repo.marathon.mesos/store/::rw}"
-JOBS=8
-[[ $MESOS_QUEUE_SIZE == huge ]] && JOBS=30
+case "$MESOS_QUEUE_SIZE" in
+  huge) JOBS=30;;
+  *) JOBS=8;;
+esac
 echo "Now running aliBuild on $JOBS parallel workers"
-aliBuild --reference-sources $MIRROR                   \
-         --debug                                       \
-         --work-dir $WORKAREA/$WORKAREA_INDEX          \
-         ${ARCHITECTURE:+--architecture $ARCHITECTURE} \
-         --jobs 10                                     \
-         --fetch-repos                                 \
-         --remote-store $REMOTE_STORE                  \
-         ${DEFAULTS:+--defaults $DEFAULTS}             \
-         build $PACKAGE_NAME || BUILDERR=$?
+aliBuild --reference-sources mirror                                               \
+         --work-dir "$WORKAREA/$WORKAREA_INDEX"                                   \
+         ${ARCHITECTURE:+--architecture "$ARCHITECTURE"}                          \
+         --remote-store "${REMOTE_STORE:-rsync://repo.marathon.mesos/store/::rw}" \
+         --defaults "$DEFAULTS" --fetch-repos --jobs "$JOBS" --debug              \
+         build "$PACKAGE_NAME" ||
+  BUILDERR=$?
 
-rm -rf $WORKAREA/$WORKAREA_INDEX/current_slave
-[[ "$BUILDERR" != '' ]] && { echo "Exiting with an error ($BUILDERR), not tagging"; exit $BUILDERR; }
+rm -rf "$WORKAREA/$WORKAREA_INDEX/current_slave"
+if [ -n "$BUILDERR" ]; then
+  echo "Exiting with an error ($BUILDERR), not tagging"
+  exit "$BUILDERR"
+fi
 
 # Now we tag, in case we should
-pushd $AUTOTAG_CLONE &> /dev/null
-  if [[ $AUTOTAG_ORIGIN != tag ]]; then
-    git push origin +$AUTOTAG_HASH:refs/tags/$AUTOTAG_TAG
-  else
-    echo "Not tagging: tag $AUTOTAG_TAG exists already as $AUTOTAG_HASH"
-  fi
-  git push origin :refs/heads/$AUTOTAG_BRANCH || true  # error is not a big deal here
-popd &> /dev/null
+cd "$AUTOTAG_CLONE"
+if [ "$AUTOTAG_ORIGIN" = tag ]; then
+  echo "Not tagging: tag $AUTOTAG_TAG exists already as $AUTOTAG_HASH"
+else
+  git push origin "+$AUTOTAG_HASH:refs/tags/$AUTOTAG_TAG"
+fi
+git push origin ":refs/heads/$AUTOTAG_BRANCH" || true  # error is not a big deal here

--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -33,11 +33,11 @@ pushd "$AUTOTAG_CLONE" &>/dev/null
 if git show-ref -q --verify "refs/tags/$AUTOTAG_TAG"; then
   autotag_hash=$(git show-ref -s "refs/tags/$AUTOTAG_TAG")
   echo "Tag $AUTOTAG_TAG exists already as $autotag_hash, using it"
-elif [ "$DO_NOT_CREATE_NEW_TAG" = true ]; then
+elif [ -n "$DO_NOT_CREATE_NEW_TAG" ]; then
   # Tag does not exist, but we have requested this job to forcibly use an
   # existing one. Will abort the job.
   echo "Tag $AUTOTAG_TAG was not found, however we have been requested to not create a new one" \
-       "(DO_NOT_CREATE_NEW_TAG is true). Aborting with error"
+       "(DO_NOT_CREATE_NEW_TAG is set). Aborting with error"
   exit 1
 else
   # Tag does not exist. Create release candidate branch, if not existing.

--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -90,15 +90,11 @@ diff -rupN "alidist/defaults-${DEFAULTS,,}.sh.old" "alidist/defaults-${DEFAULTS,
 # Select build directory in order to prevent conflicts and allow for cleanups.
 workarea=$(mktemp -dp "$PWD" daily-tags.XXXXXXXXXX)
 
-case "$MESOS_QUEUE_SIZE" in
-  huge) JOBS=30;;
-  *) JOBS=8;;
-esac
 echo "Now running aliBuild on $JOBS parallel workers"
-aliBuild --reference-sources mirror --work-dir "$workarea"           \
-         ${ARCHITECTURE:+--architecture "$ARCHITECTURE"}             \
-         --remote-store "${REMOTE_STORE:-s3://alibuild-repo::rw}"    \
-         --defaults "$DEFAULTS" --fetch-repos --jobs "$JOBS" --debug \
+aliBuild --reference-sources mirror --work-dir "$workarea"        \
+         ${ARCHITECTURE:+--architecture "$ARCHITECTURE"}          \
+         --remote-store "${REMOTE_STORE:-s3://alibuild-repo::rw}" \
+         --defaults "$DEFAULTS" --fetch-repos --jobs 8 --debug    \
          build "$PACKAGE_NAME" || {
   builderr=$?
   echo "Exiting with an error ($builderr), not tagging"

--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -71,22 +71,17 @@ popd &>/dev/null  # exit Git repo
 
 # Process overrides by changing in-place the given defaults. This requires some
 # YAML processing so we are better off with Python.
-env "AUTOTAG_BRANCH=$AUTOTAG_BRANCH" \
-    "PACKAGE_NAME=$PACKAGE_NAME"     \
-    "DEFAULTS=$DEFAULTS"             \
-    python << EOF
-import yaml
-from os import environ
-f = "alidist/defaults-%s.sh" % environ["DEFAULTS"].lower()
-p = environ["PACKAGE_NAME"]
+python - "$AUTOTAG_BRANCH" "$PACKAGE_NAME" "$DEFAULTS" << EOF
+import os, sys, yaml
+_, AUTOTAG_BRANCH, PACKAGE_NAME, DEFAULTS = sys.argv
+f = "alidist/defaults-%s.sh" % DEFAULTS.lower()
 d = yaml.safe_load(open(f).read().split("---")[0])
 open(f+".old", "w").write(yaml.dump(d)+"\n---\n")
 d["overrides"] = d.get("overrides", {})
-d["overrides"][p] = d["overrides"].get(p, {})
-d["overrides"][p]["tag"] = environ["AUTOTAG_BRANCH"]
-v = environ.get("AUTOTAG_OVERRIDE_VERSION")
-if v:
-    d["overrides"][p]["version"] = v
+d["overrides"][PACKAGE_NAME] = d["overrides"].get(PACKAGE_NAME, {})
+d["overrides"][PACKAGE_NAME]["tag"] = AUTOTAG_BRANCH
+v = os.environ.get("AUTOTAG_OVERRIDE_VERSION")
+if v: d["overrides"][PACKAGE_NAME]["version"] = v
 open(f, "w").write(yaml.dump(d)+"\n---\n")
 EOF
 

--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -111,10 +111,15 @@ aliBuild --reference-sources mirror                                             
   exit "$builderr"
 }
 
-# Now we tag, in case we should
-cd "$AUTOTAG_CLONE"
-git push origin "+$autotag_hash:refs/tags/$AUTOTAG_TAG"
-# Delete the branch we created earlier.
-git push origin ":refs/heads/$AUTOTAG_BRANCH" || true  # error is not a big deal here
+(
+  # Now we tag
+  cd "$AUTOTAG_CLONE"
+  git push origin "+$autotag_hash:refs/tags/$AUTOTAG_TAG"
+  # Delete the branch we created earlier.
+  git push origin ":refs/heads/$AUTOTAG_BRANCH" || true  # error is not a big deal here
+)
 
-rm -rf "$workarea"
+# Also tag the appropriate alidist
+(cd alidist && git push origin "HEAD:refs/tags/$PACKAGE-$AUTOTAG_TAG")
+
+rm -rf "$workarea" alidist


### PR DESCRIPTION
This PR also refactors `daily-tags.sh`. Significant changes include:

- replacing custom workspace locking code with `mktemp`
- using `git show-ref` instead of parsing `git ls-remote` output, to avoid server round-trips each time
- using the S3 remote store by default

@ktf: which of the following features are used, and which can be removed?

- tagging behaviour is pretty complicated at the moment -- should `REMOVE_RC_BRANCH_FIRST` and/or `DO_NOT_CREATE_NEW_TAG` just be made the non-configurable default?
- patching the YAML seems pretty hacky -- is it worth adding a flag to aliBuild directly to override the current package's tag and version?