### PR TITLE
bulk-change-pr-status: Allow filtering by date

### DIFF
--- a/bulk-change-pr-status
+++ b/bulk-change-pr-status
@@ -11,6 +11,7 @@ This script is useful when cleaning up after a stuck CI builder.
 
 from __future__ import print_function
 from argparse import ArgumentParser, Namespace
+from datetime import datetime, timezone
 from os.path import expanduser
 from sys import stderr
 
@@ -19,24 +20,33 @@ import alibot_helpers.github_utilities as ghutil
 
 def deduplicate_statuses(cgh, repo, pull_hash):
     '''Create a list of the latest status only for each check.'''
-    all_statuses = [(s['context'], s['created_at'], s['state'])
-                    for s in cgh.get('/repos/{repo}/commits/{ref}/statuses',
-                                     repo=repo, ref=pull_hash)]
+    all_statuses = [
+        (s['context'],
+         datetime.fromisoformat(s['updated_at'].replace('Z', '+00:00')),
+         s['state'])
+        for s in cgh.get('/repos/{repo}/commits/{ref}/statuses',
+                         repo=repo, ref=pull_hash)
+    ]
     # For each context (= check), sort statuses, newest last.
     all_statuses.sort()
     # Newer statuses 'overwrite' older ones in this dict comprehension.
-    return {check: state for check, _, state in all_statuses}
+    return {check: (date, state) for check, date, state in all_statuses}
 
 
 def process_pr(cgh, args, repo, pull):
     '''Set the statuses on a single pull request.'''
     pull_hash = pull['head']['sha']
-    for check, state in deduplicate_statuses(cgh, repo, pull_hash).items():
+    for check, (date, state) in deduplicate_statuses(cgh, repo, pull_hash).items():
         if check in args.check_name:
-            if not args.do_it and state == args.from_status:
+            should_process = state == args.from_status and \
+                args.filter_after < date < args.filter_before
+            if not should_process:
+                # This isn't a status we should change.
+                action = 'no change'
+            elif not args.do_it:
                 # -y not given, so only say what we would do.
                 action = 'would change'
-            elif state == args.from_status:
+            else:
                 # This is a status we want to change and we have -y, so do it.
                 ghutil.setGithubStatus(cgh, Namespace(
                     # Of the form org/repo#pr@sha, but setGithubStatus doesn't
@@ -46,15 +56,12 @@ def process_pr(cgh, args, repo, pull):
                     message=args.message,
                     url=''))
                 action = 'changed'
-            else:
-                # This isn't a status we should change.
-                action = 'no change'
 
             # Log line to show what PR and check we're processing.
-            pr_line = '{action:>13}: {repo}#{pr} {check}/{status}'.format(
-                action=action, repo=repo, pr=pull['number'], check=check,
-                status=state)
-            if state == args.from_status and state != args.to_status:
+            pr_line = '{action:>13}: {repo}#{pr} @{date} {check}/{status}' \
+                .format(action=action, repo=repo, pr=pull['number'], date=date,
+                        check=check, status=state)
+            if should_process:
                 pr_line += ' -> ' + args.to_status
             print(pr_line, file=stderr)
 
@@ -77,17 +84,28 @@ def main(args):
 def parse_args():
     '''Parse and return command-line arguments.'''
     statuses = ('success', 'error', 'failure', 'pending')
-    parser = ArgumentParser(
-        description=__doc__,
-        epilog=('Note that you have to pass -y/--do-it to actually send '
-                "any requested changes to GitHub! If that option isn't given, "
-                'the script just prints out what it would do.'))
+    parser = ArgumentParser(description=__doc__, epilog='''\
+    Note that you have to pass -y/--do-it to actually send any requested
+    changes to GitHub! If that option isn't given, the script just prints
+    out what it would do. DATE arguments are in the format understood by
+    datetime.fromisoformat: YYYY-mm-dd[?HH[:MM[:SS[+HH:MM]]]] (? stands for
+    any character; things in [] are optional). If no +HH:MM timezone offset is
+    given, UTC is assumed.
+    ''')
     parser.add_argument('-y', '--do-it', action='store_true',
                         help=("actually change the statuses, "
                               "don't just print what would be done"))
     parser.add_argument('-C', '--github-cache-file', metavar='GHCACHE',
                         default=expanduser('~/.github-cached-commits'),
-                        help='GitHub cache location (default %(default)s)')
+                        help='GitHub cache location; default %(default)s')
+    parser.add_argument('-b', '--before', metavar='DATE', type=datetime.fromisoformat,
+                        default=datetime.now(), dest='filter_before',
+                        help=('change only statuses last updated (strictly) '
+                              'before %(metavar)s; default now'))
+    parser.add_argument('-a', '--after', metavar='DATE', type=datetime.fromisoformat,
+                        default=datetime(1970, 1, 1), dest='filter_after',
+                        help=('change only statuses last updated (strictly) '
+                              'after %(metavar)s; default %(default)s'))
     parser.add_argument('-f', '--from', metavar='FROM', choices=statuses,
                         default='error', dest='from_status',
                         help=('change checks with this status; '
@@ -102,7 +120,12 @@ def parse_args():
                         help='repository slug, may be given multiple times')
     parser.add_argument('-c', '--check-name', action='append', required=True,
                         help='check name, may be given multiple times')
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.filter_before.tzinfo is None:
+        args.filter_before = args.filter_before.replace(tzinfo=timezone.utc)
+    if args.filter_after.tzinfo is None:
+        args.filter_after = args.filter_after.replace(tzinfo=timezone.utc)
+    return args
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes it easier to only reset checks from before a particular change was introduced.