### PR TITLE
Only increase ulimit if needed

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -49,7 +49,7 @@ if [ "$1" != --skip-setup ]; then
 
   # On MacOS, the default ulimit for open files is 256. This is too low for git
   # when fetching some large repositories (e.g. O2, Clang).
-  ulimit -n 1024
+  [ "$(ulimit -n)" -ge 10240 ] || ulimit -n 10240
 fi
 
 # Generate example of force-hashes file. This is used to override what to check for testing


### PR DESCRIPTION
The largest allowable limit seems to be 10240 on alibuildmac00. The others have a maximum limit of 24576, and on Linux the maximum limit is even higher. This patch doesn't change the ulimit if it is already large enough, as the O2 full system test on Linux needs a very high ulimit.