### PR TITLE
repo-s3-upload: Make symlink search more efficient

### DIFF
--- a/repo-s3-mirror
+++ b/repo-s3-mirror
@@ -34,6 +34,13 @@ rclone_defaults () {
   rclone --config /secrets/alibuild_rclone_config --transfers=10 --progress --delete-before "$@"
 }
 
+find_dirs () {
+  # Find directories in $prefix/$repo, with extra find predicates passed as args
+  # to this function. Exclude store/ completely (it doesn't contain symlinks, so
+  # ignoring it avoids pointless disk accesses).
+  find "$prefix/$repo" -path "$prefix/$repo/store" -prune -o -type d "$@" -print0
+}
+
 # Create a separate filesystem tree, with symlinks only. However, as S3 doesn't
 # support real symlinks, make them regular files containing the path they point
 # to instead.
@@ -44,20 +51,19 @@ if
   # If it doesn't, this is the first run, and we want to sync everything.
   ! [ -d "$symlink_tree" ] ||
     # We only copy symlinks in directories that have changed since the last run
-    # to save on disk accesses. Exclude store/ completely (it is also pruned
-    # below, but doing it here too avoids pointless disk accesses).
-    ! find "$prefix/$repo" -path "$prefix/$repo/store" -prune -o \
-      -type d -newer "$symlink_tree" -prune -print0
+    # to save on disk accesses.
+    ! find_dirs -newer "$symlink_tree"
 then
   # If this is the first run on this machine, recreate the entire hierarchy.
   # (In that case, $symlink_tree won't exist yet.)
-  printf '%s\0' "$prefix/$repo"
+  find_dirs -true
 fi |
 
-  # Find and read symlinks under each path found above (excluding store/).
+  # Find and read symlinks under each path found above. New child directories
+  # are passed separately, so we don't look for symlinks in child directories.
   # %p is the symlink's path including $prefix/$repo/..., %l is its target,
   # which for the RPM repo will be a relative path (so we can use it directly).
-  xargs -0rI {} find {} -path "$prefix/$repo/store" -prune -o -type l -printf '%p\t%l\n' |
+  xargs -0rI {} find {} -mindepth 1 -maxdepth 1 -type l -printf '%p\t%l\n' |
 
   # Create a pseudo-symlink in $symlink_tree for each symlink found above.
   while IFS='	' read -r symlink target; do


### PR DESCRIPTION
If a high-level directory is changed, this change means it won't be copied in its entirety, but only those subdirectories of it that have changed.