### PR TITLE
Add missing system requirements for pip dependencies

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -16,7 +16,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install prerequisites
-        run: pip install -r requirements.txt
+        run: |
+          apt update -y
+          apt install -y build-essential python3-dev python3-pip python3-setuptools python3-wheel libldap2-dev
+          pip install -r requirements.txt
 
       - name: Check publish/
         run: |


### PR DESCRIPTION
python-ldap requires libldap2-dev; using other packages' pre-built binaries requires python3-wheel.