### PR TITLE
Fix daily-tags.sh when a package has no git repo

### DIFF
--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -44,6 +44,7 @@ $PIP install --user --ignore-installed --upgrade ${ALIBUILD_SLUG:+git+https://gi
 
 for package in $PACKAGES; do (
   AUTOTAG_REMOTE=$(grep -E '^(source:|write_repo:)' "alidist/${package,,}.sh" | sort -r | head -n1 | cut -d: -f2- | xargs echo)
+  [ -n "$AUTOTAG_REMOTE" ] || continue
   AUTOTAG_MIRROR=$MIRROR/${package,,}
   echo "A Git tag will be created, upon success and if not existing, with the name $AUTOTAG_TAG"
   echo "A Git branch will be created to pinpoint the build operation, with the name rc/$AUTOTAG_TAG"
@@ -149,7 +150,7 @@ aliBuild --reference-sources mirror                    \
 
 # Now we tag, in case we should
 for package in $PACKAGES; do
-  pushd "${package,,}.git" &> /dev/null
+  pushd "${package,,}.git" &> /dev/null || continue
   if [ -n "$(git ls-remote origin "refs/tags/$AUTOTAG_TAG")" ]; then
     echo "Not tagging: tag $AUTOTAG_TAG exists already"
   else


### PR DESCRIPTION
In that case, we don't push a new tag for it, but still edit its `tag:`/`version:` keys (for the alidist tag).

This should fix O2PDPSuite builds, as that recipe doesn't have a `source:` key.