### PR TITLE
Fix CMake error extraction

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -194,7 +194,7 @@ class Logs(object):
         self.compiler_killed = chunk_command_output_by_log(
             "grep -he 'fatal error: Killed signal terminated program' -- %s")
         self.cmake_errors = chunk_command_output_by_log(
-            "sed -En '/^CMake (Error|Warning)/,/^Call Stack/p' %s")
+            "sed -En '/^CMake (Error|Warning)/,/^$/p' %s")
 
     def generate_pretty_log(self):
         '''Extract error messages from logs.


### PR DESCRIPTION
They don't always have a call stack attached. They always end in an empty line, but sometimes contain empty lines so this will truncate some error messages (but at least not flood the output in case of a missing call stack).