### PR TITLE
Use python3 for aliBuild also on cc7

### DIFF
--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     container: centos:7
     env:
-      ALIBUILD_TAG: v1.8.8
+      ALIBUILD_TAG: v1.8.9
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -24,14 +24,14 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Build the EL7 RPM and create a yum repo.
         run: |
-          yum install -y rpm-build scl-utils-build createrepo unzip git python-setuptools
+          yum install -y rpm-build scl-utils-build createrepo unzip git python3-setuptools
           curl https://rclone.org/install.sh | bash
           rpmbuild -ba rpms/o2-prereq.spec
           git clone -b $ALIBUILD_TAG https://github.com/alisw/alibuild
           pushd alibuild
-            perl -p -i -e "s/LAST_TAG/$ALIBUILD_TAG/g" setup.py
-            python setup.py bdist_rpm --requires python,git,PyYAML
-            cp dist/alibuild-*.noarch.rpm ~/rpmbuild/RPMS/x86_64/ 
+            perl -p -i -e "s/LAST_TAG/$ALIBUILD_TAG/g" alibuild_helpers/__init__.py
+            python setup.py bdist_rpm --requires python3,python3-requests,git,python3-PyYAML
+            cp dist/alibuild-*.noarch.rpm ~/rpmbuild/RPMS/x86_64/
           popd
           cd ~/rpmbuild/RPMS/x86_64/
           createrepo .
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     container: centos:8
     env:
-      ALIBUILD_TAG: v1.8.8
+      ALIBUILD_TAG: v1.8.9
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -60,7 +60,7 @@ jobs:
           rpmbuild -ba rpms/o2-prereq-cc8.spec
           git clone -b $ALIBUILD_TAG https://github.com/alisw/alibuild
           pushd alibuild
-            perl -p -i -e "s/LAST_TAG/$ALIBUILD_TAG/g" setup.py
+            perl -p -i -e "s/LAST_TAG/$ALIBUILD_TAG/g" alibuild_helpers/__init__.py
             python3 setup.py bdist_rpm --requires python3,git,python3-pyyaml
             cp dist/alibuild-*.noarch.rpm ~/rpmbuild/RPMS/x86_64/
           popd
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:33
     env:
-      ALIBUILD_TAG: v1.8.8
+      ALIBUILD_TAG: v1.8.9
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -92,7 +92,7 @@ jobs:
           rpmbuild -ba --define '__python %__python3' rpms/o2-prereq-fedora.spec
           git clone -b $ALIBUILD_TAG https://github.com/alisw/alibuild
           pushd alibuild
-            perl -p -i -e "s/LAST_TAG/$ALIBUILD_TAG/g" setup.py
+            perl -p -i -e "s/LAST_TAG/$ALIBUILD_TAG/g" alibuild_helpers/__init__.py
             python3 setup.py bdist_rpm --requires python3,git,python3-pyyaml,python3-requests
             cp dist/alibuild-*.noarch.rpm ~/rpmbuild/RPMS/x86_64/
           popd


### PR DESCRIPTION
This will allow us to drop python2 builds on CC7.