### PR TITLE
Publish one-off releases for AliRoot

### DIFF
--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -68,6 +68,8 @@ architectures:
       AliRoot:
        - ^v5-0[45]-Rev-.+$
        - ^v5-.*-itsmisalign-[0-9]+$
+       # One-off releases for https://alice.its.cern.ch/jira/browse/ALIROOT-8707
+       - ^v5-10-01-test-hepmc-[0-9]+$
       AliGenerators:
        - ^v20[0-9]{2}(0[0-9]|1[012])(0[0-9]|[12][0-9]|3[01])-[0-9]+$
       FLUKA_VMC:


### PR DESCRIPTION
Needed for https://alice.its.cern.ch/jira/browse/ALIROOT-8707.

@ktf, is this the correct file for lxplus/Grid publishing or do I need to add it elsewhere?