### PR TITLE
Use 16 jobs by default in build-any-ib

### DIFF
--- a/build-any-ib.sh
+++ b/build-any-ib.sh
@@ -135,7 +135,7 @@ aliBuild --reference-sources $MIRROR                    \
          --work-dir $WORKAREA/$WORKAREA_INDEX           \
          ${FETCH_REPOS:+--fetch-repos}                  \
          --architecture $ARCHITECTURE                   \
-         --jobs ${JOBS:-9}                              \
+         --jobs ${JOBS:-16}                             \
          ${REMOTE_STORE:+--remote-store $REMOTE_STORE}  \
          ${DEFAULTS:+--defaults $DEFAULTS}              \
          ${DISABLE:+--disable $DISABLE}                 \


### PR DESCRIPTION
The default of 9 jobs is still left over from before the O2/O2Physics split. 16 should be fine now.