### PR TITLE
Revert "Only process one PR at a time"

### DIFF
--- a/list-branch-pr
+++ b/list-branch-pr
@@ -287,7 +287,7 @@ def main(args):
 
     if grouped["untested"]:
         # If there are untested PRs waiting, build all of them first.
-        print_prs("untested", 1)
+        print_prs("untested")
     elif grouped["failed"] and (not grouped["succeeded"] or random.random() < 0.7):
         # Rebuild a failed PR, but sometimes fall through and rebuild a
         # successful one instead (if there are any). This is so a single red PR


### PR DESCRIPTION
Reverts alisw/ali-bot#1062

That PR meant that queued PRs didn't have their statuses updated.