### PR TITLE
Remove yum update/yum install from SLC6 Jenkins builds

### DIFF
--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -107,17 +107,12 @@ node ("slc7_x86-64-light") {
             echo $NODE_NAME
             case $NODE_NAME in
               *slc6_x86-64*)
-                perl -p -i -e 's|.*mirrorlist.centos.org.*||;s|#[ ]*baseurl=http*://mirror|baseurl=http://vault|g' /etc/yum.repos.d/*
-                yum update -y --disablerepo=eos --disablerepo=xrootd-stable
-                perl -p -i -e 's|.*mirrorlist.centos.org.*||;s|#[ ]*baseurl=http*://mirror|baseurl=http://vault|g' /etc/yum.repos.d/*
-                yum install -y --disablerepo=eos centos-release-scl-rh centos-release-scl
-                perl -p -i -e 's|.*mirrorlist.centos.org.*||;s|#[ ]*baseurl=http*://mirror|baseurl=http://vault|g' /etc/yum.repos.d/*
-                yum install -y --enablerepo=centos-sclo-rh --disablerepo=eos  rh-python35
-                source /opt/rh/rh-python35/enable
-              ;;
-              *) yum install -y python3-devel python3-pip python3-setuptools ;;
+                # python3 is not installed on the slc6-builder. Installing it seems to break the build.
+                pip install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG ;;
+              *)
+                yum install -y python3-devel python3-pip python3-setuptools
+                pip3 install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG ;;
             esac
-            pip3 install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG
             [ -f /opt/rh/rh-git218/enable ] && source /opt/rh/rh-git218/enable
             daily-tags.sh
           '''


### PR DESCRIPTION
An update to binutils seems to break the GCC-Toolchain build. It works in a clean slc6-builder container, so remove the yum update.

The yum installs seem to break the autotools build, so remove them.