### PR TITLE
Omit confusing context lines from HTML log for unit test results

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -236,7 +236,8 @@ class Logs(object):
             r'=== List of errors found ===',
             context_before=0, context_after=float('inf'))
         self.failed_unit_tests = self.grepall(
-            r'Test *#[0-9]*: .*\*\*\*(Failed|Timeout)|% tests passed')
+            r'Test *#[0-9]*: .*\*\*\*(Failed|Timeout)|% tests passed',
+            context_before=0, context_after=0)
         self.compiler_killed = self.grepall(
             r'fatal error: Killed signal terminated program')
         self.cmake_errors = self.grepall(


### PR DESCRIPTION
These context lines are just noise, and hide the important information.