### PR TITLE
Publish RPMs on CC8

### DIFF
--- a/publish/aliPublish-rpms-cc8.conf
+++ b/publish/aliPublish-rpms-cc8.conf
@@ -1,0 +1,175 @@
+# vim: set filetype=yaml:
+---
+s3_endpoint_url: https://s3.cern.ch
+s3_bucket: alibuild-repo
+base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
+base_prefix: TARS
+http_ssl_verify: True
+conn_timeout_s: 6.05
+conn_retries: 6
+conn_dethrottle_s: 0.5
+
+architectures:
+  slc8_x86-64:
+    RPM: el8.x86_64
+    include:
+      Toolchain:
+        - ^v.*$
+      rpm-test: True
+      mesos-workqueue: True
+      flpproto: True
+      Monitoring: True
+      Configuration: True
+      Configuration-Benchmark: True
+      ReadoutCard: True
+      Readout: True
+      Control: True
+      TpcFecUtils: True
+      O2Suite: True
+      ALF: True
+      CMake: True
+      FreeType: True
+      GCC-Toolchain: True
+      O2-customization: True
+      OpenSSL: True
+      Python-modules-list: True
+      RapidJSON: True
+      alibuild-recipe-tools: True
+      autotools: True
+      bz2: True
+      capstone: True
+      cub: True
+      defaults-release: True
+      double-conversion: True
+      googlebenchmark: True
+      googletest: True
+      libffi: True
+      libxml2: True
+      lz4: True
+      lzma: True
+      ms_gsl: True
+      ofi: True
+      re2: True
+      sqlite: True
+      zlib: True
+      ecsg:
+        - ^v.*
+      qcg:
+        - ^v.*
+      QualityControl: True
+      DataDistribution: True
+      ODC: True
+      O2:
+        - ^v[0-9]{2}\.[0-9]{2}-[0-9]+$
+        - ^[a-f0-9]{10}_O2_(DAQ|DATAFLOW)-[0-9]+$
+    exclude:
+      ReadoutCard:
+        - ^v0\.8\.8-2$
+      Common-O2:
+        - ^v1\.2\.5-1$
+      InfoLogger:
+        - ^v1\.0\.5-2$
+      flpproto:
+        - ^v20170915-1$
+      O2:
+        - ^fa3ea88837_O2_DAQ-1$
+      mesos-workqueue:
+        - -18d7f0d6f3-
+        - -38c51d6edf-
+        - -8112bb1d4c-
+
+# RPM-specific configuration
+rpm_repo_dir: /repo/RPMS
+
+# What packages to publish
+auto_include_deps: True
+filter_order: include,exclude
+
+notification_email:
+  server: cernmx.cern.ch
+  package_format: "  %(package)s %(version)s\n"
+  success:
+    body: |
+      Dear ALICE fellows,
+
+        RPM %(package)s %(version)s for architecture %(arch)s was created.
+
+      To install (you might need to force-refresh your cache):
+
+        yum -v clean expire-cache
+        yum install -y alisw-%(package)s+%(version)s
+
+      To use the newly created package:
+
+        aliswmod enter %(package)s/%(version)s
+
+      You can find the full set of instructions (including repo configuration) here:
+
+        https://aliceo2group.github.io/quickstart/binaries.html
+
+      The following dependencies will be automatically installed and loaded:
+
+      %(alldependencies_fmt)s
+
+      Enjoy,
+      --
+      The ALICE Build Infrastructure
+    subject: "[ALICE-RPMs] %(package)s %(version)s created"
+    from: "ALICE Builder <noreply@cern.ch>"
+    to:
+      TpcFecUtils:
+        - talt@cern.ch
+        - christian.lippmann@cern.ch
+        - kirsch@fias.uni-frankfurt.de
+      O2:
+        - barthelemy.von.haller@cern.ch
+        - adam.wegrzynek@cern.ch
+        - teo.mrnjavac@cern.ch
+      qcg:
+        - barthelemy.von.haller@cern.ch
+        - adam.wegrzynek@cern.ch
+        - piotr.jan.konopka@cern.ch
+      Monitoring:
+        - adam.wegrzynek@cern.ch
+      flpproto:
+        - alice-o2-flp-prototype@cern.ch
+      O2Suite:
+        - alice-o2-flp-prototype@cern.ch
+      mesos-workqueue:
+        - giulio.eulisse@cern.ch
+      Configuration:
+        - adam.wegrzynek@cern.ch
+      Configuration-Benchmark:
+        - adam.wegrzynek@cern.ch
+      ReadoutCard:
+        - kostas.alexopoulos@cern.ch
+        - filippo.costa@cern.ch
+      Readout:
+        - sylvain.chapeland@cern.ch
+        - teo.mrnjavac@cern.ch
+      Control:
+        - teo.mrnjavac@cern.ch
+      ALF:
+        - kostas.alexopoulos@cern.ch
+        - filippo.costa@cern.ch
+      DataDistribution:
+        - gvozden.neskovic@cern.ch
+        - teo.mrnjavac@cern.ch
+      QualityControl:
+        - barthelemy.von.haller@cern.ch
+        - piotr.jan.konopka@cern.ch
+        - teo.mrnjavac@cern.ch
+      ODC:
+        - teo.mrnjavac@cern.ch
+  failure:
+    body: |
+      Creation of RPM %(package)s %(version)s for architecture %(arch)s failed.
+      Please have a look.
+
+      Cheers,
+      --
+      The ALICE Build Infrastructure
+    subject: "[ALICE-RPMs] Failed: %(package)s %(version)s"
+    from: "ALICE Builder <noreply@cern.ch>"
+    to:
+      - giulio.eulisse@cern.ch


### PR DESCRIPTION
The running CC7 publisher won't pick this config file up automatically (and neither will the CC8 publisher), so it's safe to merge.

This file publishes O2 vYY.WW, and emails are enabled!