### PR TITLE
Make daily-tags compilation jobs configurable

### DIFF
--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -132,7 +132,7 @@ aliBuild --reference-sources mirror                    \
          --debug                                       \
          --work-dir "$workarea"                        \
          ${ARCHITECTURE:+--architecture $ARCHITECTURE} \
-         --jobs 8                                      \
+         --jobs "${JOBS:-8}"                           \
          --fetch-repos                                 \
          --remote-store $REMOTE_STORE                  \
          ${DEFAULTS:+--defaults $DEFAULTS}             \

--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -111,7 +111,8 @@ try {
                  "PYTHON_VERSION=${PYTHON_VERSION}",
                  "MESOS_QUEUE_SIZE=${MESOS_QUEUE_SIZE}",
                  "REMOVE_RC_BRANCH_FIRST=${REMOVE_RC_BRANCH_FIRST}",
-                 "NODE_NAME=${env.NODE_NAME}"]) {
+                 "NODE_NAME=${env.NODE_NAME}",
+                 "JOBS=${JOBS}"]) {
           sh '''
               set -ex
               [ -d /etc/profile.d/enable-alice.sh ] && source /etc/profile.d/enable-alice.sh


### PR DESCRIPTION
Now that O2Physics is a separate repo, it and O2 shouldn't take as much memory to compile.