### PR TITLE
Convert run-all-rpms.sh to long-running job

### DIFF
--- a/publish/run-all-rpms.sh
+++ b/publish/run-all-rpms.sh
@@ -17,29 +17,38 @@ export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 # This script is in the same directory as aliPublish{,S3} in the ali-bot repo.
 cd "$(dirname "$0")"
 
-# Look for any canary files from Jenkins builds that finished since we last ran.
-# We'll remove these once we're done, so that the respective Jenkins jobs can
-# look for the RPMs they expect.
-# We build this file list now as aliPublish can take some time, and other builds
-# (that we don't want to notify yet) might finish in the meantime. We run
-# aliPublish only for one specific architecture, so we have
-# architecture-specific canary files under rpmstatus/$arch/.
-s3cmd ls "s3://alibuild-repo/rpmstatus/$arch/" | cut -b 32- > canaries.txt
+while true; do
+  # Reset the specified git repository to its original, remote state.
+  git fetch -f origin +master:refs/remotes/origin/master
+  git reset --hard origin/master
+  git clean -fxd
 
-case "$arch" in
-  el8.*)
-    pip install boto3    # aliPublishS3 needs boto3.
-    aliPublish=./aliPublishS3;;
-  *) aliPublish=./aliPublish;;
-esac
+  # Look for any canary files from Jenkins builds that finished since we last ran.
+  # We'll remove these once we're done, so that the respective Jenkins jobs can
+  # look for the RPMs they expect.
+  # We build this file list now as aliPublish can take some time, and other builds
+  # (that we don't want to notify yet) might finish in the meantime. We run
+  # aliPublish only for one specific architecture, so we have
+  # architecture-specific canary files under rpmstatus/$arch/.
+  s3cmd ls "s3://alibuild-repo/rpmstatus/$arch/" | cut -b 32- > canaries.txt
 
-for conf in "$@"; do
-  "$aliPublish" --config "$conf" --debug sync-rpms >&2
+  case "$arch" in
+    el8.*)
+      pip install boto3    # aliPublishS3 needs boto3.
+      aliPublish=./aliPublishS3;;
+    *) aliPublish=./aliPublish;;
+  esac
+
+  for conf in "$@"; do
+    "$aliPublish" --config "$conf" --debug sync-rpms >&2
+  done
+
+  timeout 300 rclone sync --config /secrets/alibuild_rclone_config --transfers=10 --verbose \
+          "local:/repo/RPMS/$arch/" "rpms3:alibuild-repo/RPMS/$arch/" || true
+
+  # Now that we've uploaded all the new RPMs, we can delete the canary files to
+  # tell Jenkins jobs that we're done.
+  xargs -rtd '\n' -a canaries.txt s3cmd rm
+
+  sleep 120
 done
-
-timeout 300 rclone sync --config /secrets/alibuild_rclone_config --transfers=10 --verbose \
-        "local:/repo/RPMS/$arch/" "rpms3:alibuild-repo/RPMS/$arch/" || true
-
-# Now that we've uploaded all the new RPMs, we can delete the canary files to
-# tell Jenkins jobs that we're done.
-xargs -rtd '\n' -a canaries.txt s3cmd rm


### PR DESCRIPTION
This is so that it doesn't keep creating docker containers.