### PR TITLE
Add alidist o2-dataflow check on CentOS Stream 8

### DIFF
--- a/ci/repo-config/mesosci/cs8/o2-alidist-dataflow.env
+++ b/ci/repo-config/mesosci/cs8/o2-alidist-dataflow.env
@@ -1,0 +1,11 @@
+CI_NAME=build_O2_alidist-dataflow-cs8
+PACKAGE=O2Suite
+ALIBUILD_DEFAULTS=o2-dataflow
+PR_REPO=alisw/alidist
+PR_BRANCH=master
+NO_ASSUME_CONSISTENT_EXTERNALS=
+TRUST_COLLABORATORS=true
+CHECK_NAME=build/O2/alidist-dataflow-cs8
+DONT_USE_COMMENTS=1
+DEVEL_PKGS="$PR_REPO $PR_BRANCH
+AliceO2Group/AliceO2 dev O2"


### PR DESCRIPTION
This is the only check to be newly added (instead of migrated from slc8), so use this for testing.