### PR TITLE
Add a CI job for O2Physics

### DIFF
--- a/ci/repo-config/mesosci/slc7/o2physics.env
+++ b/ci/repo-config/mesosci/slc7/o2physics.env
@@ -1,0 +1,11 @@
+CI_NAME=build_O2Physics_o2
+PACKAGE=O2Physics
+ALIBUILD_DEFAULTS=o2
+PR_REPO=AliceO2Group/O2Physics
+PR_BRANCH=master
+TRUST_COLLABORATORS=true
+CHECK_NAME=build/O2Physics/o2
+DONT_USE_COMMENTS=1
+DEVEL_PKGS="$PR_REPO $PR_BRANCH
+alisw/alidist master"
+JOBS=7


### PR DESCRIPTION
This simply builds O2Physics. No unit tests are defined in that repo yet.