### PR TITLE
Reduce false positives in log output

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -182,7 +182,8 @@ class Logs(object):
             return "\n\n\n".join(blocks).strip(" \n\t")
 
         self.errors_log = chunk_command_output_by_log(
-            r"grep -EC 3 ': (internal compiler |fatal )?error:|^Error(:| in )|\*\*\*' -- %s",
+            r"grep -EC 3 ': (internal compiler |fatal )?error:|^Error(:| in )|"
+            r"make.*: \*\*\*|\*\*\*Failed|^\*{79}$' -- %s",
             # Errors from this log are reported in o2checkcode_messages
             # already, so don't report them twice. This log also contains false
             # positives, so o2checkcode_messages is better.


### PR DESCRIPTION
This replaces grepping for `***` with a more precise search for make/gmake errors (e.g. when a compiler is killed), a type of cmake error, and failed tests, which is what that pattern is for. This means disabled tests don't show up in the HTML error log any more.