### PR TITLE
Don't sync UpdRPMS for CC7 and CC8

### DIFF
--- a/publish/run-all-rpms.sh
+++ b/publish/run-all-rpms.sh
@@ -39,8 +39,6 @@ done
 
 timeout 300 rclone sync --config /secrets/alibuild_rclone_config --transfers=10 --verbose \
         "local:/repo/RPMS/$arch/" "rpms3:alibuild-repo/RPMS/$arch/" || true
-timeout 300 rclone sync --config /secrets/alibuild_rclone_config --transfers=10 --verbose \
-        "local:/repo/UpdRPMS/$arch/" "rpms3:alibuild-repo/UpdRPMS/$arch/" || true
 
 # Now that we've uploaded all the new RPMs, we can delete the canary files to
 # tell Jenkins jobs that we're done.


### PR DESCRIPTION
We aren't producing updatable RPMs at the moment, so no need to sync the directory.