### PR TITLE
Add [FATAL] messages (from O2 system test) to HTML log

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -226,7 +226,7 @@ class Logs(object):
         # logs also contain false positives, so o2checkcode_messages is better.
         self.errors_log = self.grepall(
             r': (internal compiler |fatal )?error:|^Error(:| in )|^fatal: |'
-            r'ninja: build stopped: |make.*: \*\*\*|\[ERROR\]|\*\*\*Failed',
+            r'ninja: build stopped: |make.*: \*\*\*|\[(ERROR|FATAL)\]|\*\*\*Failed',
             ignore_log_files=['*/o2checkcode-latest*/log'])
         self.warnings_log = self.grepall(
             r': warning:|^Warning: (?!Unused direct dependencies:$)',


### PR DESCRIPTION
Seen e.g. in <https://ali-ci.cern.ch/alice-build-logs/AliceO2Group/AliceO2/5745/eb46138d1ea6e0b9d651f18a92c39ad6700cf902/build_O2_fullCI/fullLog.txt>.