### PR TITLE
Get overrides before fetching PRs to build

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -69,6 +69,7 @@ fi
 # Get a list of PRs to build -- force-hashes overrides list-branch-pr.
 HASHES=$(grep -Eve '^[[:blank:]]*(#|$)' force-hashes || true)
 if [ -z "$HASHES" ]; then
+  get_config
   HASHES=$(list-branch-pr)
 fi
 


### PR DESCRIPTION
`WORKER_INDEX` and `WORKERS_POOL_SIZE` aren't set when `list-branch-pr` runs because they're only updated in a subshell. This PR also updates them when we fetch PRs.