### PR TITLE
Manually set required build vars for CC8 O2 builds

### DIFF
--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -122,6 +122,15 @@ node ("slc7_x86-64-light") {
                 *slc6_x86-64*)
                   # python3 is not installed on the slc6-builder. Installing it seems to break the build.
                   pip install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG ;;
+                *slc8*)
+                  export ALIBUILD_O2_FORCE_GPU=1
+                  export ALIBUILD_O2_TESTS=
+                  export ENABLE_UPGRADES=ON
+                  export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+$CMAKE_PREFIX_PATH:}/opt/rocm/lib/cmake:/opt/clang/lib/cmake
+                  export AMDAPPSDKROOT=/opt/amd-app
+                  export PATH=$PATH${PATH:+:}/usr/local/cuda/bin
+                  yum install -y python3-devel python3-pip python3-setuptools
+                  pip3 install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG ;;
                 *)
                   yum install -y python3-devel python3-pip python3-setuptools
                   pip3 install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG ;;

--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -124,8 +124,6 @@ node ("slc7_x86-64-light") {
                   pip install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG ;;
                 *slc8*)
                   export ALIBUILD_O2_FORCE_GPU=1
-                  export ALIBUILD_O2_TESTS=
-                  export ENABLE_UPGRADES=ON
                   export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+$CMAKE_PREFIX_PATH:}/opt/rocm/lib/cmake:/opt/clang/lib/cmake
                   export AMDAPPSDKROOT=/opt/amd-app
                   export PATH=$PATH${PATH:+:}/usr/local/cuda/bin


### PR DESCRIPTION
These are already set in the Docker container, but those settings apparently aren't applied in our build containers.