### PR TITLE
Ignore CMAKE_CXX_COMPILER warning in HTML log

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -183,7 +183,7 @@ class Logs(object):
 
         self.errors_log = chunk_command_output_by_log(
             r"grep -EC 3 ': (internal compiler |fatal )?error:|^Error(:| in )|"
-            r"make.*: \*\*\*|\*\*\*Failed|^\*{79}$' -- %s",
+            r"make.*: \*\*\*|\*\*\*Failed' -- %s",
             # Errors from this log are reported in o2checkcode_messages
             # already, so don't report them twice. This log also contains false
             # positives, so o2checkcode_messages is better.


### PR DESCRIPTION
Should be disabled anyway, so remove the clause that looks for it.

Previously, we found the following messages by looking for lines of 79 asterisks:

```
*******************************************************************************
*----------------------------------- ERROR -----------------------------------*
* The variable 'CMAKE_CXX_COMPILER' should only be set by the cmake toolchain,
* either by calling 'cmake -DCMAKE_CXX_COMPILER="/opt/rocm/hip/bin/hipcc"' or
* set in a toolchain file and added with 
* 'cmake -DCMAKE_TOOLCHAIN_FILE=<toolchain-file>'.
*-----------------------------------------------------------------------------*
*******************************************************************************
```