### PR TITLE
Fix CI skipping PRs in the queue

### DIFF
--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -32,7 +32,7 @@ echo "$HASHES" | tail -n "+$((BUILD_SEQ + 1))" | cat -n | while read -r ahead bt
     cd ..
     source_env_files "$envf"
     PR_NUMBER=$num PR_HASH=$hash report_pr_errors --pending -m "Queued ($ahead ahead) on $host_id"
-  ); fi
+  ); fi < /dev/null  # Stop commands from slurping hashes, just in case.
 done
 
 if [ "$BUILD_TYPE" = untested ]; then
@@ -57,8 +57,9 @@ export ALIBOT_ANALYTICS_APP_NAME=continuous-builder.sh
 # Get dependency development packages
 if [ -n "$DEVEL_PKGS" ]; then
   echo "$DEVEL_PKGS" | while read -r gh_url branch checkout_name; do
-    reset_git_repository "${checkout_name:-$(basename "$gh_url")}" \
-                         "https://github.com/$gh_url" ${branch:+--branch "$branch"}
+    reset_git_repository "${checkout_name:-$(basename "$gh_url")}"                  \
+                         "https://github.com/$gh_url" ${branch:+--branch "$branch"} \
+                         < /dev/null   # Make sure we're not reading DEVEL_PKGS here.
   done
 fi
 

--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -98,10 +98,10 @@ if [ -n "$HASHES" ]; then
 
     # Run the build
     . build-loop.sh
-  ); done &&
-    # If the loop succeeded, remove force-hashes so we don't keep building the
-    # same PRs forever.
-    rm -f force-hashes
+
+    # Something inside this subshell is reading stdin, which causes some hashes
+    # from above to be ignored. It shouldn't, so redirect from /dev/null.
+  ) < /dev/null; done
 else
   # If we're idling, wait a while to conserve GitHub API requests.
   sleep "$(get_config_value timeout "${TIMEOUT:-600}")"


### PR DESCRIPTION
I suspect that something inside build-helpers is reading its stdin. This causes the remaining contents of `$HASHES` to be discarded, so the outer loop doesn't process the last PRs in its queue.

I also patched the other places where we use `echo | while read`, just in case.