### PR TITLE
Only install minimal dependencies for the publisher

### DIFF
--- a/publish/get-and-run.sh
+++ b/publish/get-and-run.sh
@@ -67,7 +67,7 @@ if [[ ! $NO_UPDATE ]]; then
   popd
 fi
 
-pip3 install --user -Ur "$DEST/requirements.txt" || true
+pip3 install --user -U "$DEST"
 
 ln -nfs $(basename $LOG.error) $PWD/log/latest
 CACHE=$PWD/cache


### PR DESCRIPTION
Apparently using requirements.txt forces full installation, including the [services] stuff.