### PR TITLE
Reenable unit tests for QualityControl

### DIFF
--- a/ci/repo-config/macos/alibuildmac03/qualitycontrol-o2.env
+++ b/ci/repo-config/macos/alibuildmac03/qualitycontrol-o2.env
@@ -11,3 +11,4 @@ JOBS=4
 DEVEL_PKGS="$PR_REPO $PR_BRANCH $PR_REPO_CHECKOUT
 AliceO2Group/AliceO2 dev O2
 alisw/alidist master"
+ALIBUILD_O2_TESTS=1

--- a/ci/repo-config/mesosdaq/cs8/qualitycontrol-dataflow.env
+++ b/ci/repo-config/mesosdaq/cs8/qualitycontrol-dataflow.env
@@ -11,3 +11,4 @@ DONT_USE_COMMENTS=1
 DEVEL_PKGS="$PR_REPO $PR_BRANCH
 AliceO2Group/AliceO2 dev O2
 alisw/alidist master"
+ALIBUILD_O2_TESTS=1

--- a/ci/repo-config/mesosdaq/cs8/qualitycontrol.env
+++ b/ci/repo-config/mesosdaq/cs8/qualitycontrol.env
@@ -11,3 +11,4 @@ DONT_USE_COMMENTS=1
 DEVEL_PKGS="$PR_REPO $PR_BRANCH
 AliceO2Group/AliceO2 dev O2
 alisw/alidist master"
+ALIBUILD_O2_TESTS=1

--- a/ci/repo-config/mesosdaq/slc7/qualitycontrol-dataflow.env
+++ b/ci/repo-config/mesosdaq/slc7/qualitycontrol-dataflow.env
@@ -11,3 +11,4 @@ DONT_USE_COMMENTS=1
 DEVEL_PKGS="$PR_REPO $PR_BRANCH
 AliceO2Group/AliceO2 dev O2
 alisw/alidist master"
+ALIBUILD_O2_TESTS=1

--- a/ci/repo-config/mesosdaq/slc7/qualitycontrol.env
+++ b/ci/repo-config/mesosdaq/slc7/qualitycontrol.env
@@ -11,3 +11,4 @@ DONT_USE_COMMENTS=1
 DEVEL_PKGS="$PR_REPO $PR_BRANCH
 AliceO2Group/AliceO2 dev O2
 alisw/alidist master"
+ALIBUILD_O2_TESTS=1


### PR DESCRIPTION
These were accidentally disabled.

This also enables O2 unit tests (because both use the same variable), and because we check against O2@dev, we can't always reuse the nightly prebuilt tarballs, so checks will take a little longer.

Cc: @knopers8 @Barthelemy 