### PR TITLE
Only process one PR at a time

### DIFF
--- a/list-branch-pr
+++ b/list-branch-pr
@@ -286,7 +286,7 @@ def main(args):
 
     if grouped["untested"]:
         # If there are untested PRs waiting, build all of them first.
-        print_prs("untested")
+        print_prs("untested", 1)
     elif grouped["failed"] and (not grouped["succeeded"] or random.random() < 0.7):
         # Rebuild a failed PR, but sometimes fall through and rebuild a
         # successful one instead (if there are any). This is so a single red PR


### PR DESCRIPTION
This cuts down on long queues in CI builders, so they report pending statuses more often.