### PR TITLE
Tag alidist with other daily tags

### DIFF
--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -131,3 +131,6 @@ pushd $AUTOTAG_CLONE &> /dev/null
   fi
   git push origin :refs/heads/$AUTOTAG_BRANCH || true  # error is not a big deal here
 popd &> /dev/null
+
+# Also tag the appropriate alidist
+(cd alidist && git push origin "HEAD:refs/tags/$PACKAGE-$AUTOTAG_TAG")


### PR DESCRIPTION
When another package is successfully tagged using `daily-tags.sh`, also tag the corresponding commit of alidist that was used.