### PR TITLE
Install dependencies for aliPublish

### DIFF
--- a/publish/get-and-run.sh
+++ b/publish/get-and-run.sh
@@ -67,6 +67,8 @@ if [[ ! $NO_UPDATE ]]; then
   popd
 fi
 
+pip3 install --user -Ur "$DEST/requirements.txt"
+
 ln -nfs $(basename $LOG.error) $PWD/log/latest
 CACHE=$PWD/cache
 mkdir -p $CACHE


### PR DESCRIPTION
aliPublish is run using python3, so use pip3 to install.