### PR TITLE
Fix pip installation on OSX

### DIFF
--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -46,7 +46,8 @@ function clean_env () {
 function pipinst () {
   # Sometimes pip gets stuck when cloning the ali-bot or alibuild repos. In
   # that case: time out, skip and try again later.
-  short_timeout pip install --upgrade --upgrade-strategy only-if-needed "git+https://github.com/$1"
+  # pip's shebang mangling messes up if we don't use --install-option=--old-and-unmanageable.
+  short_timeout pip install --upgrade --install-option=--old-and-unmanageable "git+https://github.com/$1"
 }
 
 # Allow overriding a number of variables by fly, so that we can change the


### PR DESCRIPTION
We need to use `--install-option=--old-and-unmanageable` to avoid pip's shebang mangling giving us nothing. (Without that option, scripts would have `#!python`, which doesn't work.)