### PR TITLE
Sync packages from S3 in aliPublish

### DIFF
--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -481,7 +481,7 @@ def sync(pub, architectures, endpointUrl, bucket, baseUrl, basePrefix, rules,
 
   # Template URLs
   packNamesPathTpl = "%(arch)s/dist-direct"
-  distPathTpl      = "%(arch)s/dist%(dist)s/%(pack)s/%(pack)s-%(ver)s"
+  distPathTpl      = "%(arch)s/%(dist)s/%(pack)s/%(pack)s-%(ver)s"
   verPathTpl       = "%(arch)s/dist-direct/%(pack)s"
   getPackUrlTpl    = ("%(baseUrl)s/%(basePrefix)s/%(arch)s/dist-direct/%(pack)s"
                       "/%(pack)s-%(ver)s/%(pack)s-%(ver)s.%(arch)s.tar.gz")
@@ -536,7 +536,7 @@ def sync(pub, architectures, endpointUrl, bucket, baseUrl, basePrefix, rules,
 
         # At this point we have filtered in the package: let's see its dependencies!
         # Note that a package always depends on itself (list cannot be empty).
-        distPath = format(distPathTpl, dist="-runtime",
+        distPath = format(distPathTpl, dist="dist-runtime",
                           arch=arch, pack=pkgName, ver=pkgVer)
         runtimeDeps = listDir(distPath)
         if not runtimeDeps:
@@ -577,7 +577,7 @@ def sync(pub, architectures, endpointUrl, bucket, baseUrl, basePrefix, rules,
       # Get direct and indirect dependencies
       deps = {}
       depFail = False
-      for key in ("", "-direct", "-runtime"):
+      for key in ("dist", "dist-direct", "dist-runtime"):
         jdeps = listDir(format(distPathTpl, dist=key, arch=arch,
                                pack=pack["name"], ver=pack["ver"]))
         if not jdeps:

--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -518,30 +518,55 @@ def getTimestamp(s):
     return 0
   return getTotalSeconds(dt - datetime(1970, 1, 1))  # yes, it's a mess
 
-def sync(pub, architectures, baseUrl, rules, excludeOlderThanSec, includeFirst, autoIncludeDeps,
-         notifEmail, dryRun, jget):
+def sync(pub, architectures, baseUrl, basePrefix, rules, excludeOlderThanSec,
+         includeFirst, autoIncludeDeps, notifEmail, dryRun, connParams):
 
   newPackages = {}
 
   # Template URLs
-  packNamesUrlTpl   = "%(baseUrl)s/%(arch)s/dist-direct/"
-  distUrlTpl        = "%(baseUrl)s/%(arch)s/dist/%(pack)s/%(pack)s-%(ver)s/"
-  distDirectUrlTpl  = "%(baseUrl)s/%(arch)s/dist-direct/%(pack)s/%(pack)s-%(ver)s/"
-  distRuntimeUrlTpl = "%(baseUrl)s/%(arch)s/dist-runtime/%(pack)s/%(pack)s-%(ver)s/"
-  verUrlTpl         = "%(baseUrl)s/%(arch)s/dist-direct/%(pack)s/"
-  getPackUrlTpl     = distDirectUrlTpl + "/%(pack)s-%(ver)s.%(arch)s.tar.gz"
+  packNamesPathTpl = "%(arch)s/dist-direct"
+  distPathTpl      = "%(arch)s/%(dist)s/%(pack)s/%(pack)s-%(ver)s"
+  verPathTpl       = "%(arch)s/dist-direct/%(pack)s"
+  getPackUrlTpl    = "%(baseUrl)s/%(basePrefix)s/%(arch)s/dist-direct/%(pack)s/%(pack)s-%(ver)s/%(pack)s-%(ver)s.%(arch)s.tar.gz"
+
+  def listDir(path):
+    url = format("%(base)s?prefix=%(prefix)s/%(path)s/",
+                 base=baseUrl, prefix=basePrefix, path=path)
+    debug("Getting directory contents for " + url)
+    # This is a list of all file names under path (recursively).
+    files = requests.get(url, verify=connParams["http_ssl_verify"],
+                         timeout=connParams["conn_timeout_s"]) \
+                    .text.splitlines()
+    # Directories aren't listed separately, so we add a directory if we see a
+    # file inside it. This means that directories can be added multiple times
+    # (if they contain multiple files), so deduplicate by using a set here.
+    contents = set()
+    # The server returns file names with this prefix, which we want to ignore.
+    strip = basePrefix + "/" + path + "/"
+    for filename in files:
+      # Strip prefix and path from returned file names
+      if filename.startswith(strip):
+        filename = filename[len(strip):]
+      # We only care about the immediate contents of path, so if the file name
+      # contains a / after stripping path, we know it's a directory with some
+      # contents. In that case, only track the directory. If no / remains, it
+      # must be a file directly under path.
+      name, is_dir, _ = filename.partition("/")
+      contents.add((name, "directory" if is_dir else "file"))
+    # Fake a last-modified time. S3 doesn't provide this info. The timestamp
+    # must end in "UTC" or "GMT", else getTimestamp won't recognise it.
+    now = datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S GMT")
+    # Create a list of directory entries in the format expected below.
+    return [{"name": name, "mtime": now, "type": ftype} for name, ftype in contents]
 
   # Prepare the list of packages to install
   for arch in architectures:
     newPackages[arch] = []
-    packNamesUrl = format(packNamesUrlTpl,
-                          baseUrl=baseUrl, arch=arch)
 
     # Get valid package names for this architecture
-    debug(format("Getting packages for architecture %(arch)s from %(url)s",
-                 arch=arch, url=packNamesUrl))
-    distPackages = [ p["name"] for p in jget(packNamesUrl) if p["type"] == "directory" ]
-    distPackages.sort(key=lambda p: -len(p))
+    distPackages = sorted((p["name"] for p in listDir(format(packNamesPathTpl, arch=arch))
+                           if p["type"] == "directory"),
+                          key=len, reverse=True)
     debug("Packages found: %s" % ", ".join([p for p in distPackages]))
 
     # Packages to publish
@@ -553,11 +578,7 @@ def sync(pub, architectures, baseUrl, rules, excludeOlderThanSec, includeFirst, 
         continue
       if not includeFirst and rules["exclude"][arch].get(pkgName) == True:
         continue
-      verUrl = format(verUrlTpl,
-                      baseUrl=baseUrl, arch=arch, pack=pkgName)
-      debug(format("%(arch)s / %(pack)s: listing versions under %(url)s",
-                   arch=arch, pack=pkgName, url=verUrl))
-      for pkgTar in jget(verUrl):
+      for pkgTar in listDir(format(verPathTpl, arch=arch, pack=pkgName)):
         if pkgTar["type"] != "directory":
           continue
         nameVer = nameVerFromTar(pkgTar["name"], arch, [pkgName])
@@ -584,15 +605,15 @@ def sync(pub, architectures, baseUrl, rules, excludeOlderThanSec, includeFirst, 
 
         # At this point we have filtered in the package: let's see its dependencies!
         # Note that a package always depends on itself (list cannot be empty).
-        distUrl = format(distRuntimeUrlTpl,
-                         baseUrl=baseUrl, arch=arch, pack=pkgName, ver=pkgVer)
-        runtimeDeps = jget(distUrl)
+        distPath = format(distPathTpl, dist="dist-runtime",
+                          arch=arch, pack=pkgName, ver=pkgVer)
+        runtimeDeps = listDir(distPath)
         if not runtimeDeps:
           error(format("%(arch)s / %(pack)s / %(ver)s: cannot list dependencies from %(url)s: skipping",
-                       arch=arch, pack=pkgName, ver=pkgVer, url=distUrl))
+                       arch=arch, pack=pkgName, ver=pkgVer, url=distPath))
           continue
         debug(format("%(arch)s / %(pack)s / %(ver)s: listing all dependencies under %(url)s",
-                     arch=arch, pack=pkgName, ver=pkgVer, url=distUrl))
+                     arch=arch, pack=pkgName, ver=pkgVer, url=distPath))
         for depTar in runtimeDeps:
           if depTar["type"] != "file":
             continue
@@ -604,7 +625,7 @@ def sync(pub, architectures, baseUrl, rules, excludeOlderThanSec, includeFirst, 
           # Append only if it does not exist yet
           if len([p for p in pubPackages if p["name"]==depName and p["ver"]==depVer]) == 0:
             debug(format("%(arch)s / %(pack)s / %(ver)s: adding %(depName)s %(depVer)s to publish",
-                  arch=arch, pack=pkgName, ver=pkgVer, url=distUrl,
+                  arch=arch, pack=pkgName, ver=pkgVer, url=distPath,
                   depName=depName, depVer=depVer))
             pubPackages.append({ "name": depName, "ver": depVer })
 
@@ -615,8 +636,8 @@ def sync(pub, architectures, baseUrl, rules, excludeOlderThanSec, includeFirst, 
 
     # Packages installation
     for pack in pubPackages:
-      pkgUrl = format(getPackUrlTpl,
-                       baseUrl=baseUrl, arch=arch, pack=pack["name"], ver=pack["ver"])
+      pkgUrl = format(getPackUrlTpl, baseUrl=baseUrl, basePrefix=basePrefix,
+                      arch=arch, pack=pack["name"], ver=pack["ver"])
 
       if pub.installed(architectures[arch], pack["name"], pack["ver"]):
         debug(format("%(arch)s / %(pack)s / %(ver)s: already installed: skipping",
@@ -625,16 +646,9 @@ def sync(pub, architectures, baseUrl, rules, excludeOlderThanSec, includeFirst, 
 
       # Get direct and indirect dependencies
       deps = {}
-      depUrlTpls = { "dist": distUrlTpl,
-                     "dist-direct": distDirectUrlTpl,
-                     "dist-runtime": distRuntimeUrlTpl }
       depFail = False
-      for key,depsUrlTpl in depUrlTpls.iteritems():
-        depsUrl = format(depsUrlTpl,
-                         baseUrl=baseUrl, arch=arch, pack=pack["name"], ver=pack["ver"])
-        debug(format("%(arch)s / %(pack)s / %(ver)s: listing %(key)s dependencies from %(url)s",
-                     arch=arch, pack=pack["name"], ver=pack["ver"], key=key, url=depsUrl))
-        jdeps = jget(depsUrl)
+      for key in ("dist", "dist-direct", "dist-runtime"):
+        jdeps = listDir(format(distPathTpl, dist=key, arch=arch, pack=pack["name"], ver=pack["ver"]))
         if not jdeps:
           error(format("%(arch)s / %(pack)s / %(ver)s: cannot get %(dtype)s dependencies: skipping",
                        arch=arch, pack=pack["name"], ver=pack["ver"], dtype=key))
@@ -1000,13 +1014,14 @@ def main():
     r = sync(pub=pub,
              architectures=architectures,
              baseUrl=conf["base_url"],
+             basePrefix=conf["base_prefix"],
              rules=rules,
              excludeOlderThanSec=conf["exclude_older_d"] * 86400,
              includeFirst=includeFirst,
              autoIncludeDeps=conf["auto_include_deps"],
              notifEmail=conf["notification_email"],
              dryRun=args.dryRun,
-             jget=jget)
+             connParams=connParams)
     debug("Made %d unique HTTP requests (%d remote requests including retries, %d read from cache)" % \
           (jget.count_req, jget.count_req_retries, jget.count_cached))
     debug("Summary of requested URLs (DIR=direct access, HIT=cache hit, MIS=cache miss):")

--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -36,23 +36,13 @@ def searchMany(name, exprs):
     return True
   return False
 
-def applyFilter(name, timestamp, includeRules, excludeRules, includeFirst, excludeOlderThanSec):
-  if excludeOlderThanSec > 0 and time()-timestamp > excludeOlderThanSec:
-    return False  # excluding because too old (excludeOlderThanSec == 0: never exclude)
+def applyFilter(name, includeRules, excludeRules, includeFirst):
   if includeFirst:
-    if searchMany(name, includeRules):
-      return not searchMany(name, excludeRules)
-    else:
-      return False
-  else:
-    if searchMany(name, excludeRules):
-      return False
-    else:
-      if includeRules is None:
-        # process exclude first, and no explicit include rule: keep it
-        return True
-      else:
-        return searchMany(name, includeRules)
+    return searchMany(name, includeRules) and not searchMany(name, excludeRules)
+  if searchMany(name, excludeRules):
+    return False
+  # process exclude first, and no explicit include rule: keep it
+  return includeRules is None or searchMany(name, includeRules)
 
 def runInstallScript(script, dryRun, **kwsub):
   if dryRun:
@@ -495,30 +485,7 @@ def nameVerFromTar(tar, arch, validPacks):
       return { "name": vm.group(1), "ver": vm.group(2) }
   return None
 
-if hasattr(datetime, "total_seconds"):
-  # Python 2.7+
-  def getTotalSeconds(dt):
-    return dt.total_seconds()
-else:
-  # Python 2.6
-  def getTotalSeconds(dt):
-    return (dt.microseconds + (dt.seconds + dt.days * 24 * 3600) * 1000000) / 1000000
-
-def getTimestamp(s):
-  # Convert a given string in the format "Thu, 03 Aug 2017 01:12:54 GMT" to
-  # an UTC Unix timestamp and return it. Only strings ending with GMT or UTC
-  # are supported! In case of errors, zero is returned
-  if not s.endswith("GMT") and not s.endswith("UTC"):
-    return 0
-  try:
-    dt = datetime.strptime(s, "%a, %d %b %Y %H:%M:%S %Z")
-  except Exception as e:
-    error("Cannot parse time string {timestring}: {exception}".format(
-      timestring=s, exception=str(e)))
-    return 0
-  return getTotalSeconds(dt - datetime(1970, 1, 1))  # yes, it's a mess
-
-def sync(pub, architectures, baseUrl, basePrefix, rules, excludeOlderThanSec,
+def sync(pub, architectures, baseUrl, basePrefix, rules,
          includeFirst, autoIncludeDeps, notifEmail, dryRun, connParams):
 
   newPackages = {}
@@ -552,22 +519,20 @@ def sync(pub, architectures, baseUrl, basePrefix, rules, excludeOlderThanSec,
       # contents. In that case, only track the directory. If no / remains, it
       # must be a file directly under path.
       name, is_dir, _ = filename.partition("/")
-      contents.add((name, "directory" if is_dir else "file"))
-    # Fake a last-modified time. S3 doesn't provide this info. The timestamp
-    # must end in "UTC" or "GMT", else getTimestamp won't recognise it.
-    now = datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S GMT")
+      if (is_dir and incl_dirs) or (not is_dir and incl_files):
+        contents.add((name, "directory" if is_dir else "file"))
     # Create a list of directory entries in the format expected below.
-    return [{"name": name, "mtime": now, "type": ftype} for name, ftype in contents]
+    return [{"name": name, "type": ftype} for name, ftype in contents]
 
   # Prepare the list of packages to install
   for arch in architectures:
     newPackages[arch] = []
 
     # Get valid package names for this architecture
-    distPackages = sorted((p["name"] for p in listDir(format(packNamesPathTpl, arch=arch))
-                           if p["type"] == "directory"),
+    distPackages = sorted((p["name"] for p in listDir(format(packNamesPathTpl, arch=arch),
+                                                      incl_files=False)),
                           key=len, reverse=True)
-    debug("Packages found: %s" % ", ".join([p for p in distPackages]))
+    debug("Packages found: %s", ", ".join(distPackages))
 
     # Packages to publish
     pubPackages = []
@@ -578,23 +543,17 @@ def sync(pub, architectures, baseUrl, basePrefix, rules, excludeOlderThanSec,
         continue
       if not includeFirst and rules["exclude"][arch].get(pkgName) == True:
         continue
-      for pkgTar in listDir(format(verPathTpl, arch=arch, pack=pkgName)):
-        if pkgTar["type"] != "directory":
-          continue
+      for pkgTar in listDir(format(verPathTpl, arch=arch, pack=pkgName), incl_files=False):
         nameVer = nameVerFromTar(pkgTar["name"], arch, [pkgName])
         if nameVer is None:
           continue
         pkgVer = nameVer["ver"]
-        pkgTime = getTimestamp(pkgTar["mtime"])  # UTC seconds since Unix epoch
         # Here we decide whether to include/exclude it
         if not applyFilter(pkgVer,
-                           pkgTime,
                            rules["include"][arch].get(pkgName, None),
                            rules["exclude"][arch].get(pkgName, None),
-                           includeFirst,
-                           excludeOlderThanSec):
-          debug(format("%(arch)s / %(pack)s / %(ver)s: excluded (timestamp: %(mtime)d)",
-                arch=arch, pack=pkgName, ver=pkgVer, mtime=pkgTime))
+                           includeFirst):
+          debug("%s / %s / %s: excluded", arch, pkgName, pkgVer)
           continue
 
         if not autoIncludeDeps:
@@ -607,7 +566,7 @@ def sync(pub, architectures, baseUrl, basePrefix, rules, excludeOlderThanSec,
         # Note that a package always depends on itself (list cannot be empty).
         distPath = format(distPathTpl, dist="dist-runtime",
                           arch=arch, pack=pkgName, ver=pkgVer)
-        runtimeDeps = listDir(distPath)
+        runtimeDeps = listDir(distPath, incl_dirs=False)
         if not runtimeDeps:
           error(format("%(arch)s / %(pack)s / %(ver)s: cannot list dependencies from %(url)s: skipping",
                        arch=arch, pack=pkgName, ver=pkgVer, url=distPath))
@@ -615,8 +574,6 @@ def sync(pub, architectures, baseUrl, basePrefix, rules, excludeOlderThanSec,
         debug(format("%(arch)s / %(pack)s / %(ver)s: listing all dependencies under %(url)s",
                      arch=arch, pack=pkgName, ver=pkgVer, url=distPath))
         for depTar in runtimeDeps:
-          if depTar["type"] != "file":
-            continue
           depNameVer = nameVerFromTar(depTar["name"], arch, distPackages)
           if depNameVer is None:
             continue
@@ -648,7 +605,9 @@ def sync(pub, architectures, baseUrl, basePrefix, rules, excludeOlderThanSec,
       deps = {}
       depFail = False
       for key in ("dist", "dist-direct", "dist-runtime"):
-        jdeps = listDir(format(distPathTpl, dist=key, arch=arch, pack=pack["name"], ver=pack["ver"]))
+        jdeps = listDir(format(distPathTpl, dist=key, arch=arch,
+                               pack=pack["name"], ver=pack["ver"]),
+                        incl_dirs=False)
         if not jdeps:
           error(format("%(arch)s / %(pack)s / %(ver)s: cannot get %(dtype)s dependencies: skipping",
                        arch=arch, pack=pack["name"], ver=pack["ver"], dtype=key))
@@ -863,7 +822,6 @@ def main():
   conf["conn_retries"]      = conf.get("conn_retries"     , 3)
   conf["conn_dethrottle_s"] = conf.get("conn_dethrottle_s", 0)
   conf["kill_after_s"]      = conf.get("kill_after_s"     , 3600)
-  conf["exclude_older_d"]   = conf.get("exclude_older_d"  , 0)  # in days; 0 == don't exclude
 
   doExit = False
 
@@ -1016,7 +974,6 @@ def main():
              baseUrl=conf["base_url"],
              basePrefix=conf["base_prefix"],
              rules=rules,
-             excludeOlderThanSec=conf["exclude_older_d"] * 86400,
              includeFirst=includeFirst,
              autoIncludeDeps=conf["auto_include_deps"],
              notifEmail=conf["notification_email"],
@@ -1060,14 +1017,11 @@ def main():
       for pkg in testRules[arch]:
         for ver in testRules[arch][pkg]:
           match = applyFilter(ver,
-                              0,
                               rules["include"].get(arch, {}).get(pkg, None),
                               rules["exclude"].get(arch, {}).get(pkg, None),
-                              includeFirst,
-                              0)
-          msg = format(match and "%(arch)s: %(pkg)s ver %(ver)s matches filters"
-                             or "%(arch)s: %(pkg)s ver %(ver)s does NOT match filters",
-                       arch=arch, pkg=pkg, ver=ver)
+                              includeFirst)
+          msg = ("%s: %s ver %s matches filters" if match else
+                 "%s: %s ver %s does NOT match filters") % (arch, pkg, ver)
           if match != testRules[arch][pkg][ver]:
             error(msg + (match and " but it should not" or " but it should"))
             sys.exit(1)

--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import logging, sys, json, yaml, requests, urllib3, errno
+import logging, sys, json, yaml, requests, urllib3, errno, boto3
 from glob import glob
 from argparse import ArgumentParser
 from commands import getstatusoutput
@@ -8,16 +8,16 @@ from datetime import datetime
 from requests import RequestException
 from time import sleep, time
 from yaml import YAMLError
-from logging import debug, error, info
+from logging import debug, info, warning, error
 from re import search, escape, sub
 from os.path import isdir, isfile, realpath, dirname, getmtime, join, basename
-from os import chmod, remove, chdir, getcwd, getpid, kill, makedirs, rename
+from os import chmod, remove, chdir, getcwd, getpid, kill, makedirs, rename, environ
 from shutil import rmtree
 from tempfile import NamedTemporaryFile, mkdtemp
 from subprocess import Popen, PIPE, STDOUT
 from smtplib import SMTP
 from socket import getfqdn
-from random import random, choice, shuffle
+from random import random, shuffle
 from urlparse import urlsplit, urlunsplit
 
 def format(s, **kwds):
@@ -485,53 +485,100 @@ def nameVerFromTar(tar, arch, validPacks):
       return { "name": vm.group(1), "ver": vm.group(2) }
   return None
 
-def sync(pub, architectures, baseUrl, basePrefix, rules,
-         includeFirst, autoIncludeDeps, notifEmail, dryRun, connParams):
+def getS3PackageLister(endpointUrl, bucket, basePrefix, architectures,
+                       pathCommonPrefix):
+  """Return a function that gets a directory's contents from S3.
 
-  newPackages = {}
+  Cache the directory tree from S3 in advance, because we tend to use this
+  function to get first the contents of a directory, then one of its
+  subdirectories. S3 can only return the items with a prefix, so when getting
+  the parent dir, we get everything already, so we better use it when getting
+  the subdirectory's contents later.
+
+  There are lots of paths on S3, so we take every bit of common prefix that we
+  can get -- hence the pathCommonPrefix argument. We get all paths with prefix
+  basePrefix/$arch/$pathCommonPrefix (pathCommonPrefix doesn't need to be a
+  full directory name).
+  """
+  s3 = boto3.client("s3", endpoint_url=endpointUrl,
+                    aws_access_key_id=environ["AWS_ACCESS_KEY_ID"],
+                    aws_secret_access_key=environ["AWS_SECRET_ACCESS_KEY"])
+
+  # This will be a dictionary where file-/dirnames are keys and dir contents
+  # are values. Files will be an entry with value None.
+  filesystemTree = {}
+  for arch in architectures:
+    # Build the filesystem tree on the server.
+    debug("Getting directory contents for %s/%s/dist*", basePrefix, arch)
+    pages = s3.get_paginator("list_objects_v2") \
+              .paginate(Bucket=bucket, Prefix='%s/%s/dist' % (basePrefix, arch))
+    for i, page in enumerate(pages):
+      debug("Page %d: got %d items", i, len(page['Contents']))
+      for item in page["Contents"]:
+        filename = item["Key"]
+        # The server returns file names with a prefix, which we want to ignore.
+        # We keep the arch prefix, though.
+        if filename.startswith(basePrefix + "/"):
+          filename = filename[len(basePrefix)+1:]
+        components = filename.split("/")
+        # Start at the root. We kept the arch prefix above in components, so
+        # we'll enter/create the arch directory in the loop below.
+        curDir = filesystemTree
+        # Leading directories: create empty dictionaries for directories we
+        # traverse for the first time.
+        for component in components[:-1]:
+          # If we have a file at this location, overwrite it with a directory
+          # entry. S3 can have files and directories with the same name in the
+          # same directory, but we don't care about the files in that case.
+          if curDir.get(component, {}) is None:
+            curDir[component] = {}
+          # Follow the path down into the next directory.
+          curDir = curDir.setdefault(component, {})
+        # File basename: add an entry to its parent directory's dictionary, but
+        # don't overwrite an existing directory entry here.
+        curDir.setdefault(components[-1], None)
+
+  def listDir(path):
+    """Look up the contents of path in the cached FS tree."""
+    curDir = filesystemTree
+    try:
+      if path:
+        for component in path.split("/"):
+          curDir = curDir[component]
+    except KeyError as err:
+      warning("listDir(%r) => NOT FOUND: %s, returning empty list", path, err)
+      return []
+    # Create a list of directory entries in the format expected below.
+    return [{"name": name, "type": "file" if value is None else "directory"}
+            for name, value in curDir.items()]
+  return listDir
+
+def sync(pub, architectures, endpointUrl, bucket, baseUrl, basePrefix, rules,
+         includeFirst, autoIncludeDeps, notifEmail, dryRun, connParams):
 
   # Template URLs
   packNamesPathTpl = "%(arch)s/dist-direct"
-  distPathTpl      = "%(arch)s/%(dist)s/%(pack)s/%(pack)s-%(ver)s"
+  distPathTpl      = "%(arch)s/dist%(dist)s/%(pack)s/%(pack)s-%(ver)s"
   verPathTpl       = "%(arch)s/dist-direct/%(pack)s"
-  getPackUrlTpl    = "%(baseUrl)s/%(basePrefix)s/%(arch)s/dist-direct/%(pack)s/%(pack)s-%(ver)s/%(pack)s-%(ver)s.%(arch)s.tar.gz"
-
-  def listDir(path):
-    url = format("%(base)s?prefix=%(prefix)s/%(path)s/",
-                 base=baseUrl, prefix=basePrefix, path=path)
-    debug("Getting directory contents for " + url)
-    # This is a list of all file names under path (recursively).
-    files = requests.get(url, verify=connParams["http_ssl_verify"],
-                         timeout=connParams["conn_timeout_s"]) \
-                    .text.splitlines()
-    # Directories aren't listed separately, so we add a directory if we see a
-    # file inside it. This means that directories can be added multiple times
-    # (if they contain multiple files), so deduplicate by using a set here.
-    contents = set()
-    # The server returns file names with this prefix, which we want to ignore.
-    strip = basePrefix + "/" + path + "/"
-    for filename in files:
-      # Strip prefix and path from returned file names
-      if filename.startswith(strip):
-        filename = filename[len(strip):]
-      # We only care about the immediate contents of path, so if the file name
-      # contains a / after stripping path, we know it's a directory with some
-      # contents. In that case, only track the directory. If no / remains, it
-      # must be a file directly under path.
-      name, is_dir, _ = filename.partition("/")
-      if (is_dir and incl_dirs) or (not is_dir and incl_files):
-        contents.add((name, "directory" if is_dir else "file"))
-    # Create a list of directory entries in the format expected below.
-    return [{"name": name, "type": ftype} for name, ftype in contents]
+  getPackUrlTpl    = ("%(baseUrl)s/%(basePrefix)s/%(arch)s/dist-direct/%(pack)s"
+                      "/%(pack)s-%(ver)s/%(pack)s-%(ver)s.%(arch)s.tar.gz")
+  # The path templates (first 3 above) all have a common prefix --
+  # %(arch)s/dist. getS3PackageLister can use this prefix to narrow down the
+  # file list it retrieves from the server, to save some time.
+  listDir = getS3PackageLister(endpointUrl, bucket, basePrefix, architectures,
+                               pathCommonPrefix="dist")
+  newPackages = {}
 
   # Prepare the list of packages to install
   for arch in architectures:
     newPackages[arch] = []
 
     # Get valid package names for this architecture
-    distPackages = sorted((p["name"] for p in listDir(format(packNamesPathTpl, arch=arch),
-                                                      incl_files=False)),
-                          key=len, reverse=True)
+    debug("Getting packages for architecture %s", arch)
+    distPackages = sorted(
+      (p["name"] for p in listDir(packNamesPathTpl % {"arch": arch})
+       if p["type"] == "directory"),
+      key=len, reverse=True)
     debug("Packages found: %s", ", ".join(distPackages))
 
     # Packages to publish
@@ -543,7 +590,9 @@ def sync(pub, architectures, baseUrl, basePrefix, rules,
         continue
       if not includeFirst and rules["exclude"][arch].get(pkgName) == True:
         continue
-      for pkgTar in listDir(format(verPathTpl, arch=arch, pack=pkgName), incl_files=False):
+      for pkgTar in listDir(format(verPathTpl, arch=arch, pack=pkgName)):
+        if pkgTar["type"] != "directory":
+          continue
         nameVer = nameVerFromTar(pkgTar["name"], arch, [pkgName])
         if nameVer is None:
           continue
@@ -564,9 +613,9 @@ def sync(pub, architectures, baseUrl, basePrefix, rules,
 
         # At this point we have filtered in the package: let's see its dependencies!
         # Note that a package always depends on itself (list cannot be empty).
-        distPath = format(distPathTpl, dist="dist-runtime",
+        distPath = format(distPathTpl, dist="-runtime",
                           arch=arch, pack=pkgName, ver=pkgVer)
-        runtimeDeps = listDir(distPath, incl_dirs=False)
+        runtimeDeps = listDir(distPath)
         if not runtimeDeps:
           error(format("%(arch)s / %(pack)s / %(ver)s: cannot list dependencies from %(url)s: skipping",
                        arch=arch, pack=pkgName, ver=pkgVer, url=distPath))
@@ -574,6 +623,8 @@ def sync(pub, architectures, baseUrl, basePrefix, rules,
         debug(format("%(arch)s / %(pack)s / %(ver)s: listing all dependencies under %(url)s",
                      arch=arch, pack=pkgName, ver=pkgVer, url=distPath))
         for depTar in runtimeDeps:
+          if depTar["type"] != "file":
+            continue
           depNameVer = nameVerFromTar(depTar["name"], arch, distPackages)
           if depNameVer is None:
             continue
@@ -604,10 +655,9 @@ def sync(pub, architectures, baseUrl, basePrefix, rules,
       # Get direct and indirect dependencies
       deps = {}
       depFail = False
-      for key in ("dist", "dist-direct", "dist-runtime"):
+      for key in ("", "-direct", "-runtime"):
         jdeps = listDir(format(distPathTpl, dist=key, arch=arch,
-                               pack=pack["name"], ver=pack["ver"]),
-                        incl_dirs=False)
+                               pack=pack["name"], ver=pack["ver"]))
         if not jdeps:
           error(format("%(arch)s / %(pack)s / %(ver)s: cannot get %(dtype)s dependencies: skipping",
                        arch=arch, pack=pack["name"], ver=pack["ver"], dtype=key))
@@ -748,14 +798,6 @@ def hostport(s, defaultPort):
   host = host[0]
   return host,port
 
-def mesos_resolve(host, dns, jget):
-  for d in sorted(dns, key=lambda k: random()):
-    ips = [ x["ip"] for x in jget(format("http://%(dns)s/v1/hosts/%(host)s", dns=d, host=host))
-                    if x.get("ip", None) ]
-    if ips:
-      return ips
-  return [host]  # fallback to input on error
-
 def main():
   parser = ArgumentParser()
   parser.add_argument("action", metavar="sync-cvmfs|sync-dir|sync-alien|sync-rpms|test-rules")
@@ -840,9 +882,6 @@ def main():
   if not isinstance(conf.get("architectures", None), dict):
     error("architectures must be a dict of dicts")
     doExit = True
-  if not isinstance(conf.get("base_url", None), basestring):
-    error("base_url must be a string")
-    doExit = True
   conf["auto_include_deps"] = conf.get("auto_include_deps", True)
   if not isinstance(conf["auto_include_deps"], bool):
     error("auto_include_deps must be a boolean")
@@ -856,12 +895,6 @@ def main():
     doExit = True
 
   if doExit: exit(1)
-
-  # Resolve base_url name via Mesos
-  us = urlsplit(conf["base_url"])
-  if us.netloc.endswith(".mesos") and conf["mesos_dns"] and args.action != "test-rules":
-    us = us._replace( netloc=choice(mesos_resolve(us.netloc, conf["mesos_dns"], jget)) )
-    conf["base_url"] = urlunsplit(us)
 
   debug("Configuration: " + json.dumps(conf, indent=2))
   incexc = conf.get("filter_order", "include,exclude")
@@ -971,6 +1004,8 @@ def main():
     debug("Architecture names mappings: %s" % json.dumps(architectures, indent=2))
     r = sync(pub=pub,
              architectures=architectures,
+             endpointUrl=conf["s3_endpoint_url"],
+             bucket=conf["s3_bucket"],
              baseUrl=conf["base_url"],
              basePrefix=conf["base_prefix"],
              rules=rules,

--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -566,8 +566,10 @@ def sync(pub, architectures, endpointUrl, bucket, baseUrl, basePrefix, rules,
 
     # Packages installation
     for pack in pubPackages:
-      pkgUrl = format(getPackUrlTpl, baseUrl=baseUrl, basePrefix=basePrefix,
-                      arch=arch, pack=pack["name"], ver=pack["ver"])
+      pkgUrl = format(getPackUrlTpl,
+                      baseUrl=baseUrl.rstrip("/"),
+                      basePrefix=basePrefix, arch=arch,
+                      pack=pack["name"], ver=pack["ver"])
 
       if pub.installed(architectures[arch], pack["name"], pack["ver"]):
         debug("%s / %s / %s: already installed: skipping",

--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import logging, sys, json, yaml, errno, boto3
+import logging, sys, json, yaml, errno, boto3, requests
 from glob import glob
 from argparse import ArgumentParser
 from commands import getstatusoutput
@@ -566,11 +566,6 @@ def sync(pub, architectures, endpointUrl, bucket, baseUrl, basePrefix, rules,
 
     # Packages installation
     for pack in pubPackages:
-      pkgUrl = format(getPackUrlTpl,
-                      baseUrl=baseUrl.rstrip("/"),
-                      basePrefix=basePrefix, arch=arch,
-                      pack=pack["name"], ver=pack["ver"])
-
       if pub.installed(architectures[arch], pack["name"], pack["ver"]):
         debug("%s / %s / %s: already installed: skipping",
               arch, pack["name"], pack["ver"])
@@ -600,6 +595,17 @@ def sync(pub, architectures, endpointUrl, bucket, baseUrl, basePrefix, rules,
         x for x in deps["dist-direct"]
         if any(x["name"] == y["name"] for y in deps["dist-runtime"])
       ]
+
+      symlinkUrl = format(getPackUrlTpl,
+                          baseUrl=baseUrl.rstrip("/"),
+                          basePrefix=basePrefix, arch=arch,
+                          pack=pack["name"], ver=pack["ver"])
+      pkgUrl = join(baseUrl,
+                    requests.get(symlinkUrl,
+                                 verify=connParams["http_ssl_verify"],
+                                 timeout=connParams["conn_timeout_s"])
+                            .text.rstrip())
+
 
       # Here we can attempt the installation
       def prettyPrintPkgs(key):

--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -260,7 +260,7 @@ class RPM(object):
     self._dryRun = dryRun
     self._genUpdatableRpms = genUpdatableRpms
     self._repoDir = repoDir
-    self._stageDir = join(repoDir, "staging")
+    self._stageDir = mkdtemp(prefix="staging-", dir=repoDir)
     self._publishScriptTpl = publishScriptTpl
     self._countChanges = 0
     self._connParams = connParams
@@ -297,7 +297,7 @@ class RPM(object):
 
     stageDirArch = join(self._stageDir, arch)
     if not self._dryRun:
-      workDir = mkdtemp(prefix=join(self._stageDir, "tmp", "aliPublish-RPM-"))
+      workDir = mkdtemp(prefix="aliPublish-RPM-", dir=join(self._stageDir, "tmp"))
     else:
       workDir = "/dryrun_doesnotexist"
 
@@ -620,7 +620,7 @@ def sync(pub, architectures, endpointUrl, bucket, baseUrl, basePrefix, rules,
       if not pub.transaction():
         sys.exit(2)  # fatal
       rv = pub.install(pkgUrl, architectures[arch], pack["name"], pack["ver"],
-                        deps["dist-direct-runtime"], deps["dist-runtime"])
+                       deps["dist-direct-runtime"], deps["dist-runtime"])
       newPackages[arch].append({
         "name": pack["name"],
         "ver": pack["ver"],

--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -1,24 +1,19 @@
 #!/usr/bin/env python
 
-import logging, sys, json, yaml, requests, urllib3, errno, boto3
+import logging, sys, json, yaml, errno, boto3
 from glob import glob
 from argparse import ArgumentParser
 from commands import getstatusoutput
 from datetime import datetime
-from requests import RequestException
-from time import sleep, time
-from yaml import YAMLError
+from time import time
 from logging import debug, info, warning, error
-from re import search, escape, sub
+from re import search, escape
 from os.path import isdir, isfile, realpath, dirname, getmtime, join, basename
 from os import chmod, remove, chdir, getcwd, getpid, kill, makedirs, rename, environ
 from shutil import rmtree
 from tempfile import NamedTemporaryFile, mkdtemp
 from subprocess import Popen, PIPE, STDOUT
 from smtplib import SMTP
-from socket import getfqdn
-from random import random, shuffle
-from urlparse import urlsplit, urlunsplit
 
 def format(s, **kwds):
   return s % kwds
@@ -46,102 +41,30 @@ def applyFilter(name, includeRules, excludeRules, includeFirst):
 
 def runInstallScript(script, dryRun, **kwsub):
   if dryRun:
-    debug(format("Dry run: publish script follows:\n" + script, **kwsub))
+    debug(("Dry run: publish script follows:\n" + script) % kwsub)
     return 0
   with NamedTemporaryFile(delete=False) as fp:
     fn = fp.name
     fp.write(format(script, **kwsub))
   chmod(fn, 0o700)
-  debug(format("Created unpack script: %(file)s", file=fn))
+  debug("Created unpack script: %s", fn)
   rv = execute(fn)
   remove(fn)
-  debug(format("Unpack script %(file)s returned %(rv)d", file=fn, rv=rv))
+  debug("Unpack script %s returned %d", fn, rv)
   return rv
 
 def execute(command):
   popen = Popen(command, shell=False, stdout=PIPE, stderr=STDOUT)
-  linesIterator = iter(popen.stdout.readline, "")
-  for line in linesIterator:
-    debug(line.strip("\n"))  # yield line
-  output = popen.communicate()[0]
-  debug(output)
-  exitCode = popen.returncode
-  return exitCode
+  for line in iter(popen.stdout.readline, ""):
+    debug("Script: %s", line.strip("\n"))  # yield line
+  output, _ = popen.communicate()
+  debug("Script returned: %s", output)
+  return popen.returncode
 
 def grabOutput(command):
-  debug("Executing command: " + " ".join(command))
+  debug("Executing command: %s", " ".join(command))
   popen = Popen(command, shell=False, stdout=PIPE, stderr=STDOUT)
-  out = popen.communicate()[0]
-  return (popen.returncode, out)
-
-class JGet(object):
-  def __init__(self, http_ssl_verify, conn_timeout_s, conn_retries, conn_dethrottle_s, cache_dir):
-    self.http_ssl_verify   = http_ssl_verify
-    self.conn_timeout_s    = conn_timeout_s
-    self.conn_retries      = conn_retries
-    self.conn_dethrottle_s = conn_dethrottle_s
-    self.last_ts           = time()
-    self.count_cached      = 0
-    self.count_req         = 0
-    self.count_req_retries = 0
-    self.cache_dir         = cache_dir
-    if cache_dir:
-      try:
-        makedirs(cache_dir)
-      except OSError as exc:
-        if not isdir(cache_dir) or exc.errno != errno.EEXIST:
-          error(format("Cannot create cache dir for package deps %(cache)s: disabling",
-                       cache=cache_dir))
-          self.cache_dir = None
-    self.urls              = []
-    self.cachable          = '/[^/]+/(dist|dist-runtime|dist-direct)/[^/]+/[^/]+/$'
-  def __call__(self, url):
-    self.count_req += 1
-    dethrottle = self.conn_dethrottle_s
-    cache_file = None
-    cache_status = "DIR"
-    m = search(self.cachable, url)
-    if self.cache_dir and m:
-      cache_file = join(self.cache_dir, sub("[^A-Za-z0-9-_]", "_", m.group(0)).strip("_")+".json")
-      try:
-        j = json.loads(open(cache_file).read())
-        debug("Using cached data for %s" % url)
-        self.count_cached += 1
-        self.urls.append({"url":url, "cached":"HIT"})
-        return j
-      except (IOError,ValueError):
-        pass
-
-    self.urls.append({"url":url, "cached": "MIS" if m else "DIR"})
-    for i in range(0,self.conn_retries+1):
-      pause_s = max(dethrottle-(time()-self.last_ts), 0)
-      debug(format("Dethrottling connection to %(url)s: pausing %(pause).2f second(s)",
-                   url=url, pause=pause_s))
-      sleep(pause_s)
-      try:
-        self.count_req_retries += 1
-        j = requests.get(url,
-                         verify=self.http_ssl_verify,
-                         timeout=self.conn_timeout_s).json()
-      except ValueError:
-        j = {}
-      except RequestException as e:
-        error(format("Error getting %(url)s, %(att)d attempt(s) left: %(msg)s",
-                     url=url,
-                     att=self.conn_retries-i,
-                     msg=str(e)))
-        dethrottle = 2*dethrottle
-        j = None
-      self.last_ts = time()
-      if j is not None:
-        if cache_file:
-          try:
-            with open(cache_file, "w") as jc:
-              jc.write(json.dumps(j))
-          except IOError as e:
-            error("Cannot cache %s: %s" % (url,e))
-        return j
-    return {}
+  return popen.returncode, popen.communicate()[0]
 
 class PublishException(Exception):
   pass
@@ -170,7 +93,7 @@ class PlainFilesystem(object):
 
   def installed(self, arch, pkgName, pkgVer):
     kw = self._kw(None, arch, pkgName, pkgVer)
-    debug(format("%(repo)s: checking if %(package)s %(version)s is installed for %(arch)s", **kw))
+    debug("%(repo)s: checking if %(package)s %(version)s is installed for %(arch)s" % kw)
     return isdir(kw["pkgdir"]) or isfile(kw["modulefile"])
 
   def install(self, url, arch, pkgName, pkgVer, deps, allDeps):
@@ -184,7 +107,7 @@ class PlainFilesystem(object):
 
   def _cleanup(self, arch, pkgName, pkgVer):
     kw = self._kw(None, arch, pkgName, pkgVer)
-    debug(format("%(repo)s: cleaning up %(pkgdir)s and %(modulefile)s", **kw))
+    debug("%(repo)s: cleaning up %(pkgdir)s and %(modulefile)s" % kw)
     rmrf(kw["pkgdir"])
     rmrf(kw["modulefile"])
 
@@ -209,57 +132,56 @@ class CvmfsServer(PlainFilesystem):
 
   def transaction(self):
     if self._inCvmfsTransaction:
-      debug(format("%(repo)s: already in a transaction", repo=self._repository))
+      debug("%s: already in a transaction", self._repository)
       return True
     elif self._dryRun:
-      info(format("%(repo)s: started transaction (dry run)", repo=self._repository))
+      info("%s: started transaction (dry run)", self._repository)
       self._inCvmfsTransaction = True
       return True
     else:
       if execute([ "cvmfs_server", "transaction", self._repository ]) == 0:
-        info(format("%(repo)s: started transaction", repo=self._repository))
+        info("%s: started transaction", self._repository)
         self._inCvmfsTransaction = True
         return True
-      error(format("%(repo)s: cannot commence transaction: maybe another one is in progress?",
-                   repo=self._repository))
+      error("%s: cannot commence transaction: maybe another one is in progress?",
+            self._repository)
       return False
 
   def abort(self, force=False):
     if not self._inCvmfsTransaction and not force:
-      debug(format("%(repo)s: no transaction to abort", repo=self._repository))
+      debug("%s: no transaction to abort", self._repository)
       return True
     if self._dryRun and not force:
-      info(format("%(repo)s: transaction aborted (dry run)", repo=self._repository))
+      info("%s: transaction aborted (dry run)", self._repository)
       self._inCvmfsTransaction = False
       return True
     rv = execute([ "cvmfs_server", "abort", "-f", self._repository ])
     if rv == 0:
-      info(format("%(repo)s: transaction aborted", repo=self._repository))
+      info("%s: transaction aborted", self._repository)
       self._inCvmfsTransaction = False
       return True
-    error(format("%(repo)s: cannot abort transaction", repo=self._repository))
+    error("%s: cannot abort transaction", self._repository)
     return False
 
   def publish(self):
     if not self._inCvmfsTransaction:
-      debug(format("%(repo)s: not in a transaction", repo=self._repository))
+      debug("%s: not in a transaction", self._repository)
       return True
     if not self._countChanges:
-      debug(format("%(repo)s: nothing to publish, cancelling transaction", repo=self._repository))
+      debug("%s: nothing to publish, cancelling transaction", self._repository)
       return self.abort()
-    info(format("%(repo)s: publishing transaction, %(npkg)d new package(s)",
-                repo=self._repository, npkg=self._countChanges))
+    info("%s: publishing transaction, %d new package(s)",
+         self._repository, self._countChanges)
     if self._dryRun:
-      info(format("%(repo)s: transaction published (dry run)", repo=self._repository))
+      info("%s: transaction published (dry run)", self._repository)
       return True
     rv = execute([ "cvmfs_server", "publish", self._repository ])
     if rv == 0:
-      info(format("%(repo)s: transaction published!", repo=self._repository))
+      info("%s: transaction published!", self._repository)
       self._inCvmfsTransaction = False
       return True
     else:
-      error(format("%(repo)s: cannot publish CVMFS transaction, aborting",
-            repo=self._repository))
+      error("%s: cannot publish CVMFS transaction, aborting", self._repository)
       self.abort()
       return False
 
@@ -281,7 +203,7 @@ class AliEnPackMan(object):
 
   def installed(self, arch, pkgName, pkgVer):
     kw = self._kw(None, arch, pkgName, pkgVer, None)
-    debug(format("PackMan: checking if %(package)s %(version)s is installed for %(arch)s", **kw))
+    debug("PackMan: checking if %(package)s %(version)s is installed for %(arch)s" % kw)
 
     if self._packs is None:
       self._packs = {}
@@ -366,7 +288,7 @@ class RPM(object):
 
   def installed(self, arch, pkgName, pkgVer):
     kw = self._kw(None, arch, pkgName, pkgVer)
-    debug(format("RPM: checking if %(rpm)s exists for %(package)s %(version)s on %(arch)s", **kw))
+    debug("RPM: checking if %(rpm)s exists for %(package)s %(version)s on %(arch)s" % kw)
     return isfile(format("%(repodir)s/%(rpm)s", **kw))
 
   def install(self, url, arch, pkgName, pkgVer, deps, allDeps):
@@ -383,13 +305,13 @@ class RPM(object):
                   " ".join(["alisw-%s+%s" % (x["name"], x["ver"]) for x in deps]))
 
     if not self._dryRun:
-      debug(format("RPM: created temporary working directory %(workdir)s", **kw))
-      debug(format("RPM: creating staging directory %(staging)s", staging=stageDirArch))
+      debug("RPM: created temporary working directory %(workdir)s" % kw)
+      debug("RPM: creating staging directory %s", stageDirArch)
       try:
         makedirs(stageDirArch)
       except OSError as exc:
         if not isdir(stageDirArch) or exc.errno != errno.EEXIST:
-          error(format("RPM: error creating staging directory %(staging)s", staging=stageDirArch))
+          error("RPM: error creating staging directory %s", stageDirArch)
           return 1
 
     rv = runInstallScript(self._publishScriptTpl, self._dryRun, **kw)
@@ -397,36 +319,35 @@ class RPM(object):
       if not arch in self._archs:
         self._archs.append(arch)
       self._countChanges += 1
-    debug(format("RPM: removing temporary working directory %(workdir)s", **kw))
+    debug("RPM: removing temporary working directory %(workdir)s" % kw)
     rmrf(workDir)
     return rv
 
   def transaction(self):
     if not self._inRpmTransaction and not self._dryRun:
       self._inRpmTransaction = True
-      debug(format("RPM: cleaning up staging dir %(staging)s", staging=self._stageDir))
+      debug("RPM: cleaning up staging dir %s", self._stageDir)
       rmrf(self._stageDir)
       stagingTmp = join(self._stageDir, "tmp")
-      debug(format("RPM: creating staging tempdir %(staging)s", staging=stagingTmp))
+      debug("RPM: creating staging tempdir %s", stagingTmp)
       try:
         makedirs(stagingTmp)
       except OSError as exc:
         if not isdir(stagingTmp) or exc.errno != errno.EEXIST:
-          error(format("RPM: error creating staging tempdir %(staging)s", staging=stagingTmp))
+          error("RPM: error creating staging tempdir %s", stagingTmp)
           return False
     return True
 
   def abort(self, force=False):
     if self._inRpmTransaction and not self._dryRun:
-      debug(format("RPM: aborting: cleaning up staging dir %(staging)s", staging=self._stageDir))
+      debug("RPM: aborting: cleaning up staging dir %s", self._stageDir)
       rmrf(self._stageDir)
       self._inRpmTransaction = False
     return True
 
   def publish(self):
     if self._countChanges > 0:
-      info(format("RPM: updating repository: %(npkgs)s new package(s)",
-           npkgs=self._countChanges))
+      info("RPM: updating repository: %s new package(s)", self._countChanges)
       if not self._dryRun:
         for arch in self._archs:
           cachedir = join(self._repoDir, "createrepo_cachedir", arch)
@@ -437,35 +358,33 @@ class RPM(object):
             makedirs(cachedir)
           except OSError as exc:
             if not isdir(cachedir) or exc.errno != errno.EEXIST:
-              error(format("RPM: error creating createrepo cachedir %(cachedir)s", cachedir=cachedir))
+              error("RPM: error creating createrepo cachedir %s", cachedir)
               return False
 
           try:
             makedirs(archdir)
           except OSError as exc:
             if not isdir(archdir) or exc.errno != errno.EEXIST:
-              error(format("RPM: error creating repository dir %(archdir)s", archdir=archdir))
+              error("RPM: error creating repository dir %s", archdir)
               return False
 
-          info(format("RPM: moving newly created packages from %(staging)s to %(repo)s",
-                      staging=stagedir, repo=archdir))
+          info("RPM: moving newly created packages from %s to %s", stagedir, archdir)
           for srcRpm in glob(join(stagedir, "*.rpm")):
             try:
-              info(format("RPM: moving %(staged)s to %(archdir)s", staged=srcRpm, archdir=archdir))
+              info("RPM: moving %s to %s", srcRpm, archdir)
               rename(srcRpm, join(archdir, basename(srcRpm)))
             except OSError:
-              error(format("RPM: cannot move %(staged)s to %(archdir)s",
-                    staged=srcRpm, archdir=archdir))
+              error("RPM: cannot move %s to %s", srcRpm, archdir)
 
-          # We can already remove the staging directory before calling `createrepo`. Errors here are
-          # not fatal
-          debug(format("RPM: removing staging directory %(staging)s", staging=self._stageDir))
+          # We can already remove the staging directory before calling
+          # `createrepo`. Errors here are not fatal.
+          debug("RPM: removing staging directory %s", self._stageDir)
           rmrf(self._stageDir)
 
           if execute([ "time", "createrepo", "--cachedir", cachedir, "--update", archdir ]) == 0:
-            info(format("RPM: repository updated for %(arch)s", arch=arch))
+            info("RPM: repository updated for %s", arch)
           else:
-            error(format("RPM: error updating repository for %(arch)s", arch=arch))
+            error("RPM: error updating repository for %s", arch)
             return False
         return True
       elif self._dryRun:
@@ -484,6 +403,10 @@ def nameVerFromTar(tar, arch, validPacks):
     if vm:
       return { "name": vm.group(1), "ver": vm.group(2) }
   return None
+
+def prettyPrintPkg(pkg):
+  """Return a human-readable representation of the package."""
+  return pkg["name"] + " " + pkg["ver"]
 
 def getS3PackageLister(endpointUrl, bucket, basePrefix, architectures,
                        pathCommonPrefix):
@@ -617,11 +540,11 @@ def sync(pub, architectures, endpointUrl, bucket, baseUrl, basePrefix, rules,
                           arch=arch, pack=pkgName, ver=pkgVer)
         runtimeDeps = listDir(distPath)
         if not runtimeDeps:
-          error(format("%(arch)s / %(pack)s / %(ver)s: cannot list dependencies from %(url)s: skipping",
-                       arch=arch, pack=pkgName, ver=pkgVer, url=distPath))
+          error("%s / %s / %s: cannot list dependencies from %s: skipping",
+                arch, pkgName, pkgVer, distPath)
           continue
-        debug(format("%(arch)s / %(pack)s / %(ver)s: listing all dependencies under %(url)s",
-                     arch=arch, pack=pkgName, ver=pkgVer, url=distPath))
+        debug("%s / %s / %s: listing all dependencies under %s",
+              arch, pkgName, pkgVer, distPath)
         for depTar in runtimeDeps:
           if depTar["type"] != "file":
             continue
@@ -631,16 +554,15 @@ def sync(pub, architectures, endpointUrl, bucket, baseUrl, basePrefix, rules,
           depName = depNameVer["name"]
           depVer = depNameVer["ver"]
           # Append only if it does not exist yet
-          if len([p for p in pubPackages if p["name"]==depName and p["ver"]==depVer]) == 0:
-            debug(format("%(arch)s / %(pack)s / %(ver)s: adding %(depName)s %(depVer)s to publish",
-                  arch=arch, pack=pkgName, ver=pkgVer, url=distPath,
-                  depName=depName, depVer=depVer))
-            pubPackages.append({ "name": depName, "ver": depVer })
+          if not any(p["name"] == depName and p["ver"] == depVer
+                     for p in pubPackages):
+            debug("%s / %s / %s: adding %s %s to publish",
+                  arch, pkgName, pkgVer, depName, depVer)
+            pubPackages.append({"name": depName, "ver": depVer})
 
     pubPackages.sort(key=lambda itm: itm["name"])
-    debug(format("%(arch)s: %(npacks)d package(s) candidate for publication: %(packs)s",
-                 arch=arch, npacks=len(pubPackages),
-                 packs=", ".join([p["name"]+" "+p["ver"] for p in pubPackages])))
+    debug("%s: %d package(s) candidate for publication: %s",
+          arch, len(pubPackages), ", ".join(map(prettyPrintPkg, pubPackages)))
 
     # Packages installation
     for pack in pubPackages:
@@ -648,8 +570,8 @@ def sync(pub, architectures, endpointUrl, bucket, baseUrl, basePrefix, rules,
                       arch=arch, pack=pack["name"], ver=pack["ver"])
 
       if pub.installed(architectures[arch], pack["name"], pack["ver"]):
-        debug(format("%(arch)s / %(pack)s / %(ver)s: already installed: skipping",
-                     arch=arch, pack=pack["name"], ver=pack["ver"]))
+        debug("%s / %s / %s: already installed: skipping",
+              arch, pack["name"], pack["ver"])
         continue
 
       # Get direct and indirect dependencies
@@ -659,68 +581,66 @@ def sync(pub, architectures, endpointUrl, bucket, baseUrl, basePrefix, rules,
         jdeps = listDir(format(distPathTpl, dist=key, arch=arch,
                                pack=pack["name"], ver=pack["ver"]))
         if not jdeps:
-          error(format("%(arch)s / %(pack)s / %(ver)s: cannot get %(dtype)s dependencies: skipping",
-                       arch=arch, pack=pack["name"], ver=pack["ver"], dtype=key))
-          newPackages[arch].append({ "name": pack["name"], "ver": pack["ver"], "success": False })
+          error("%s / %s / %s: cannot get %s dependencies: skipping",
+                arch, pack["name"], pack["ver"], key)
+          newPackages[arch].append({
+            "name": pack["name"], "ver": pack["ver"], "success": False})
           depFail = True
           break
-        deps[key] = [ nameVerFromTar(x["name"], arch, distPackages)
-                      for x in jdeps if x["type"] == "file" ]
-        deps[key] = [ x for x in deps[key] if (x is not None and
-                                               x["name"] != pack["name"]) ]
+        deps[key] = [nameVerFromTar(x["name"], arch, distPackages)
+                     for x in jdeps if x["type"] == "file"]
+        deps[key] = [x for x in deps[key]
+                     if x is not None and x["name"] != pack["name"]]
       if depFail:
         continue
-      # dist-direct-runtime: all entries in dist-direct but not in dist-runtime
-      deps["dist-direct-runtime"] = [ x for x in deps["dist-direct"]
-                                      if [ 1 for y in deps["dist-runtime"]
-                                           if x["name"] == y["name"] ] ]
+      # dist-direct-runtime: all entries in dist-direct also in dist-runtime
+      deps["dist-direct-runtime"] = [
+        x for x in deps["dist-direct"]
+        if any(x["name"] == y["name"] for y in deps["dist-runtime"])
+      ]
 
       # Here we can attempt the installation
-      info(format("%(arch)s / %(pack)s / %(ver)s: getting and installing",
-                  arch=arch, pack=pack["name"], ver=pack["ver"]))
-      info(" * Source: %s" % pkgUrl)
-      info(" * Direct deps: %s" % ", ".join([i["name"]+" "+i["ver"] for i in deps["dist-direct"]]))
-      info(" * All deps: %s" % ", ".join([i["name"]+" "+i["ver"] for i in deps["dist"]]))
-      info(" * Direct runtime deps: %s" % ", ".join([i["name"]+" "+i["ver"] for i in deps["dist-direct-runtime"]]))
-      info(" * Runtime deps: %s" % ", ".join([i["name"]+" "+i["ver"] for i in deps["dist-runtime"]]))
+      def prettyPrintPkgs(key):
+        return ", ".join(map(prettyPrintPkg, deps[key]))
+      info("%s / %s / %s: getting and installing", arch, pack["name"], pack["ver"])
+      info(" * Source: %s", pkgUrl)
+      info(" * Direct deps: %s", prettyPrintPkgs("dist-direct"))
+      info(" * All deps: %s", prettyPrintPkgs("dist"))
+      info(" * Direct runtime deps: %s", prettyPrintPkgs("dist-direct-runtime"))
+      info(" * Runtime deps: %s", prettyPrintPkgs("dist-runtime"))
 
       if not pub.transaction():
         sys.exit(2)  # fatal
-      else:
-        rv = pub.install(pkgUrl, architectures[arch], pack["name"], pack["ver"],
-                         deps["dist-direct-runtime"], deps["dist-runtime"])
-        newPackages[arch].append({ "name": pack["name"],
-                                   "ver": pack["ver"],
-                                   "success": (rv==0),
-                                   "deps": deps["dist-direct-runtime"],
-                                   "alldeps": deps["dist-runtime"] })
+      rv = pub.install(pkgUrl, architectures[arch], pack["name"], pack["ver"],
+                        deps["dist-direct-runtime"], deps["dist-runtime"])
+      newPackages[arch].append({
+        "name": pack["name"],
+        "ver": pack["ver"],
+        "success": rv == 0,
+        "deps": deps["dist-direct-runtime"],
+        "alldeps": deps["dist-runtime"],
+      })
       if rv == 0:
-        info(format("%(arch)s / %(pack)s / %(ver)s: installed successfully",
-                     arch=arch, pack=pack["name"], ver=pack["ver"]))
+        info("%s / %s / %s: installed successfully",
+             arch, pack["name"], pack["ver"])
       else:
-        error(format("%(arch)s / %(pack)s / %(ver)s: publish script failed with %(rv)d",
-                     arch=arch, pack=pack["name"], ver=pack["ver"], rv=rv))
+        error("%s / %s / %s: publish script failed with %d",
+              arch, pack["name"], pack["ver"], rv)
 
   # Publish eventually
   if pub.publish():
     totSuccess = 0
     totFail = 0
-    for arch,packStatus in newPackages.iteritems():
-      nSuccess = sum([1 for x in packStatus if x["success"]])
+    for arch, packStatus in newPackages.iteritems():
+      nSuccess = sum(1 for x in packStatus if x["success"])
       nFail = len(packStatus) - nSuccess
-      totSuccess = totSuccess + nSuccess
-      totFail = totFail + nFail
-      info(format("%(arch)s: install OK for %(nSuccess)d/%(nPacks)d package(s): %(successPacks)s",
-           arch=arch,
-           nSuccess=nSuccess,
-           nPacks=len(packStatus),
-           successPacks=", ".join([x["name"]+" "+x["ver"] for x in packStatus if x["success"]])))
+      totSuccess += nSuccess
+      totFail += nFail
+      info("%s: install OK for %d/%d package(s): %s", arch, nSuccess, len(packStatus),
+           ", ".join(prettyPrintPkg(x) for x in packStatus if x["success"]))
       if nFail:
-        error(format("%(arch)s: install failed for %(nFail)d/%(nPacks)d package(s): %(failedPacks)s",
-              arch=arch,
-              nFail=nFail,
-              nPacks=len(packStatus),
-              failedPacks=", ".join([x["name"]+" "+x["ver"] for x in packStatus if not x["success"]])))
+        error("%s: install failed for %d/%d package(s): %s", arch, nFail, len(packStatus),
+              ", ".join(prettyPrintPkg(x) for x in packStatus if not x["success"]))
     if notifEmail:
       notify(notifEmail, architectures, newPackages, dryRun)
     else:
@@ -735,59 +655,58 @@ def notify(conf, archs, pack, dryRun):
   try:
     mailer = SMTP(conf["server"], conf.get("port", 25))
   except Exception as e:
-    error("Email notification: cannot connect to %s" % conf["server"])
+    error("Email notification: cannot connect to %s", conf["server"])
     return
-  for arch,packs in pack.iteritems():
+  for arch, packs in pack.iteritems():
     for p in packs:
       key = "success" if p["success"] else "failure"
-      deps_fmt = "".join([ format(conf.get("package_format", "%(package)s %(version)s "),
-                                   package=x["name"],
-                                   version=x["ver"],
-                                   arch=archs[arch]) for x in p.get("alldeps", []) ])
-      kw =  { "package": p["name"],
-              "version": p["ver"],
-              "arch": archs[arch],
-              "dependencies_fmt":
-                "".join([
-                          format(conf.get("package_format", "%(package)s %(version)s "),
-                                 package=x["name"], version=x["ver"], arch=archs[arch])
-                          for x in p.get("deps", [])
-                 ]),
-              "alldependencies_fmt":
-                "".join([
-                          format(conf.get("package_format", "%(package)s %(version)s "),
-                                 package=x["name"], version=x["ver"], arch=archs[arch])
-                          for x in p.get("alldeps", [])
-                ])
-            }
+      deps_fmt = "".join(format(conf.get("package_format", "%(package)s %(version)s "),
+                                package=x["name"],
+                                version=x["ver"],
+                                arch=archs[arch]) for x in p.get("alldeps", []))
+      kw = {
+        "package": p["name"],
+        "version": p["ver"],
+        "arch": archs[arch],
+        "dependencies_fmt": "".join(
+          format(conf.get("package_format", "%(package)s %(version)s "),
+                 package=x["name"], version=x["ver"], arch=archs[arch])
+          for x in p.get("deps", [])),
+        "alldependencies_fmt": "".join(
+          format(conf.get("package_format", "%(package)s %(version)s "),
+                 package=x["name"], version=x["ver"], arch=archs[arch])
+          for x in p.get("alldeps", [])),
+      }
 
-      body = format(conf.get(key, {}).get("body", ""), **kw)
-      subj = format(conf.get(key, {}).get("subject", "%(package)s %(version)s: "+key), **kw)
+      body = conf.get(key, {}).get("body", "") % kw
+      subj = conf.get(key, {}).get("subject", "%(package)s %(version)s: " + key) % kw
 
       to = conf.get(key, {}).get("to", "")
       if isinstance(to, dict):
         to = to.get(p["name"], to.get("default", ""))
       if isinstance(to, list):
         to = ",".join(to)
-      to = [ x.strip() for x in to.split(",") ] if to else []
+      to = [x.strip() for x in to.split(",")] if to else []
 
-      sender = format(conf.get(key, {}).get("from", "noreply@localhost"), **kw)
-      if body == "" or not to:
-        debug(format("Not sending email notification for %(package)s %(version)s (%(arch)s)",
-                     package=p["name"], version=p["ver"], arch=archs[arch]))
+      sender = conf.get(key, {}).get("from", "noreply@localhost") % kw
+      if not body or not to:
+        debug("Not sending email notification for %s %s (%s)",
+              p["name"], p["ver"], archs[arch])
         continue
-      body = ("Subject: %s\nFrom: %s\nTo: %s\n\n" % (subj, sender, ", ".join(to))) + body
+      body = ("Subject: %s\nFrom: %s\nTo: %s\n\n%s" %
+              (subj, sender, ", ".join(to), body))
       if dryRun:
-        debug(format("Notification email for %(package)s %(version)s (%(arch)s) follows:\n%(body)s",
-                     package=p["name"], version=p["ver"], arch=archs[arch], body=body))
-      else:
-        try:
-          mailer.sendmail(sender, to, body)
-          debug(format("Sent email notification for %(package)s %(version)s (%(arch)s)",
-                       package=p["name"], version=p["ver"], arch=archs[arch]))
-        except Exception as e:
-          error(format("Cannot send email notification for %(package)s %(version)s (%(arch)s)",
-                       package=p["name"], version=p["ver"], arch=archs[arch]))
+        debug("Notification email for %s %s (%s) follows:\n%s",
+              p["name"], p["ver"], archs[arch], body)
+        continue
+      try:
+        mailer.sendmail(sender, to, body)
+      except Exception as e:
+        error("Cannot send email notification for %s %s (%s): %s",
+              p["name"], p["ver"], archs[arch], e)
+        continue
+      debug("Sent email notification for %s %s (%s)",
+            p["name"], p["ver"], archs[arch])
 
 def hostport(s, defaultPort):
   host = s.split(":", 1)
@@ -817,8 +736,6 @@ def main():
                       help="Do not write or publish anything")
   parser.add_argument("--pidfile", "-p", dest="pidFile", default=None,
                       help="Write PID to this file and do not run if already running")
-  parser.add_argument("--cache-deps-dir", dest="cacheDepsDir", default=None,
-                      help="Directory where to cache package dependencies (optional)")
   parser.add_argument("--override", dest="override", nargs="+",
                       help="Override configuration options in JSON format")
   args = parser.parse_args()
@@ -833,51 +750,41 @@ def main():
   logger = logging.getLogger()
   loggerHandler = logging.StreamHandler()
   logger.addHandler(loggerHandler)
-
   loggerHandler.setFormatter(logging.Formatter('%(levelname)-5s: %(message)s'))
-  if args.debug: logger.setLevel(logging.DEBUG)
-  else: logger.setLevel(logging.INFO)
-
-  logging.getLogger("requests").setLevel(logging.WARNING)
-  logging.getLogger("urllib3").setLevel(logging.WARNING)
+  logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
 
   progDir = dirname(realpath(__file__))
 
   try:
-    debug(format("Reading configuration from %(configFile)s (current directory: %(curDir)s)",
-                 configFile=args.configFile, curDir=getcwd()))
+    debug("Reading configuration from %s (current directory: %s)",
+          args.configFile, getcwd())
     with open(args.configFile, "r") as cf:
       conf = yaml.safe_load(cf.read())
-  except (IOError, YAMLError) as e:
-    error(format("While reading %(configFile)s: " + str(e), configFile=args.configFile))
-    sys.exit(1)
+  except (IOError, yaml.YAMLError) as e:
+    error("While reading %s: %s", args.configFile, e)
+    return 1
 
   if overrideConf:
-    debug("Overriding configuration: " + json.dumps(overrideConf, indent=2))
+    debug("Overriding configuration: %s", json.dumps(overrideConf, indent=2))
     conf.update(overrideConf)
 
   if conf is None: conf = {}
   if conf.get("include", None) is None: conf["include"] = {}
   if conf.get("exclude", None) is None: conf["exclude"] = {}
-  conf["http_ssl_verify"]   = conf.get("http_ssl_verify"  , True)
-  conf["conn_timeout_s"]    = conf.get("conn_timeout_s"   , 6.05)
-  conf["conn_retries"]      = conf.get("conn_retries"     , 3)
-  conf["conn_dethrottle_s"] = conf.get("conn_dethrottle_s", 0)
-  conf["kill_after_s"]      = conf.get("kill_after_s"     , 3600)
+  conf.setdefault("http_ssl_verify", True)
+  conf.setdefault("conn_timeout_s", 6.05)
+  conf.setdefault("conn_retries", 3)
+  conf.setdefault("conn_dethrottle_s", 0)
+  conf.setdefault("kill_after_s", 3600)
 
   doExit = False
 
-  conf["mesos_dns"] = [ ":".join(map(str, hostport(x, 8123))) for x in conf.get("mesos_dns", []) ]
-  shuffle(conf["mesos_dns"])
-
   # Connection handler
-  connParams = dict((k, conf[k]) for k in [ "http_ssl_verify", "conn_timeout_s",
-                                            "conn_retries", "conn_dethrottle_s" ])
-  connParams["cache_dir"] = args.cacheDepsDir
-  jget = JGet(**connParams)
+  connParams = {k: conf[k] for k in ("http_ssl_verify", "conn_timeout_s",
+                                     "conn_retries", "conn_dethrottle_s")}
 
-  conf["package_dir"] = conf.get("package_dir", conf.get("cvmfs_package_dir", None))
-  conf["modulefile"] = conf.get("modulefile", conf.get("cvmfs_modulefile", None))
+  conf.setdefault("package_dir", conf.get("cvmfs_package_dir", None))
+  conf.setdefault("modulefile", conf.get("cvmfs_modulefile", None))
 
   if not isinstance(conf.get("architectures", None), dict):
     error("architectures must be a dict of dicts")
@@ -896,13 +803,13 @@ def main():
 
   if doExit: exit(1)
 
-  debug("Configuration: " + json.dumps(conf, indent=2))
+  debug("Configuration: %s", json.dumps(conf, indent=2))
   incexc = conf.get("filter_order", "include,exclude")
   if incexc == "include,exclude": includeFirst = True
   elif incexc == "exclude,include": includeFirst = False
   else:
     error("filter_order can be include,exclude or exclude,include")
-    sys.exit(1)
+    return 1
 
   rules = { "include": {}, "exclude": {} }
   for arch,maps in conf["architectures"].iteritems():
@@ -928,7 +835,7 @@ def main():
         else:
           assert False, "Unhandled case: %s rule for %s (%s): general=%s, specific=%s" % (r, uk, arch, general, specific)
 
-  debug("Per architecture include/exclude rules: %s" % json.dumps(rules, indent=2))
+  debug("Per architecture include/exclude rules: %s", json.dumps(rules, indent=2))
 
   if args.action in [ "sync-cvmfs", "sync-dir", "sync-alien", "sync-rpms" ]:
     chdir("/")
@@ -939,19 +846,19 @@ def main():
         runningFor = time() - getmtime(args.pidFile)
         if runningFor > conf["kill_after_s"]:
           kill(otherPid, 9)
-          error("aliPublish with PID %d in overtime (%ds): killed" % (otherPid, runningFor))
+          error("aliPublish with PID %d in overtime (%ds): killed", otherPid, runningFor)
           otherPid = 0
       except (IOError, OSError, ValueError):
         otherPid = 0
       if otherPid:
-        error("aliPublish already running with PID %d for %ds" % (otherPid, runningFor))
-        sys.exit(1)
+        error("aliPublish already running with PID %d for %ds", otherPid, runningFor)
+        return 1
       try:
         with open(args.pidFile, "w") as f:
           f.write(str(getpid()))
       except IOError as e:
-        error("Cannot write pidfile %s, aborting" % args.pidFile)
-        sys.exit(1)
+        error("Cannot write pidfile %s, aborting", args.pidFile)
+        return 1
     if args.action in [ "sync-cvmfs", "sync-dir" ]:
       if not isinstance(conf["package_dir"], basestring):
         error("[cvmfs_]package_dir must be a string")
@@ -963,7 +870,7 @@ def main():
       if not isinstance(conf.get("cvmfs_repository", None), basestring):
         error("cvmfs_repository must be a string")
         doExit = True
-      if doExit: sys.exit(1)
+      if doExit: return 1
       archKey = "CVMFS"
       pub = CvmfsServer(repository=conf["cvmfs_repository"],
                         modulefileTpl=conf["modulefile"],
@@ -972,7 +879,7 @@ def main():
                         connParams=connParams,
                         dryRun=args.dryRun)
     elif args.action == "sync-dir":
-      if doExit: sys.exit(1)
+      if doExit: return 1
       archKey = "dir"
       pub = PlainFilesystem(modulefileTpl=conf["modulefile"],
                             pkgdirTpl=conf["package_dir"],
@@ -987,7 +894,7 @@ def main():
     else:
       if not isinstance(conf.get("rpm_repo_dir", None), basestring):
         error("rpm_repo_dir must be a string")
-        sys.exit(1)
+        return 1
       conf["rpm_updatable"] = conf.get("rpm_updatable", False)
       archKey = "RPM"
       pub = RPM(repoDir=conf["rpm_repo_dir"],
@@ -998,36 +905,30 @@ def main():
     if args.abort:
       pub.abort(force=True)
 
-    architectures = dict((arch, maps.get(archKey, arch) if isinstance(maps, dict) else arch)
-                         for (arch,maps) in conf["architectures"].iteritems())
-    architectures = dict((k,v) for (k,v) in architectures.iteritems() if v)
-    debug("Architecture names mappings: %s" % json.dumps(architectures, indent=2))
-    r = sync(pub=pub,
-             architectures=architectures,
-             endpointUrl=conf["s3_endpoint_url"],
-             bucket=conf["s3_bucket"],
-             baseUrl=conf["base_url"],
-             basePrefix=conf["base_prefix"],
-             rules=rules,
-             includeFirst=includeFirst,
-             autoIncludeDeps=conf["auto_include_deps"],
-             notifEmail=conf["notification_email"],
-             dryRun=args.dryRun,
-             connParams=connParams)
-    debug("Made %d unique HTTP requests (%d remote requests including retries, %d read from cache)" % \
-          (jget.count_req, jget.count_req_retries, jget.count_cached))
-    debug("Summary of requested URLs (DIR=direct access, HIT=cache hit, MIS=cache miss):")
-    for u in jget.urls:
-      debug("[%s] %s" % (u["cached"], u["url"]))
-    sys.exit(0 if r else 1)
-  elif args.action == "test-rules":
+    architectures = {arch: maps.get(archKey, arch) if isinstance(maps, dict) else arch
+                     for arch, maps in conf["architectures"].iteritems()}
+    architectures = {k: v for k, v in architectures.iteritems() if v}
+    debug("Architecture names mappings: %s", json.dumps(architectures, indent=2))
+    return int(not sync(pub=pub,
+                        architectures=architectures,
+                        endpointUrl=conf["s3_endpoint_url"],
+                        bucket=conf["s3_bucket"],
+                        baseUrl=conf["base_url"],
+                        basePrefix=conf["base_prefix"],
+                        rules=rules,
+                        includeFirst=includeFirst,
+                        autoIncludeDeps=conf["auto_include_deps"],
+                        notifEmail=conf["notification_email"],
+                        dryRun=args.dryRun,
+                        connParams=connParams))
+  if args.action == "test-rules":
     testRules = {}
 
     if args.pkgName and args.pkgVer and args.pkgArch:
       # Test rules using command-line arguments
       if args.testConf:
         parser.error("cannot specify at the same time a test file and --pkg* arguments")
-      testRules = { args.pkgArch: { args.pkgName: { args.pkgVer: True } } }
+      testRules = {args.pkgArch: {args.pkgName: {args.pkgVer: True}}}
 
     else:
       # Test rules by reading them from a configuration file
@@ -1039,13 +940,13 @@ def main():
         m = search("^aliPublish(|.*)\.conf$", args.configFile)
         if m:
           args.testConf = "test%s.yaml" % m.group(1)
-          debug("Using %s as default configuration file for tests" % args.testConf)
+          debug("Using %s as default configuration file for tests", args.testConf)
 
       try:
         testRules = yaml.safe_load(open(args.testConf).read())
-      except (IOError, YAMLError) as e:
-        error("Cannot open rules to test: %s" % e)
-        sys.exit(1)
+      except (IOError, yaml.YAMLError) as e:
+        error("Cannot open rules to test: %s", e)
+        return 1
 
     # At this point we have everything in testRules, let's test them
     for arch in testRules:
@@ -1055,17 +956,19 @@ def main():
                               rules["include"].get(arch, {}).get(pkg, None),
                               rules["exclude"].get(arch, {}).get(pkg, None),
                               includeFirst)
-          msg = ("%s: %s ver %s matches filters" if match else
-                 "%s: %s ver %s does NOT match filters") % (arch, pkg, ver)
+          msg = ("%s: %s ver %s matches filters%s" if match else
+                 "%s: %s ver %s does NOT match filters%s")
           if match != testRules[arch][pkg][ver]:
-            error(msg + (match and " but it should not" or " but it should"))
-            sys.exit(1)
-          info(msg)
-    info("All rules%s tested with success" % (" in "+args.testConf if args.testConf else ""))
-    sys.exit(0)
+            error(msg, arch, pkg, ver,
+                  " but it should not" if match else " but it should")
+            return 1
+          info(msg, arch, pkg, ver)
+    info("All rules%s tested with success",
+         " in "+args.testConf if args.testConf else "")
+    return 0
 
   else:
     parser.error("wrong action, see --help")
 
 if __name__ == "__main__":
-  main()
+  sys.exit(main())

--- a/publish/aliPublish-example.conf
+++ b/publish/aliPublish-example.conf
@@ -1,6 +1,7 @@
 # vim: set filetype=yaml:
 ---
-base_url: https://ali-ci.cern.ch/TARS
+base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
+base_prefix: TARS
 http_ssl_verify: False
 architectures:
   slc5_x86-64:

--- a/publish/aliPublish-example.conf
+++ b/publish/aliPublish-example.conf
@@ -1,8 +1,10 @@
 # vim: set filetype=yaml:
 ---
+s3_endpoint_url: https://s3.cern.ch
+s3_bucket: alibuild-repo
 base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
 base_prefix: TARS
-http_ssl_verify: False
+http_ssl_verify: True
 architectures:
   slc5_x86-64:
     dir: x86_64-2.6-gnu-4.1.2

--- a/publish/aliPublish-nightlies.conf
+++ b/publish/aliPublish-nightlies.conf
@@ -1,5 +1,7 @@
 # vim: set filetype=yaml:
 ---
+s3_endpoint_url: https://s3.cern.ch
+s3_bucket: alibuild-repo
 base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
 base_prefix: TARS
 
@@ -150,5 +152,3 @@ notification_email:
 # What packages to publish
 auto_include_deps: True
 filter_order: include,exclude
-
-# Packages older than 7 days will be excluded (limits too many packages published by mistake)

--- a/publish/aliPublish-nightlies.conf
+++ b/publish/aliPublish-nightlies.conf
@@ -152,4 +152,3 @@ auto_include_deps: True
 filter_order: include,exclude
 
 # Packages older than 7 days will be excluded (limits too many packages published by mistake)
-exclude_older_d: 7

--- a/publish/aliPublish-nightlies.conf
+++ b/publish/aliPublish-nightlies.conf
@@ -1,6 +1,7 @@
 # vim: set filetype=yaml:
 ---
-base_url: https://ali-ci.cern.ch/TARS
+base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
+base_prefix: TARS
 
 # YAML variables. Not aliPublish-specific.
 experts_email_notif_conf: &experts_email_notif

--- a/publish/aliPublish-rpms-cc8.conf
+++ b/publish/aliPublish-rpms-cc8.conf
@@ -60,6 +60,7 @@ architectures:
       DataDistribution: True
       ODC: True
       O2:
+        - ^v[0-9]{2}\.[0-9]{2}-[0-9]+$
         - ^[a-f0-9]{10}_O2_(DAQ|DATAFLOW)-[0-9]+$
     exclude:
       ReadoutCard:

--- a/publish/aliPublish-rpms-cc8.conf
+++ b/publish/aliPublish-rpms-cc8.conf
@@ -1,0 +1,174 @@
+# vim: set filetype=yaml:
+---
+s3_endpoint_url: https://s3.cern.ch
+s3_bucket: alibuild-repo
+base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
+base_prefix: TARS
+http_ssl_verify: True
+conn_timeout_s: 6.05
+conn_retries: 6
+conn_dethrottle_s: 0.5
+
+architectures:
+  slc8_x86-64:
+    RPM: el8.x86_64
+    include:
+      Toolchain:
+        - ^v.*$
+      rpm-test: True
+      mesos-workqueue: True
+      flpproto: True
+      Monitoring: True
+      Configuration: True
+      Configuration-Benchmark: True
+      ReadoutCard: True
+      Readout: True
+      Control: True
+      TpcFecUtils: True
+      O2Suite: True
+      ALF: True
+      CMake: True
+      FreeType: True
+      GCC-Toolchain: True
+      O2-customization: True
+      OpenSSL: True
+      Python-modules-list: True
+      RapidJSON: True
+      alibuild-recipe-tools: True
+      autotools: True
+      bz2: True
+      capstone: True
+      cub: True
+      defaults-release: True
+      double-conversion: True
+      googlebenchmark: True
+      googletest: True
+      libffi: True
+      libxml2: True
+      lz4: True
+      lzma: True
+      ms_gsl: True
+      ofi: True
+      re2: True
+      sqlite: True
+      zlib: True
+      ecsg:
+        - ^v.*
+      qcg:
+        - ^v.*
+      QualityControl: True
+      DataDistribution: True
+      ODC: True
+      O2:
+        - ^[a-f0-9]{10}_O2_(DAQ|DATAFLOW)-[0-9]+$
+    exclude:
+      ReadoutCard:
+        - ^v0\.8\.8-2$
+      Common-O2:
+        - ^v1\.2\.5-1$
+      InfoLogger:
+        - ^v1\.0\.5-2$
+      flpproto:
+        - ^v20170915-1$
+      O2:
+        - ^fa3ea88837_O2_DAQ-1$
+      mesos-workqueue:
+        - -18d7f0d6f3-
+        - -38c51d6edf-
+        - -8112bb1d4c-
+
+# RPM-specific configuration
+rpm_repo_dir: /repo/RPMS
+
+# What packages to publish
+auto_include_deps: True
+filter_order: include,exclude
+
+notification_email:
+  server: cernmx.cern.ch
+  package_format: "  %(package)s %(version)s\n"
+  success:
+    body: |
+      Dear ALICE fellows,
+
+        RPM %(package)s %(version)s for architecture %(arch)s was created.
+
+      To install (you might need to force-refresh your cache):
+
+        yum -v clean expire-cache
+        yum install -y alisw-%(package)s+%(version)s
+
+      To use the newly created package:
+
+        aliswmod enter %(package)s/%(version)s
+
+      You can find the full set of instructions (including repo configuration) here:
+
+        https://aliceo2group.github.io/quickstart/binaries.html
+
+      The following dependencies will be automatically installed and loaded:
+
+      %(alldependencies_fmt)s
+
+      Enjoy,
+      --
+      The ALICE Build Infrastructure
+    subject: "[ALICE-RPMs] %(package)s %(version)s created"
+    from: "ALICE Builder <noreply@cern.ch>"
+    to:
+      TpcFecUtils:
+        - talt@cern.ch
+        - christian.lippmann@cern.ch
+        - kirsch@fias.uni-frankfurt.de
+      O2:
+        - barthelemy.von.haller@cern.ch
+        - adam.wegrzynek@cern.ch
+        - teo.mrnjavac@cern.ch
+      qcg:
+        - barthelemy.von.haller@cern.ch
+        - adam.wegrzynek@cern.ch
+        - piotr.jan.konopka@cern.ch
+      Monitoring:
+        - adam.wegrzynek@cern.ch
+      flpproto:
+        - alice-o2-flp-prototype@cern.ch
+      O2Suite:
+        - alice-o2-flp-prototype@cern.ch
+      mesos-workqueue:
+        - giulio.eulisse@cern.ch
+      Configuration:
+        - adam.wegrzynek@cern.ch
+      Configuration-Benchmark:
+        - adam.wegrzynek@cern.ch
+      ReadoutCard:
+        - kostas.alexopoulos@cern.ch
+        - filippo.costa@cern.ch
+      Readout:
+        - sylvain.chapeland@cern.ch
+        - teo.mrnjavac@cern.ch
+      Control:
+        - teo.mrnjavac@cern.ch
+      ALF:
+        - kostas.alexopoulos@cern.ch
+        - filippo.costa@cern.ch
+      DataDistribution:
+        - gvozden.neskovic@cern.ch
+        - teo.mrnjavac@cern.ch
+      QualityControl:
+        - barthelemy.von.haller@cern.ch
+        - piotr.jan.konopka@cern.ch
+        - teo.mrnjavac@cern.ch
+      ODC:
+        - teo.mrnjavac@cern.ch
+  failure:
+    body: |
+      Creation of RPM %(package)s %(version)s for architecture %(arch)s failed.
+      Please have a look.
+
+      Cheers,
+      --
+      The ALICE Build Infrastructure
+    subject: "[ALICE-RPMs] Failed: %(package)s %(version)s"
+    from: "ALICE Builder <noreply@cern.ch>"
+    to:
+      - giulio.eulisse@cern.ch

--- a/publish/aliPublish-rpms-cc8.conf
+++ b/publish/aliPublish-rpms-cc8.conf
@@ -87,79 +87,6 @@ filter_order: include,exclude
 notification_email:
   server: cernmx.cern.ch
   package_format: "  %(package)s %(version)s\n"
-  success:
-    body: |
-      Dear ALICE fellows,
-
-        RPM %(package)s %(version)s for architecture %(arch)s was created.
-
-      To install (you might need to force-refresh your cache):
-
-        yum -v clean expire-cache
-        yum install -y alisw-%(package)s+%(version)s
-
-      To use the newly created package:
-
-        aliswmod enter %(package)s/%(version)s
-
-      You can find the full set of instructions (including repo configuration) here:
-
-        https://aliceo2group.github.io/quickstart/binaries.html
-
-      The following dependencies will be automatically installed and loaded:
-
-      %(alldependencies_fmt)s
-
-      Enjoy,
-      --
-      The ALICE Build Infrastructure
-    subject: "[ALICE-RPMs] %(package)s %(version)s created"
-    from: "ALICE Builder <noreply@cern.ch>"
-    to:
-      TpcFecUtils:
-        - talt@cern.ch
-        - christian.lippmann@cern.ch
-        - kirsch@fias.uni-frankfurt.de
-      O2:
-        - barthelemy.von.haller@cern.ch
-        - adam.wegrzynek@cern.ch
-        - teo.mrnjavac@cern.ch
-      qcg:
-        - barthelemy.von.haller@cern.ch
-        - adam.wegrzynek@cern.ch
-        - piotr.jan.konopka@cern.ch
-      Monitoring:
-        - adam.wegrzynek@cern.ch
-      flpproto:
-        - alice-o2-flp-prototype@cern.ch
-      O2Suite:
-        - alice-o2-flp-prototype@cern.ch
-      mesos-workqueue:
-        - giulio.eulisse@cern.ch
-      Configuration:
-        - adam.wegrzynek@cern.ch
-      Configuration-Benchmark:
-        - adam.wegrzynek@cern.ch
-      ReadoutCard:
-        - kostas.alexopoulos@cern.ch
-        - filippo.costa@cern.ch
-      Readout:
-        - sylvain.chapeland@cern.ch
-        - teo.mrnjavac@cern.ch
-      Control:
-        - teo.mrnjavac@cern.ch
-      ALF:
-        - kostas.alexopoulos@cern.ch
-        - filippo.costa@cern.ch
-      DataDistribution:
-        - gvozden.neskovic@cern.ch
-        - teo.mrnjavac@cern.ch
-      QualityControl:
-        - barthelemy.von.haller@cern.ch
-        - piotr.jan.konopka@cern.ch
-        - teo.mrnjavac@cern.ch
-      ODC:
-        - teo.mrnjavac@cern.ch
   failure:
     body: |
       Creation of RPM %(package)s %(version)s for architecture %(arch)s failed.
@@ -171,4 +98,4 @@ notification_email:
     subject: "[ALICE-RPMs] Failed: %(package)s %(version)s"
     from: "ALICE Builder <noreply@cern.ch>"
     to:
-      - giulio.eulisse@cern.ch
+      - timo.wilken@cern.ch

--- a/publish/aliPublish-rpms.conf
+++ b/publish/aliPublish-rpms.conf
@@ -1,6 +1,7 @@
 # vim: set filetype=yaml:
 ---
-base_url: https://ali-ci.cern.ch/TARS
+base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
+base_prefix: TARS
 http_ssl_verify: False
 conn_timeout_s: 6.05
 conn_retries: 6

--- a/publish/aliPublish-rpms.conf
+++ b/publish/aliPublish-rpms.conf
@@ -1,8 +1,10 @@
 # vim: set filetype=yaml:
 ---
+s3_endpoint_url: https://s3.cern.ch
+s3_bucket: alibuild-repo
 base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
 base_prefix: TARS
-http_ssl_verify: False
+http_ssl_verify: True
 conn_timeout_s: 6.05
 conn_retries: 6
 conn_dethrottle_s: 0.5
@@ -84,8 +86,6 @@ rpm_repo_dir: /repo/RPMS
 # What packages to publish
 auto_include_deps: True
 filter_order: include,exclude
-
-# Packages older than 7 days will be excluded (limits too many packages published by mistake)
 
 notification_email:
   server: cernmx.cern.ch

--- a/publish/aliPublish-rpms.conf
+++ b/publish/aliPublish-rpms.conf
@@ -86,7 +86,6 @@ auto_include_deps: True
 filter_order: include,exclude
 
 # Packages older than 7 days will be excluded (limits too many packages published by mistake)
-exclude_older_d: 30
 
 notification_email:
   server: cernmx.cern.ch

--- a/publish/aliPublish-titan.conf
+++ b/publish/aliPublish-titan.conf
@@ -1,6 +1,7 @@
 # vim: set filetype=yaml:
 ---
-base_url: https://ali-ci.cern.ch/TARS
+base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
+base_prefix: TARS
 
 architectures:
 

--- a/publish/aliPublish-titan.conf
+++ b/publish/aliPublish-titan.conf
@@ -1,5 +1,7 @@
 # vim: set filetype=yaml:
 ---
+s3_endpoint_url: https://s3.cern.ch
+s3_bucket: alibuild-repo
 base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
 base_prefix: TARS
 
@@ -34,7 +36,7 @@ auto_include_deps: True
 filter_order: include,exclude
 
 # Connection parameters
-http_ssl_verify: False
+http_ssl_verify: True
 conn_timeout_s: 6.05
 conn_retries: 6
 conn_dethrottle_s: 0.5

--- a/publish/aliPublish-updatable-rpms.conf
+++ b/publish/aliPublish-updatable-rpms.conf
@@ -1,6 +1,7 @@
 # vim: set filetype=yaml:
 ---
-base_url: https://ali-ci.cern.ch/TARS
+base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
+base_prefix: TARS
 http_ssl_verify: False
 conn_timeout_s: 6.05
 conn_retries: 6

--- a/publish/aliPublish-updatable-rpms.conf
+++ b/publish/aliPublish-updatable-rpms.conf
@@ -1,8 +1,10 @@
 # vim: set filetype=yaml:
 ---
+s3_endpoint_url: https://s3.cern.ch
+s3_bucket: alibuild-repo
 base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
 base_prefix: TARS
-http_ssl_verify: False
+http_ssl_verify: True
 conn_timeout_s: 6.05
 conn_retries: 6
 conn_dethrottle_s: 0.5
@@ -45,8 +47,6 @@ filter_order: include,exclude
 
 # Generate updatable RPMs
 rpm_updatable: True
-
-# Packages older than 7 days will be excluded (limits too many packages published by mistake)
 
 notification_email:
   server: cernmx.cern.ch

--- a/publish/aliPublish-updatable-rpms.conf
+++ b/publish/aliPublish-updatable-rpms.conf
@@ -47,7 +47,6 @@ filter_order: include,exclude
 rpm_updatable: True
 
 # Packages older than 7 days will be excluded (limits too many packages published by mistake)
-exclude_older_d: 30
 
 notification_email:
   server: cernmx.cern.ch

--- a/publish/aliPublish-updatable-test-rpms.conf
+++ b/publish/aliPublish-updatable-test-rpms.conf
@@ -1,6 +1,7 @@
 # vim: set filetype=yaml:
 ---
-base_url: https://ali-ci.cern.ch/TARS
+base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
+base_prefix: TARS
 http_ssl_verify: False
 conn_timeout_s: 6.05
 conn_retries: 6

--- a/publish/aliPublish-updatable-test-rpms.conf
+++ b/publish/aliPublish-updatable-test-rpms.conf
@@ -27,7 +27,6 @@ filter_order: include,exclude
 rpm_updatable: True
 
 # Packages older than 7 days will be excluded (limits too many packages published by mistake)
-exclude_older_d: 7
 
 notification_email:
   server: cernmx.cern.ch

--- a/publish/aliPublish-updatable-test-rpms.conf
+++ b/publish/aliPublish-updatable-test-rpms.conf
@@ -1,8 +1,10 @@
 # vim: set filetype=yaml:
 ---
+s3_endpoint_url: https://s3.cern.ch
+s3_bucket: alibuild-repo
 base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
 base_prefix: TARS
-http_ssl_verify: False
+http_ssl_verify: True
 conn_timeout_s: 6.05
 conn_retries: 6
 conn_dethrottle_s: 0.5
@@ -25,8 +27,6 @@ filter_order: include,exclude
 
 # Generate updatable RPMs
 rpm_updatable: True
-
-# Packages older than 7 days will be excluded (limits too many packages published by mistake)
 
 notification_email:
   server: cernmx.cern.ch

--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -1,6 +1,7 @@
 # vim: set filetype=yaml:
 ---
-base_url: http://test-results.marathon.mesos/TARS
+base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
+base_prefix: TARS
 
 # Mesos DNSes. Used via the API for .mesos domains.
 mesos_dns: [ "alimesos01.cern.ch", "alimesos02.cern.ch", "alimesos03.cern.ch" ]

--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -5,9 +5,6 @@ s3_bucket: alibuild-repo
 base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
 base_prefix: TARS
 
-# Mesos DNSes. Used via the API for .mesos domains.
-mesos_dns: [ "alimesos01.cern.ch", "alimesos02.cern.ch", "alimesos03.cern.ch" ]
-
 # YAML variables. Not aliPublish-specific.
 alice_email_notif_conf: &alice_email_notif alice-analysis-operations@cern.ch
 experts_email_notif_conf: &experts_email_notif

--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -326,7 +326,6 @@ auto_include_deps: True
 filter_order: include,exclude
 
 # Packages older than 7 days will be excluded (limits too many packages published by mistake)
-exclude_older_d: 7
 
 # Avoid connection flooding and retry
 conn_retries: 10

--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -1,5 +1,7 @@
 # vim: set filetype=yaml:
 ---
+s3_endpoint_url: https://s3.cern.ch
+s3_bucket: alibuild-repo
 base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
 base_prefix: TARS
 
@@ -324,8 +326,6 @@ notification_email:
 # What packages to publish
 auto_include_deps: True
 filter_order: include,exclude
-
-# Packages older than 7 days will be excluded (limits too many packages published by mistake)
 
 # Avoid connection flooding and retry
 conn_retries: 10

--- a/publish/run-all-rpms.sh
+++ b/publish/run-all-rpms.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
 yum install -y rclone
-pip install -U boto3
+pip install -U requests boto3
 
 . /etc/profile.d/enable-alice.sh
 . /secrets/aws_bot_secrets

--- a/publish/run-all-rpms.sh
+++ b/publish/run-all-rpms.sh
@@ -3,5 +3,10 @@
 # Check if variables are provided.
 [ X${DEBUG:-1} = X1 ] && set -x
 
-./aliPublish --config "aliPublish-rpms.conf" --debug --cache-deps-dir /tmp/pubdepscache sync-rpms >&2
-timeout 300 rclone sync --config /secrets/alibuild_rclone_config --transfers=10 --verbose local:/repo/RPMS/el7.x86_64/ rpms3:alibuild-repo/RPMS/el7.x86_64/ || true
+for CONF in aliPublish*-rpms.conf; do
+  echo === $(LANG=C date) :: running for configuration $CONF === >&2
+  ./aliPublish --config "$CONF" --debug sync-rpms >&2
+  timeout 300 rclone sync --config /secrets/alibuild_rclone_config --transfers=10 --verbose local:/repo/RPMS/el7.x86_64/ rpms3:alibuild-repo/RPMS/el7.x86_64/ || true
+  timeout 300 rclone sync --config /secrets/alibuild_rclone_config --transfers=10 --verbose local:/repo/UpdRPMS/el7.x86_64/ rpms3:alibuild-repo/UpdRPMS/el7.x86_64/ || true
+  printf "\n\n\n\n" >&2
+done

--- a/publish/run-all-rpms.sh
+++ b/publish/run-all-rpms.sh
@@ -3,9 +3,9 @@
 yum install -y rclone
 pip install -U boto3
 
-. /secrets/alibot_secrets
 . /etc/profile.d/enable-alice.sh
-export FLP_RPM_CI_TOKEN SYNC_PASS=$ALIBOT_PASSWORD SYNC_USER=alibot
+. /secrets/aws_bot_secrets
+export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 
 cd "$(dirname "$0")" || exit 2
 while true; do

--- a/publish/run-all-rpms.sh
+++ b/publish/run-all-rpms.sh
@@ -1,12 +1,25 @@
-#!/bin/bash
+#!/bin/bash -x
 
-# Check if variables are provided.
-[ X${DEBUG:-1} = X1 ] && set -x
+yum install -y rclone
+pip install -U boto3
 
-for CONF in aliPublish*-rpms.conf; do
-  echo === $(LANG=C date) :: running for configuration $CONF === >&2
-  ./aliPublish --config "$CONF" --debug sync-rpms >&2
-  timeout 300 rclone sync --config /secrets/alibuild_rclone_config --transfers=10 --verbose local:/repo/RPMS/el7.x86_64/ rpms3:alibuild-repo/RPMS/el7.x86_64/ || true
-  timeout 300 rclone sync --config /secrets/alibuild_rclone_config --transfers=10 --verbose local:/repo/UpdRPMS/el7.x86_64/ rpms3:alibuild-repo/UpdRPMS/el7.x86_64/ || true
-  printf "\n\n\n\n" >&2
+. /secrets/alibot_secrets
+. /etc/profile.d/enable-alice.sh
+export FLP_RPM_CI_TOKEN SYNC_PASS=$ALIBOT_PASSWORD SYNC_USER=alibot
+
+cd "$(dirname "$0")" || exit 2
+while true; do
+  # Supply possible conf suffix, e.g. -cc8, as arg to this script.
+  for conf in aliPublish*-rpms"$1".conf; do
+    echo "=== $(LANG=C date) :: running for configuration $conf ===" >&2
+    ./aliPublish --config "$conf" --debug sync-rpms >&2 || exit 1
+    for rpmtype in RPMS UpdRPMS; do
+      for arch in el7.x86_64 el8.x86_64; do
+        timeout 300 rclone sync --config /secrets/alibuild_rclone_config --transfers=10 --verbose \
+                "local:/repo/$rpmtype/$arch/" "rpms3:alibuild-repo/$rpmtype/$arch/"
+      done
+    done
+    printf '\n\n\n\n' >&2
+  done
+  sleep 600
 done


### PR DESCRIPTION
This patch changes aliPublish to get packages from S3 instead of ali-ci.cern.ch.

To keep the package processing code intact and reduce the potential for bugs, essentially insert a shim between S3 and code that expects ali-ci's JSON format for directory listings.

Untested for now.