### PR TITLE
Publisher: Install concurrent.futures for boto3

### DIFF
--- a/publish/run-all-rpms.sh
+++ b/publish/run-all-rpms.sh
@@ -34,7 +34,8 @@ while true; do
 
   case "$arch" in
     el8.*)
-      pip install boto3    # aliPublishS3 needs boto3.
+      # aliPublishS3 needs boto3, which in turn needs concurrent.futures.
+      pip install boto3 futures
       aliPublish=./aliPublishS3;;
     *) aliPublish=./aliPublish;;
   esac


### PR DESCRIPTION
Boto3 is dropping support for python2, so we should move aliPublish over to python3. As a stopgap to make the publisher work for now, install concurrent.futures ourselves.