### PR TITLE
Add timeout to dev packages' git clone in CI

### DIFF
--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -55,16 +55,12 @@ export ALIBOT_ANALYTICS_USER_UUID ALIBOT_ANALYTICS_ARCHITECTURE
 export ALIBOT_ANALYTICS_APP_NAME=continuous-builder.sh
 
 # Get dependency development packages
-if [ -n "$DEVEL_PKGS" ]; then
-  echo "$DEVEL_PKGS" | while read -r gh_url branch checkout_name; do
-    : "${checkout_name:=$(basename "$gh_url")}"
-    if [ -d "$checkout_name" ]; then
-      reset_git_repository "$checkout_name"
-    else
-      git clone "https://github.com/$gh_url" ${branch:+--branch "$branch"} "$checkout_name"
-    fi
-  done
-fi
+# Use printf without a trailing newline so that the while loop doesn't run if
+# $DEVEL_PKGS is empty.
+printf %s "$DEVEL_PKGS" | while read -r gh_url branch checkout_name; do
+  reset_git_repository "${checkout_name:-$(basename "$gh_url")}" \
+                       "https://github.com/$gh_url" ${branch:+--branch "$branch"}
+done
 
 # Remove logs older than 5 days
 find separate_logs/ -type f -mtime +5 -delete || true

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -16,12 +16,6 @@ if [ "$1" != --skip-setup ]; then
               MONALISA_HOST MONALISA_PORT MESOS_ROLE CONTAINER_IMAGE \
               WORKER_INDEX WORKERS_POOL_SIZE
 
-  if ! [ -d ali-bot ]; then
-    # This is for *.env files. These should always be taken from ali-bot@master,
-    # irrespective of the *installed* ali-bot version required by each repo.
-    git clone https://github.com/alisw/ali-bot
-  fi
-
   # Disable aliBuild analytics prompt
   mkdir -p ~/.config/alibuild
   touch ~/.config/alibuild/disable-analytics
@@ -51,6 +45,12 @@ if [ "$1" != --skip-setup ]; then
   # when fetching some large repositories (e.g. O2, Clang).
   [ "$(ulimit -n)" -ge 10240 ] || ulimit -n 10240
 fi
+
+# Get updates to ali-bot, or clone it if it's the first time.
+# This is for *.env files. These should always be taken from ali-bot@master,
+# irrespective of the *installed* ali-bot version required by each repo.
+TIMEOUT=$(get_config_value timeout "${TIMEOUT:-600}") \
+       reset_git_repository ali-bot https://github.com/alisw/ali-bot
 
 # Generate example of force-hashes file. This is used to override what to check for testing
 if ! [ -e force-hashes ]; then
@@ -103,9 +103,6 @@ else
   # If we're idling, wait a while to conserve GitHub API requests.
   sleep "$(get_config_value timeout "${TIMEOUT:-600}")"
 fi
-
-# Get updates to ali-bot
-TIMEOUT=$(get_config_value timeout "${TIMEOUT:-600}") reset_git_repository ali-bot
 
 # Re-exec ourselves. This lets us update pick up updates to this script, e.g.
 # when upgraded by pip.


### PR DESCRIPTION
This git clone sometimes gets stuck, so clone it with a timeout instead.

This patch moves the shared cloning logic into reset_git_repository and calls it when needed -- this simplifies the separate logic for dev packages and ali-bot.