### PR TITLE
daily tags: If no tag is set in recipe, add it

### DIFF
--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -96,9 +96,14 @@ edit_tags () {
   # Patch package definition (e.g. o2.sh)
   local package tag=$1 version=$AUTOTAG_OVERRIDE_VERSION
   for package in $PACKAGES; do
-    sed -E -i.old \
-        "s|^tag: .*\$|tag: \"$tag\"|; ${version:+s|^version: .*\$|version: \"$version\"|}" \
-        "alidist/${package,,}.sh"
+    local sed_script="${version:+s|^version: .*\$|version: \"$version\"|;}"
+    if grep -q '^tag:' "alidist/${package,,}.sh"; then
+      sed_script="$sed_script s|^tag: .*\$|tag: \"$tag\"|"
+    else
+      sed_script="$sed_script 2i\\
+tag: \"$tag\""
+    fi
+    sed -E -i.old "$sed_script" "alidist/${package,,}.sh"
 
     # Patch defaults definition (e.g. defaults-o2.sh)
     # Process overrides by changing in-place the given defaults. This requires


### PR DESCRIPTION
If the recipe we're building doesn't specify a `tag:` key, we need to add one, as at this point in the script we cannot use the `version:` key instead (the latter doesn't have an `rc/` prefix.)

This misses the case where no tag is set in the recipe, but the default's override section sets a tag. In that case, a `tag:` line would be added to the recipe, but would be overridden by the default.