### PR TITLE
Use MacOS-compatible hostname invocation

### DIFF
--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -20,7 +20,7 @@ export ALIBUILD_O2_TESTS
 
 host_id=$(echo "$MESOS_EXECUTOR_ID" |
             sed -ne 's#^\(thermos-\)\?\([a-z]*\)-\([a-z]*\)-\([a-z0-9_-]*\)-\([0-9]*\)\(-[0-9a-f]*\)\{5\}$#\2/\4/\5#p')
-: "${host_id:=$(hostname --fqdn)}"
+: "${host_id:=$(hostname -f)}"
 
 # Update all PRs in the queue with their number before we start building.
 echo "$HASHES" | tail -n "+$((BUILD_SEQ + 1))" | cat -n | while read -r ahead btype PR_NUMBER PR_HASH envf; do


### PR DESCRIPTION
On the Macs, `MESOS_EXECUTOR_ID` isn't defined, so we fall back to the hostname. They don't understand `--fqdn`, though. `-f` is more compatible.