### PR TITLE
Require EPEL release for python36

### DIFF
--- a/rpms/o2-prereq.spec
+++ b/rpms/o2-prereq.spec
@@ -14,7 +14,7 @@ Name: %scl_name
 Version: 1
 Release: 1%{?dist}
 License: GPLv2+
-Requires: make python-requests python-yaml pigz which git mysql-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libXi-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed environment-modules tk-devel libXinerama-devel libXcursor-devel libXrandr-devel
+Requires: make epel-release python-requests python-yaml pigz which git mysql-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libXi-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed environment-modules tk-devel libXinerama-devel libXcursor-devel libXrandr-devel
 BuildRequires: scl-utils-build
 
 %description


### PR DESCRIPTION
This is already embedded in the slc7-builder and it is required to be able to install and run aliBuild using python3 as it contains python36-requests and python36-pyyaml