### PR TITLE
Don't use pip install --ignore-installed

### DIFF
--- a/build-any-ib.sh
+++ b/build-any-ib.sh
@@ -39,7 +39,7 @@ case "$PYTHON_VERSION" in
   2) PIP=pip2 PYTHON=python2 ;;
   3) PIP=pip3 PYTHON=python3 ;;
 esac
-$PIP install --user --ignore-installed --upgrade ${ALIBUILD_SLUG:+"git+https://github.com/${ALIBUILD_SLUG}"}
+$PIP install --user --upgrade "${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild}"
 type aliBuild
 
 rm -rf alidist

--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -53,7 +53,7 @@ case "$PYTHON_VERSION" in
 esac
 
 # Install the latest release if ALIBUILD_SLUG is not provided
-$PIP install --user --ignore-installed --upgrade ${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild}
+$PIP install --user --upgrade "${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild}"
 
 [ "$TEST_TAG" = true ] && AUTOTAG_TAG=TEST-IGNORE-$AUTOTAG_TAG
 [ -e git-creds ] || git config --global credential.helper "store --file ~/git-creds-autotag"  # backwards compat

--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -33,7 +33,7 @@ try {
               export PATH="$PYTHONUSERBASE/bin:$PATH"
               rm -rf "$PYTHONUSERBASE"
               yum install -y python3-pip python3-devel python3-setuptools
-              pip3 install --user --upgrade --ignore-installed "${ALIBOT_SLUG:+git+https://github.com/${ALIBOT_SLUG}}"
+              pip3 install --user --upgrade "${ALIBOT_SLUG:+git+https://github.com/${ALIBOT_SLUG}}"
               type check-open-pr
               if [ "${PACKAGES%% *}" = AliPhysics ]; then
                 WAIT_TESTS="build/AliPhysics/release build/AliPhysics/root6"
@@ -136,7 +136,7 @@ try {
                 *)
                   pip=pip3 ;;
               esac
-              $pip install --ignore-installed --upgrade --user git+https://github.com/$ALIBOT_SLUG
+              $pip install --upgrade --user "git+https://github.com/$ALIBOT_SLUG"
               [ -f /opt/rh/rh-git218/enable ] && source /opt/rh/rh-git218/enable
               daily-tags.sh || err=$?
               rm -rf alidist daily-tags.?????????? mirror


### PR DESCRIPTION
This causes errors when installing a different version of alibuild and then trying to run it.