### PR TITLE
Require rsync and GLEW devel

### DIFF
--- a/rpms/o2-prereq-cc8.spec
+++ b/rpms/o2-prereq-cc8.spec
@@ -14,7 +14,7 @@ Name: %scl_name
 Version: 1
 Release: 1%{?dist}
 License: GPLv2+
-Requires: make python3-requests python3-yaml pigz which git mysql-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libXi-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed environment-modules tk-devel libXinerama-devel libXcursor-devel libXrandr-devel subversion-devel apr-util-devel apr-devel
+Requires: make rsync glew-devel python3-requests python3-yaml pigz which git mysql-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libXi-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed environment-modules tk-devel libXinerama-devel libXcursor-devel libXrandr-devel subversion-devel apr-util-devel apr-devel
 BuildRequires: scl-utils-build
 
 %description


### PR DESCRIPTION
While not strictly required for aliBuild, it looks like the are now for O2 software.