### PR TITLE
Use Ubuntu 18.04 for PR checker

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
`ubuntu-latest` is now Ubuntu 20.04, which doesn't provide a package for `pip2`. Using Ubuntu 18.04, we can continue to test using `python3` and `python2`.