### PR TITLE
Improvements to Jenkins daily build script

### DIFF
--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -1,109 +1,25 @@
 #!/bin/bash -ex
-set -x
-
-# Check for required variables
-ALIDIST_SLUG=${ALIDIST_SLUG:-alisw/alidist@master}
-[ ! -z "$PACKAGE_NAME" ]
-[ ! -z "$AUTOTAG_PATTERN" ]
-[ ! -z "$NODE_NAME" ]
-
-# Clean up old stuff
-rm -rf alidist/
-
-# Determine branch from slug string: group/repo@ref
-ALIDIST_BRANCH="${ALIDIST_SLUG##*@}"
-ALIDIST_REPO="${ALIDIST_SLUG%@*}"
-
-git config --global user.name 'ALICE Builder'
-git config --global user.email alibuild@cern.ch
-
-git clone -b $ALIDIST_BRANCH https://github.com/$ALIDIST_REPO alidist/
-
-# Install the latest release if ALIBUILD_SLUG is not provided
-pip install --user --ignore-installed --upgrade ${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild} ||
-  # Fall back to explicit pip version if `pip` doesn't exist, like on CentOS 8. (There, python is python3.)
-  pip3 install --user --ignore-installed --upgrade ${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild}
-
-PACKAGE_LOWER=$(echo $PACKAGE_NAME | tr '[[:upper:]]' '[[:lower:]]')
-RECIPE=alidist/$PACKAGE_LOWER.sh
-AUTOTAG_REMOTE=$(grep -E '^(source:|write_repo:)' $RECIPE | sort -r | head -n1 | cut -d: -f2- | xargs echo)
-AUTOTAG_MIRROR=$MIRROR/$PACKAGE_LOWER
-AUTOTAG_TAG=$(LANG=C TZ=Europe/Rome date +"$AUTOTAG_PATTERN")
-[[ "$TEST_TAG" == "true" ]] && AUTOTAG_TAG=TEST-IGNORE-$AUTOTAG_TAG
-echo "A Git tag will be created, upon success and if not existing, with the name $AUTOTAG_TAG"
-AUTOTAG_BRANCH=rc/$AUTOTAG_TAG
-echo "A Git branch will be created to pinpoint the build operation, with the name $AUTOTAG_BRANCH"
-AUTOTAG_CLONE=$PWD/$PACKAGE_LOWER.git
-
-[[ -d $AUTOTAG_MIRROR ]] || AUTOTAG_MIRROR=
-rm -rf $AUTOTAG_CLONE
-mkdir $AUTOTAG_CLONE
-pushd $AUTOTAG_CLONE &> /dev/null
-  [[ -e ../git-creds ]] || git config --global credential.helper "store --file ~/git-creds-autotag"  # backwards compat
-  git clone --bare                                         \
-            ${AUTOTAG_MIRROR:+--reference=$AUTOTAG_MIRROR} \
-            $AUTOTAG_REMOTE .
-  AUTOTAG_HASH=$( (git ls-remote 2> /dev/null | grep refs/tags/$AUTOTAG_TAG || true) | awk 'END{print $1}' )
-  if [[ "$AUTOTAG_HASH" != '' ]]; then
-    echo "Tag $AUTOTAG_TAG exists already as $AUTOTAG_HASH, using it"
-    AUTOTAG_ORIGIN=tag
-  elif [[ $DO_NOT_CREATE_NEW_TAG == true ]]; then
-    # Tag does not exist, but we have requested this job to forcibly use an existing one.
-    # Will abort the job.
-    echo "Tag $AUTOTAG_TAG was not found, however we have been requested to not create a new one" \
-         "(DO_NOT_CREATE_NEW_TAG is true). Aborting with error"
-    exit 1
-  else
-    # Tag does not exist. Create release candidate branch, if not existing.
-
-    AUTOTAG_HASH=$( (git ls-remote 2> /dev/null | grep refs/heads/$AUTOTAG_BRANCH || true) | awk 'END{print $1}' )
-    AUTOTAG_ORIGIN=rcbranch
-
-    if [[ "$AUTOTAG_HASH" != '' && "$REMOVE_RC_BRANCH_FIRST" == true ]]; then
-      # Remove branch first if requested. Error is fatal.
-      git push origin :refs/heads/$AUTOTAG_BRANCH
-      AUTOTAG_HASH=
-    fi
-
-    if [[ ! $AUTOTAG_HASH ]]; then
-      # Let's point it to HEAD
-      AUTOTAG_HASH=$( (git ls-remote 2> /dev/null | sed -e 's/\t/ /g' | grep -E ' HEAD$' || true) | awk 'END{print $1}' )
-      [[ $AUTOTAG_HASH ]] || { echo "FATAL: Cannot find any hash pointing to HEAD (repo's default branch)!" >&2; exit 1; }
-      echo "Head of $AUTOTAG_REMOTE will be used, it's at $AUTOTAG_HASH"
-      AUTOTAG_ORIGIN=HEAD
-    fi
-
-  fi
-
-  # At this point, we have $AUTOTAGH_HASH for sure. It might come from HEAD, an existing rc/* branch,
-  # or an existing tag. We always create a new branch out of it
-  git push origin +$AUTOTAG_HASH:refs/heads/$AUTOTAG_BRANCH
-
-popd &> /dev/null  # exit Git repo
-
-: ${DEFAULTS:=release}
 
 edit_tags () {
   # Patch package definition (e.g. o2.sh)
   local tag=$1 version=$AUTOTAG_OVERRIDE_VERSION
-  sed -E -i.old \
-      "s|^tag: .*\$|tag: \"$tag\"|; ${version:+s|^version: .*\$|version: \"$version\"|}" \
-      "alidist/${PACKAGE_NAME,,}.sh"
+  sed -ri.old "s|^tag: .*\$|tag: \"$tag\"|; ${version:+s|^version: .*\$|version: \"$version\"|}" \
+      "$alidist_clone/${PACKAGE_NAME,,}.sh"
 
   # Patch defaults definition (e.g. defaults-o2.sh)
   # Process overrides by changing in-place the given defaults. This requires
   # some YAML processing so we are better off with Python.
-  TAG=$1 PACKAGE_NAME=$PACKAGE_NAME DEFAULTS=$DEFAULTS python <<\EOF
+  tag=$1 pkg=$PACKAGE_NAME def=${DEFAULTS,,} dist=$alidist_clone python << EOF
 import yaml
 from os import environ
-f = "alidist/defaults-%s.sh" % environ["DEFAULTS"].lower()
-p = environ["PACKAGE_NAME"]
+f = "%(dist)s/defaults-%(def)s.sh" % environ
+p = environ["pkg"]
 meta, rest = open(f).read().split("\n---\n", 1)
 d = yaml.safe_load(meta)
 open(f+".old", "w").write(yaml.dump(d)+"\n---\n"+rest)
 d["overrides"] = d.get("overrides", {})
 d["overrides"][p] = d["overrides"].get(p, {})
-d["overrides"][p]["tag"] = environ["TAG"]
+d["overrides"][p]["tag"] = environ["tag"]
 v = environ.get("AUTOTAG_OVERRIDE_VERSION")
 if v:
     d["overrides"][p]["version"] = v
@@ -111,54 +27,100 @@ open(f, "w").write(yaml.dump(d)+"\n---\n"+rest)
 EOF
 }
 
-# The tag doesn't exist yet, so build using the branch first.
-edit_tags "$AUTOTAG_BRANCH"
+# Check for required variables
+: "${PACKAGE_NAME:?}" "${AUTOTAG_TAG:?}"
+: "${DEFAULTS:=release}" "${ALIDIST_SLUG:=alisw/alidist@master}"
 
-diff -rupN alidist/defaults-${DEFAULTS_LOWER}.sh.old alidist/defaults-${DEFAULTS_LOWER}.sh | cat
+# Determine branch from slug string: group/repo@ref
+alidist_branch=${ALIDIST_SLUG##*@}
+autotag_branch=rc/$AUTOTAG_TAG
+autotag_clone=$PWD/${PACKAGE_NAME,,}.git
+echo "A Git tag will be created, upon success and if not existing, with the name $AUTOTAG_TAG" >&2
+echo "A Git branch will be created to pinpoint the build operation, with the name $autotag_branch" >&2
+alidist_clone=$PWD/alidist
 
 # Select build directory in order to prevent conflicts and allow for cleanups.
 workarea=$(mktemp -d "$PWD/daily-tags.XXXXXXXXXX")
 
-REMOTE_STORE="${REMOTE_STORE:-rsync://repo.marathon.mesos/store/::rw}"
-JOBS=8
-[[ $MESOS_QUEUE_SIZE == huge ]] && JOBS=30
-echo "Now running aliBuild on $JOBS parallel workers"
-aliBuild --reference-sources mirror                    \
-         --debug                                       \
-         --work-dir "$workarea"                        \
-         ${ARCHITECTURE:+--architecture $ARCHITECTURE} \
-         --jobs 10                                     \
-         --fetch-repos                                 \
-         --remote-store $REMOTE_STORE                  \
-         ${DEFAULTS:+--defaults $DEFAULTS}             \
-         build "$PACKAGE_NAME" || {
+# Even when exiting with an error, clean up build area.
+trap 'rm -rf "$alidist_clone" "$autotag_clone" "$workarea"' EXIT
+
+rm -rf "$alidist_clone" "$autotag_clone"
+git clone -b "$alidist_branch" "https://github.com/${ALIDIST_SLUG%@*}" "$alidist_clone"
+git clone --bare "$(grep -E '^(source:|write_repo:)' "$alidist_clone/${PACKAGE_NAME,,}.sh" |
+                      sort -r | head -1 | cut -d: -f2- | xargs echo)" "$autotag_clone"
+
+pushd "$autotag_clone" &>/dev/null
+autotag_origin=
+
+if autotag_hash=$(git rev-parse --verify --end-of-options "$AUTOTAG_TAG"); then
+  echo "Tag $AUTOTAG_TAG exists already as $autotag_hash, using it" >&2
+  autotag_origin=tag
+elif [ "$DO_NOT_CREATE_NEW_TAG" = true ]; then
+  # Tag does not exist, but we have requested this job to forcibly use an
+  # existing one. Will abort the job.
+  echo "Tag $AUTOTAG_TAG was not found, however we have been requested" \
+       "to not create a new one (DO_NOT_CREATE_NEW_TAG is true)."       \
+       "Aborting with error" >&2
+  exit 1
+elif autotag_hash=$(git rev-parse --verify HEAD); then
+  # Tag does not exist. Let's point it to HEAD.
+  echo "Head of $(git remote get-url origin) will be used, it's at $autotag_hash" >&2
+else
+  echo "FATAL: Cannot find any hash pointing to HEAD (repo's default branch)!" >&2
+  exit 1
+fi
+
+if [ "$REMOVE_RC_BRANCH_FIRST" = true ] && [ "$autotag_origin" != tag ] &&
+     # Make sure branch exists before we remove it, so we don't get an error.
+     git rev-parse --verify --end-of-options "$autotag_branch"
+then
+  # Remove existing branch first if requested. Only necessary if we aren't using
+  # the existing tag. Error is fatal.
+  git push origin ":refs/heads/$autotag_branch"
+fi
+
+# At this point, we have $autotag_hash for sure. It might come from HEAD, an
+# existing rc/* branch, or an existing tag. We always create a new branch.
+git push origin "+$autotag_hash:refs/heads/$autotag_branch"
+popd &>/dev/null
+
+# The tag doesn't exist yet, so build using the branch first.
+edit_tags "$autotag_branch"
+
+# diff(1) exits with 1 if the inputs are different. This is expected; it
+# shouldn't fail the build!
+diff -Nup "$alidist_clone/defaults-${DEFAULTS,,}.sh"{.old,} || true
+
+aliBuild build "$PACKAGE_NAME" --debug --fetch-repos --jobs 10 --work-dir "$workarea" \
+         --defaults "$DEFAULTS" ${ARCHITECTURE:+--architecture "$ARCHITECTURE"}       \
+         --remote-store "${REMOTE_STORE:-rsync://repo.marathon.mesos/store/::rw}"  || {
   builderr=$?
-  echo "Exiting with an error ($builderr), not tagging"
+  echo "Exiting with an error ($builderr), not tagging" >&2
   exit $builderr
 }
 
-# Now we tag, in case we should
-pushd $AUTOTAG_CLONE &> /dev/null
-  if [[ $AUTOTAG_ORIGIN != tag ]]; then
-    git push origin +$AUTOTAG_HASH:refs/tags/$AUTOTAG_TAG
-  else
-    echo "Not tagging: tag $AUTOTAG_TAG exists already as $AUTOTAG_HASH"
-  fi
-  git push origin :refs/heads/$AUTOTAG_BRANCH || true  # error is not a big deal here
-popd &> /dev/null
+# Now we tag the package, in case we should.
+cd "$autotag_clone"
+if [ "$autotag_origin" = tag ]; then
+  echo "Not tagging: tag $AUTOTAG_TAG exists already as $autotag_hash" >&2
+else
+  git push origin "+$autotag_hash:refs/tags/$AUTOTAG_TAG"
+fi
+git push origin ":refs/heads/$autotag_branch" || true  # error is not a big deal here
 
-# Also tag the appropriate alidist
+# Also tag the appropriate alidist.
 # We normally want to build using the tag, and now it exists.
 edit_tags "$AUTOTAG_TAG"
-cd alidist
+cd "$alidist_clone"
 defaults_fname=defaults-${DEFAULTS,,}.sh pkg_fname=${PACKAGE_NAME,,}.sh
 # If the file was modified, the output of git status will be non-empty.
 if [ -n "$(git status --porcelain "$defaults_fname" "$pkg_fname")" ]; then
   git add "$defaults_fname" "$pkg_fname"
   git commit -m "Auto-update $defaults_fname and $pkg_fname"
 fi
-git push origin -f "HEAD:refs/tags/${PACKAGE_NAME:?}-${AUTOTAG_TAG:?}"
-# If ALIDIST_BRANCH doesn't exist or we can push to it, do it.
-git push origin "HEAD:${ALIDIST_BRANCH:?}" ||
+git push origin -f "HEAD:refs/tags/$PACKAGE_NAME-$AUTOTAG_TAG"
+# If alidist_branch doesn't exist or we can push to it, do it.
+git push origin "HEAD:$alidist_branch" ||
   # Else, make a PR by pushing an rc/ branch. (An action in the repo handles this.)
-  git push origin -f "HEAD:rc/${ALIDIST_BRANCH:?}"
+  git push origin -f "HEAD:rc/$alidist_branch"

--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -1,134 +1,125 @@
 #!groovy
-node ("slc7_x86-64-light") {
-  try {
-    currentBuild.displayName = "#${env.BUILD_NUMBER} - $PACKAGE_NAME $DEFAULTS $ARCHITECTURE"
+try {
+  stage('Construct tag name') {
+    /* Turn AUTOTAG_PATTERN into AUTOTAG_TAG now, before waiting for PRs,
+     * because waiting can take hours, and that would mean we use the incorrect
+     * date to name the tag.
+     * Run on any free node -- doesn't matter which, but we need one to use sh.
+     */
+    node {
+      AUTOTAG_TAG = sh(script: "LANG=C TZ=Europe/Zurich date '+$AUTOTAG_PATTERN'",
+                       returnStdout: true).trim()
+    }
+    currentBuild.displayName = ("#${env.BUILD_NUMBER} - $PACKAGE_NAME " +
+                                AUTOTAG_TAG + " $DEFAULTS $ARCHITECTURE")
+  }
 
-    stage "Wait pull requests"
-    if ("$WAIT_PR" == "true") {
-      timeout (7200) {
-        withEnv(["ALIBOT_SLUG=${ALIBOT_SLUG}",
-                 "WAIT_PR_LIMIT=${WAIT_PR_LIMIT}",
-                 "PACKAGE_NAME=${PACKAGE_NAME}"]) {
-          withCredentials([[$class: 'StringBinding',
-                            credentialsId: 'github_token',
-                            variable: 'GITHUB_TOKEN']]) {
-            sh '''
-              set -e
-              echo $GITHUB_TOKEN > ~/.github-token
-              chmod 0600 ~/.github-token
-              # Use pip to get the Python scripts (with all the correct dependencies)
-              export PYTHONUSERBASE="$PWD/localpython"
-              export PATH="$PYTHONUSERBASE/bin:$PATH"
-              rm -rf "$PYTHONUSERBASE"
-              yum install -y python3-pip python3-devel python3-setuptools
-              pip3 install --user --upgrade --ignore-installed "${ALIBOT_SLUG:+git+https://github.com/${ALIBOT_SLUG}}"
-              type check-open-pr
-              if [[ $PACKAGE_NAME == AliPhysics ]]; then
-                WAIT_TESTS="build/AliPhysics/release build/AliPhysics/root6"
-              else
-                WAIT_TESTS="build/$PACKAGE_NAME/release"
-              fi
-              while ! check-open-pr $WAIT_PR_LIMIT alisw/$PACKAGE_NAME $WAIT_TESTS; do
-                echo "Waiting for all pull requests to be merged"
-                sleep 120
-              done
-            '''
+  stage('Wait for pull requests') {
+    if ("$WAIT_PR" == 'true') {
+      node('slc7_x86-64-light') {
+        timeout(7200) {
+          withEnv(["ALIBOT_SLUG=$ALIBOT_SLUG",
+                   "WAIT_PR_LIMIT=$WAIT_PR_LIMIT",
+                   "PACKAGE_NAME=$PACKAGE_NAME"]) {
+            withCredentials([string(credentialsId: 'github_token',
+                                    variable: 'GITHUB_TOKEN')]) {
+              sh '''
+                set -e
+                (umask 077; echo "$GITHUB_TOKEN" > ~/.github-token)
+                # Use pip to get the Python scripts (with all the correct dependencies)
+                export PYTHONUSERBASE=$PWD/localpython
+                export PATH=$PYTHONUSERBASE/bin:$HOME/.local/bin${PATH:+:}$PATH
+                rm -rf "$PYTHONUSERBASE"
+                yum install -y python3-pip python3-devel python3-setuptools
+                pip3 install --user --upgrade "git+https://github.com/$ALIBOT_SLUG"
+                type check-open-pr
+                case "$PACKAGE_NAME" in
+                  AliPhysics) WAIT_TESTS='build/AliPhysics/release build/AliPhysics/root6';;
+                  *) WAIT_TESTS=build/$PACKAGE_NAME/release;;
+                esac
+                while ! check-open-pr "$WAIT_PR_LIMIT" "alisw/$PACKAGE_NAME" $WAIT_TESTS; do
+                  echo 'Waiting for all pull requests to be merged' >&2
+                  sleep 120
+                done
+              '''
+            }
           }
         }
       }
+    } else {
+      println('Not waiting for open pull requests')
     }
-    else {
-      println("Not waiting for open pull requests")
+  }
+
+  node("$ARCHITECTURE-$MESOS_QUEUE_SIZE") {
+    stage('Configure credentials') {
+      withCredentials([usernamePassword(credentialsId: 'github_alibuild',
+                                        usernameVariable: 'GITHUB_USER',
+                                        passwordVariable: 'GITHUB_PASS'),
+                       usernamePassword(credentialsId: '369b09bf-5f5e-4b68-832a-2f30cad28755',
+                                        usernameVariable: 'GITCERN_USER',
+                                        passwordVariable: 'GITCERN_PASS'),
+                       usernamePassword(credentialsId: 'gitlab_alibuild',
+                                        usernameVariable: 'GITLAB_USER',
+                                        passwordVariable: 'GITLAB_PASS')]) {
+        sh '''
+          set -eo pipefail
+          git config --global user.name 'ALICE Builder'
+          git config --global user.email alibuild@cern.ch
+          git config --global credential.helper "store --file $PWD/git-creds"
+          printf 'protocol=https\\nhost=%s\\nusername=%s\\npassword=%s\\n' \
+                 github.com "$GITHUB_USER" "$GITHUB_PASS"                  \
+                 git.cern.ch "$GITCERN_USER" "$GITCERN_PASS"               \
+                 gitlab.cern.ch "$GITLAB_USER" "$GITLAB_PASS"              |
+            git credential-store --file git-creds store
+        '''
+      }
     }
 
-    node ("$ARCHITECTURE-$MESOS_QUEUE_SIZE") {
-
-      stage "Config credentials"
-      withCredentials([[$class: 'UsernamePasswordMultiBinding',
-                        credentialsId: 'github_alibuild',
-                        usernameVariable: 'GIT_BOT_USER',
-                        passwordVariable: 'GIT_BOT_PASS']]) {
-        sh '''
-          set -e
-          set -o pipefail
-          printf "protocol=https\nhost=github.com\nusername=$GIT_BOT_USER\npassword=$GIT_BOT_PASS\n" | \
-            git credential-store --file $PWD/git-creds store
-        '''
-      }
-      withCredentials([[$class: 'UsernamePasswordMultiBinding',
-                        credentialsId: '369b09bf-5f5e-4b68-832a-2f30cad28755',
-                        usernameVariable: 'GIT_BOT_USER',
-                        passwordVariable: 'GIT_BOT_PASS']]) {
-        sh '''
-          set -e
-          set -o pipefail
-          printf "protocol=https\nhost=git.cern.ch\nusername=$GIT_BOT_USER\npassword=$GIT_BOT_PASS\n" | \
-            git credential-store --file $PWD/git-creds store
-        '''
-      }
-      withCredentials([[$class: 'UsernamePasswordMultiBinding',
-                        credentialsId: 'gitlab_alibuild',
-                        usernameVariable: 'GIT_BOT_USER',
-                        passwordVariable: 'GIT_BOT_PASS']]) {
-        sh '''
-          set -e
-          set -o pipefail
-          printf "protocol=https\nhost=gitlab.cern.ch\nusername=$GIT_BOT_USER\npassword=$GIT_BOT_PASS\n" | \
-            git credential-store --file $PWD/git-creds store
-        '''
-      }
-      sh '''
-        set -e
-        git config --global credential.helper "store --file $PWD/git-creds"
-        ls -l $PWD/git-creds
-      '''
-
-      stage "Create daily"
-      retry (2) {
-        timeout (240) {
-          withEnv(["ALIBUILD_SLUG=${ALIBUILD_SLUG}",
-                   "ALIDIST_SLUG=${ALIDIST_SLUG}",
-                   "ALIBOT_SLUG=${ALIBOT_SLUG}",
-                   "ARCHITECTURE=${ARCHITECTURE}",
-                   "PACKAGE_NAME=${PACKAGE_NAME}",
-                   "DEFAULTS=${DEFAULTS}",
-                   "TEST_TAG=${TEST_TAG}",
-                   "REMOTE_STORE=${REMOTE_STORE}",
-                   "AUTOTAG_PATTERN=${AUTOTAG_PATTERN}",
-                   "AUTOTAG_OVERRIDE_VERSION=${AUTOTAG_OVERRIDE_VERSION}",
-                   "MESOS_QUEUE_SIZE=${MESOS_QUEUE_SIZE}",
-                   "REMOVE_RC_BRANCH_FIRST=${REMOVE_RC_BRANCH_FIRST}",
+    stage('Build and tag daily') {
+      retry(2) {
+        timeout(240) {
+          withEnv(["ALIBUILD_SLUG=$ALIBUILD_SLUG",
+                   "ALIDIST_SLUG=$ALIDIST_SLUG",
+                   "ALIBOT_SLUG=$ALIBOT_SLUG",
+                   "ARCHITECTURE=$ARCHITECTURE",
+                   "PACKAGE_NAME=$PACKAGE_NAME",
+                   "DEFAULTS=$DEFAULTS",
+                   "AUTOTAG_TAG=" + AUTOTAG_TAG,
+                   "REMOTE_STORE=$REMOTE_STORE",
+                   "AUTOTAG_OVERRIDE_VERSION=$AUTOTAG_OVERRIDE_VERSION",
+                   "REMOVE_RC_BRANCH_FIRST=$REMOVE_RC_BRANCH_FIRST",
                    "NODE_NAME=${env.NODE_NAME}"]) {
             sh '''
-              set -ex
-              [ -d /etc/profile.d/enable-alice.sh ] && source /etc/profile.d/enable-alice.sh
-              export PYTHONUSERBASE=${PWD}/python-bin
-              export PATH=${PYTHONUSERBASE}/bin:$PATH
-              export LD_LIBRARY_PATH=${PYTHONUSERBASE}/lib:${LD_LIBRARY_PATH}
-              echo $NODE_NAME
-              case $NODE_NAME in
+              set +ex   # We don't care about tracing these, and we ignore errors.
+              [ -f /etc/profile.d/enable-alice.sh ] && . /etc/profile.d/enable-alice.sh
+              [ -f /opt/rh/rh-git218/enable ] && . /opt/rh/rh-git218/enable
+              set -ex   # Back to our code, so reenable tracing and errexit.
+              case "$NODE_NAME" in
                 *slc6_x86-64*)
                   # python3 is not installed on the slc6-builder. Installing it seems to break the build.
-                  pip install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG ;;
+                  pip=pip ;;
                 *)
                   yum install -y python3-devel python3-pip python3-setuptools
-                  pip3 install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG ;;
+                  pip=pip3 ;;
               esac
-              [ -f /opt/rh/rh-git218/enable ] && source /opt/rh/rh-git218/enable
-              daily-tags.sh || err=$?
-              rm -rf alidist daily-tags.?????????? mirror
-              exit ${err-0}
+              export PYTHONUSERBASE=$PWD/python-bin
+              export PATH=$PYTHONUSERBASE/bin:$HOME/.local/bin${PATH:+:}$PATH
+              export LD_LIBRARY_PATH=${PYTHONUSERBASE}/lib:${LD_LIBRARY_PATH}
+              "$pip" install --user --upgrade git+https://github.com/$ALIBOT_SLUG \
+                     "${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild}"
+              exec daily-tags.sh
             '''
           }
         }
       }
     }
   }
-  catch (e) {
-    // Notify failures
-    emailext(subject: "Daily ${PACKAGE_NAME} tag failed",
-             body: "More details here: ${env.BUILD_URL}",
-             to: "${NOTIFY_EMAILS}")
-    throw e
-  }
+
+} catch (e) {
+  // Notify of any build failures.
+  emailext(subject: "Daily $PACKAGE_NAME tag failed",
+           body: "More details here: ${env.BUILD_URL}",
+           to: "$NOTIFY_EMAILS")
+  throw e
 }


### PR DESCRIPTION
- parse `AUTOTAG_PATTERN` before build starts

  This avoids bugs where waiting for PRs to be merged can make the build roll over midnight, which leads to `AUTOTAG_TAG` holding the wrong date.

- separate steps run in non-overlapping `node` blocks

  This means a slot of the slc7-light builder is not taken up by a daily build that is not waiting for pull requests any more. If waiting for PRs is disabled, the script also doesn't need an slc7-light slot at all any more.

- `daily-tags.sh` now uses `git rev-parse` instead of parsing `git ls-remote`

  This improves pre-build setup dramatically. As we clone the package's repo anyway, we may as well get the hashes directly instead of making three additional network requests.

- removed `TEST_TAG` and `JOBS` settings

  `TEST_TAG` would previously prepend a string to the tag to be generated. This can just as easily be done using `AUTOTAG_PATTERN`, so this extra option isn't needed.

  `JOBS` was previously set depending on `MESOS_QUEUE_SIZE`, but we always run on identically-sized nodes anyway, so this complexity isn't needed.

- readability improvements and simplification

  I combined the credential setup into a single step, so it's easier to read and executes faster. Alibuild is installed in the Jenkins script, not in `daily-tags.sh`, to simplify the latter; while cleanup is done in the shell script, as the required variables are available there. I also improved quoting in the shell script.