### PR TITLE
Install required python modules in workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,6 +15,9 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Install prerequisites
+        run: pip install -r requirements.txt
+
       - name: Check publish/
         run: |
           git diff --name-only "$(git merge-base HEAD ${{ github.event.pull_request.base.sha }})" |
@@ -27,7 +30,7 @@ jobs:
               [ -r "$test" ] || continue
               if ! ./aliPublish test-rules --conf "$conf" --test-conf "$test" --debug; then
                 echo "Testing $conf against $test failed." >&2
-                return 1
+                exit 1
               fi
             done
           popd


### PR DESCRIPTION
The publish step gets skipped if nothing changed any relevant files, so the error didn't crop up until now.