### PR TITLE
Add CI checks on new M1 Mac

### DIFF
--- a/ci/repo-config/macos/alibuildmac04/alidist-o2.env
+++ b/ci/repo-config/macos/alibuildmac04/alidist-o2.env
@@ -1,0 +1,15 @@
+CI_NAME=build_alidist_O2Suite_o2_macOS-arm
+PR_REPO=alisw/alidist
+PR_REPO_CHECKOUT=alidist
+PR_BRANCH=master
+PACKAGE=O2Suite
+CHECK_NAME=build/alidist/O2Suite/o2/macOS-arm
+BRANCH_REMOTE_STORE=s3://alibuild-repo::rw
+ALIBUILD_DEFAULTS=o2
+TRUSTED_USERS=
+TRUST_COLLABORATORS=true
+DONT_USE_COMMENTS=1
+DEVEL_PKGS="$PR_REPO $PR_BRANCH $PR_REPO_CHECKOUT
+AliceO2Group/AliceO2 dev O2
+alisw/alidist master"
+ALIBUILD_O2_TESTS=1


### PR DESCRIPTION
Add a check for O2, alidist, QC and O2Physics.

Draft until the builder is fully deployed.

Cc: @MichaelLettrich 