### PR TITLE
Use Python 3 for aliBuild in Jenkins and CI

### DIFF
--- a/build-any-ib.sh
+++ b/build-any-ib.sh
@@ -29,11 +29,7 @@ WORKAREA_INDEX=0
 export PYTHONUSERBASE=$(mktemp -d)
 export PATH=$PYTHONUSERBASE/bin:$PATH
 export LD_LIBRARY_PATH=$PYTHONUSERBASE/lib:$LD_LIBRARY_PATH
-case $ARCHITECTURE in
-  slc8*) PIP=pip3 ; PYTHON=python3 ;;
-  *) PIP=pip ; PYTHON=python ;;
-esac
-$PIP install --user --ignore-installed --upgrade ${ALIBUILD_SLUG:+"git+https://github.com/${ALIBUILD_SLUG}"}
+pip3 install --user --upgrade "git+https://github.com/$ALIBUILD_SLUG"
 type aliBuild
 
 rm -rf alidist
@@ -67,7 +63,7 @@ echo $NODE_NAME > $WORKAREA/$WORKAREA_INDEX/current_slave
 env OVERRIDE_TAGS="$OVERRIDE_TAGS"         \
     OVERRIDE_VERSIONS="$OVERRIDE_VERSIONS" \
     DEFAULTS="$DEFAULTS"                   \
-$PYTHON <<\EOF
+python3 <<\EOF
 import yaml
 from os import environ
 f = "alidist/defaults-%s.sh" % environ["DEFAULTS"].lower()

--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -46,7 +46,7 @@ function clean_env () {
 function pipinst () {
   # Sometimes pip gets stuck when cloning the ali-bot or alibuild repos. In
   # that case: time out, skip and try again later.
-  short_timeout pip install --upgrade --upgrade-strategy only-if-needed "git+https://github.com/$1"
+  short_timeout pip3 install --upgrade --upgrade-strategy only-if-needed "git+https://github.com/$1"
 }
 
 # Allow overriding a number of variables by fly, so that we can change the

--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -20,9 +20,7 @@ git config --global user.email alibuild@cern.ch
 git clone -b $ALIDIST_BRANCH https://github.com/$ALIDIST_REPO alidist/
 
 # Install the latest release if ALIBUILD_SLUG is not provided
-pip install --user --ignore-installed --upgrade ${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild} ||
-  # Fall back to explicit pip version if `pip` doesn't exist, like on CentOS 8. (There, python is python3.)
-  pip3 install --user --ignore-installed --upgrade ${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild}
+pip3 install --user --upgrade ${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild}
 
 PACKAGE_LOWER=$(echo $PACKAGE_NAME | tr '[[:upper:]]' '[[:lower:]]')
 RECIPE=alidist/$PACKAGE_LOWER.sh

--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -32,8 +32,7 @@ node ("slc7_x86-64-light") {
               export PYTHONUSERBASE="$PWD/localpython"
               export PATH="$PYTHONUSERBASE/bin:$PATH"
               rm -rf "$PYTHONUSERBASE"
-              yum install -y python3-pip python3-devel python3-setuptools
-              pip3 install --user --upgrade --ignore-installed "${ALIBOT_SLUG:+git+https://github.com/${ALIBOT_SLUG}}"
+              pip3 install --user --upgrade "git+https://github.com/$ALIBOT_SLUG"
               type check-open-pr
               if [[ $PACKAGE_NAME == AliPhysics ]]; then
                 WAIT_TESTS="build/AliPhysics/release build/AliPhysics/root6"
@@ -119,20 +118,13 @@ node ("slc7_x86-64-light") {
               export LD_LIBRARY_PATH=${PYTHONUSERBASE}/lib:${LD_LIBRARY_PATH}
               echo $NODE_NAME
               case $NODE_NAME in
-                *slc6_x86-64*)
-                  # python3 is not installed on the slc6-builder. Installing it seems to break the build.
-                  pip install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG ;;
                 *slc8*)
                   export ALIBUILD_O2_FORCE_GPU=1
                   export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+$CMAKE_PREFIX_PATH:}/opt/rocm/lib/cmake:/opt/clang/lib/cmake
                   export AMDAPPSDKROOT=/opt/amd-app
-                  export PATH=$PATH${PATH:+:}/usr/local/cuda/bin
-                  yum install -y python3-devel python3-pip python3-setuptools
-                  pip3 install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG ;;
-                *)
-                  yum install -y python3-devel python3-pip python3-setuptools
-                  pip3 install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG ;;
+                  export PATH=$PATH${PATH:+:}/usr/local/cuda/bin ;;
               esac
+              pip3 install --upgrade --user git+https://github.com/$ALIBOT_SLUG
               [ -f /opt/rh/rh-git218/enable ] && source /opt/rh/rh-git218/enable
               daily-tags.sh || err=$?
               rm -rf alidist daily-tags.?????????? mirror


### PR DESCRIPTION
This changes the CI builders and the build-any-ib and daily-tags Jenkins jobs to install alibuild with pip3 instead of pip2.

There are probably more Jenkins jobs that have to be changed manually. Is there anything else that uses alibuild that I've missed?