### PR TITLE
Reenable unit tests in Infologger and Monitoring

### DIFF
--- a/ci/repo-config/mesosdaq/slc7/infologger-dataflow.env
+++ b/ci/repo-config/mesosdaq/slc7/infologger-dataflow.env
@@ -9,3 +9,4 @@ CHECK_NAME=build/O2/InfoLogger
 DONT_USE_COMMENTS=1
 DEVEL_PKGS="$PR_REPO $PR_BRANCH
 alisw/alidist master"
+ALIBUILD_O2_TESTS=1

--- a/ci/repo-config/mesosdaq/slc7/monitoring-dataflow.env
+++ b/ci/repo-config/mesosdaq/slc7/monitoring-dataflow.env
@@ -10,3 +10,4 @@ CHECK_NAME=build/Monitoring/o2-dataflow
 DONT_USE_COMMENTS=1
 DEVEL_PKGS="$PR_REPO
 alisw/alidist master"
+ALIBUILD_O2_TESTS=1


### PR DESCRIPTION
As for QC. Also enables O2 tests, but in these cases we should be able to reuse nightly tarballs for O2.