### PR TITLE
Improve unit test result parsing

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -235,7 +235,7 @@ class Logs(object):
             r'=== List of errors found ===',
             context_before=0, context_after=float('inf'))
         self.failed_unit_tests = self.grepall(
-            r'Test *#[0-9]*: .*\*\*\*Failed|%% tests passed')
+            r'Test *#[0-9]*: .*\*\*\*(Failed|Timeout)|% tests passed')
         self.compiler_killed = self.grepall(
             r'fatal error: Killed signal terminated program')
         self.cmake_errors = self.grepall(


### PR DESCRIPTION
Find timed-out unit tests as well, not just failed ones.

A double `%` was included previously because a `grep` command was constructed using `%`-formatting. This isn't the case any more, so the duplicate `%%` means we accidentally ignore the unit test summary line.