### PR TITLE
Parse AUTOTAG_PATTERN before waiting for PRs

### DIFF
--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -4,7 +4,7 @@ set -x
 # Check for required variables
 ALIDIST_SLUG=${ALIDIST_SLUG:-alisw/alidist@master}
 [ ! -z "$PACKAGE_NAME" ]
-[ ! -z "$AUTOTAG_PATTERN" ]
+[ ! -z "$AUTOTAG_TAG" ]
 [ ! -z "$NODE_NAME" ]
 
 # Clean up old stuff
@@ -28,7 +28,6 @@ PACKAGE_LOWER=$(echo $PACKAGE_NAME | tr '[[:upper:]]' '[[:lower:]]')
 RECIPE=alidist/$PACKAGE_LOWER.sh
 AUTOTAG_REMOTE=$(grep -E '^(source:|write_repo:)' $RECIPE | sort -r | head -n1 | cut -d: -f2- | xargs echo)
 AUTOTAG_MIRROR=$MIRROR/$PACKAGE_LOWER
-AUTOTAG_TAG=$(LANG=C TZ=Europe/Rome date +"$AUTOTAG_PATTERN")
 [[ "$TEST_TAG" == "true" ]] && AUTOTAG_TAG=TEST-IGNORE-$AUTOTAG_TAG
 echo "A Git tag will be created, upon success and if not existing, with the name $AUTOTAG_TAG"
 AUTOTAG_BRANCH=rc/$AUTOTAG_TAG

--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -1,7 +1,19 @@
 #!groovy
 node ("slc7_x86-64-light") {
   try {
-    currentBuild.displayName = "#${env.BUILD_NUMBER} - $PACKAGE_NAME $DEFAULTS $ARCHITECTURE"
+    stage('Construct tag name') {
+      /* Turn AUTOTAG_PATTERN into AUTOTAG_TAG now, before waiting for PRs,
+       * because waiting can take hours, and that would mean we use the incorrect
+       * date to name the tag.
+       * Run on any free node -- doesn't matter which, but we need one to use sh.
+       */
+      node {
+        AUTOTAG_TAG = sh(script: "LANG=C TZ=Europe/Zurich date '+$AUTOTAG_PATTERN'",
+                         returnStdout: true).trim()
+      }
+      currentBuild.displayName = ("#${env.BUILD_NUMBER} - $PACKAGE_NAME " +
+                                  AUTOTAG_TAG + " $DEFAULTS $ARCHITECTURE")
+    }
 
     stage "Wait pull requests"
     if ("$WAIT_PR" == "true") {
@@ -94,7 +106,7 @@ node ("slc7_x86-64-light") {
                    "DEFAULTS=${DEFAULTS}",
                    "TEST_TAG=${TEST_TAG}",
                    "REMOTE_STORE=${REMOTE_STORE}",
-                   "AUTOTAG_PATTERN=${AUTOTAG_PATTERN}",
+                   "AUTOTAG_TAG=" + AUTOTAG_TAG,
                    "AUTOTAG_OVERRIDE_VERSION=${AUTOTAG_OVERRIDE_VERSION}",
                    "MESOS_QUEUE_SIZE=${MESOS_QUEUE_SIZE}",
                    "REMOVE_RC_BRANCH_FIRST=${REMOVE_RC_BRANCH_FIRST}",


### PR DESCRIPTION
This fixes a bug where the date rolls over while waiting for PRs, leading to an incorrectly named tag.