### PR TITLE
Fix spurious shlex error

### DIFF
--- a/list-branch-pr
+++ b/list-branch-pr
@@ -87,42 +87,41 @@ class RepoConfig:
     def _parse_env_file(self, env_file_path):
         """Apply settings from env_file_path to this class."""
         with open(env_file_path) as envf:
-            for line in envf:
-                try:
-                    tokens = shlex.split(line, comments=False)
-                except ValueError as err:
-                    # Some values are multiline, e.g. DEVEL_PKGS. This confuses
-                    # shlex. None of the variables we care about are multiline.
-                    print("shlex", err, "on line", line,
-                          sep=": ", end="", file=sys.stderr)
-                    continue
+            try:
+                tokens = shlex.split(envf.read(), comments=False)
+            except ValueError as err:
+                # Some values are multiline, e.g. DEVEL_PKGS. This confuses
+                # shlex. None of the variables we care about are multiline.
+                print("shlex", err, "in file", env_file_path,
+                      sep=": ", file=sys.stderr)
+                return
 
-                # Some variables are used elsewhere in the CI builder, so they
-                # are defined as shell variables. Handle these here (including
-                # multiple assignments on one line). Note that non-assignments
-                # containing "=" (e.g. command arguments), variables valid only
-                # for one command, and the like confuse this simple approach.
-                for token in tokens:
-                    var, is_assignment, value = token.partition("=")
-                    if not is_assignment:
-                        continue
-                    if var == "PR_REPO":
-                        self.repo_name = value
-                    elif var == "PR_BRANCH":
-                        self.branch_ref = value
-                    elif var == "CHECK_NAME":
-                        self.check_name = value
-                    elif var == "TRUST_COLLABORATORS":
-                        # Shell-style boolean: True if non-empty.
-                        self.trust_contributors = bool(value)
-                    elif var == "TRUSTED_USERS":
-                        self.trusted_users = value.split(",")
-                    elif var == "TRUSTED_TEAM" and value:
-                        teams = self.cgh.get("/orgs/{org}/teams", org=self.org)
-                        for team in teams:
-                            if team["name"] == value:
-                                self.trusted_team = team["id"]
-                                break
+            # Some variables are used elsewhere in the CI builder, so they
+            # are defined as shell variables. Handle these here (including
+            # multiple assignments on one line). Note that non-assignments
+            # containing "=" (e.g. command arguments), variables valid only
+            # for one command, and the like confuse this simple approach.
+            for token in tokens:
+                var, is_assignment, value = token.partition("=")
+                if not is_assignment:
+                    continue
+                if var == "PR_REPO":
+                    self.repo_name = value
+                elif var == "PR_BRANCH":
+                    self.branch_ref = value
+                elif var == "CHECK_NAME":
+                    self.check_name = value
+                elif var == "TRUST_COLLABORATORS":
+                    # Shell-style boolean: True if non-empty.
+                    self.trust_contributors = bool(value)
+                elif var == "TRUSTED_USERS":
+                    self.trusted_users = value.split(",")
+                elif var == "TRUSTED_TEAM" and value:
+                    teams = self.cgh.get("/orgs/{org}/teams", org=self.org)
+                    for team in teams:
+                        if team["name"] == value:
+                            self.trusted_team = team["id"]
+                            break
 
     @property
     def org(self):


### PR DESCRIPTION
This processes whole .env files at a time, instead of line-by-line.

Note that it doesn't parse files perfectly! A command with an argument containing `=` would cause that argument to be parsed as an assignment. For example, `echo foo=bar` would parse as an ignored token `echo` and an assignment `foo=bar`. (This might be useful with export statements, actually.) As .env files are supposed to be simple key-value stores anyway, we can ignore this problem for now.

(Most of the diff is due to an indentation change caused by the removal of the for loop.)