### PR TITLE
Run CI iterations in a subshell

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -68,7 +68,7 @@ fi
 
 if [ -n "$HASHES" ]; then
   # Loop through PRs we can build if there are any.
-  echo "$HASHES" | cat -n | while read -r BUILD_SEQ BUILD_TYPE PR_NUMBER PR_HASH env_name; do
+  echo "$HASHES" | cat -n | while read -r BUILD_SEQ BUILD_TYPE PR_NUMBER PR_HASH env_name; do (
     # Run iterations in a subshell so environment variables are not kept
     # across potentially different repos. This is an issue as env files are
     # allowed to define arbitrary variables that other files (or the defaults
@@ -91,7 +91,7 @@ if [ -n "$HASHES" ]; then
 
     # Run the build
     . build-loop.sh
-  done &&
+  ); done &&
     # If the loop succeeded, remove force-hashes so we don't keep building the
     # same PRs forever.
     rm -f force-hashes


### PR DESCRIPTION
We need this as we `cd` into repo-specific directories inside the loop. The automatic subshell around the loop doesn't get us back to the sandbox directory after each iteration.

This means we don't query for pending PRs after each iteration but only when done iterating, as intended. This means new incoming PRs don't displace old untested ones in the queue.