### PR TITLE
Reduce Jenkins jobs to 8

### DIFF
--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -120,14 +120,11 @@ diff -rupN alidist/defaults-${DEFAULTS_LOWER}.sh.old alidist/defaults-${DEFAULTS
 workarea=$(mktemp -d "$PWD/daily-tags.XXXXXXXXXX")
 
 REMOTE_STORE="${REMOTE_STORE:-rsync://repo.marathon.mesos/store/::rw}"
-JOBS=8
-[[ $MESOS_QUEUE_SIZE == huge ]] && JOBS=30
-echo "Now running aliBuild on $JOBS parallel workers"
 aliBuild --reference-sources mirror                    \
          --debug                                       \
          --work-dir "$workarea"                        \
          ${ARCHITECTURE:+--architecture $ARCHITECTURE} \
-         --jobs 10                                     \
+         --jobs 8                                      \
          --fetch-repos                                 \
          --remote-store $REMOTE_STORE                  \
          ${DEFAULTS:+--defaults $DEFAULTS}             \


### PR DESCRIPTION
Builders are runnning out of memory, again.