### PR TITLE
Enable ALIBUILD_O2_TESTS in O2Physics Linux CI

### DIFF
--- a/ci/repo-config/mesosci/slc7-o2physics/o2physics.env
+++ b/ci/repo-config/mesosci/slc7-o2physics/o2physics.env
@@ -8,3 +8,4 @@ CHECK_NAME=build/O2Physics/o2
 DONT_USE_COMMENTS=1
 DEVEL_PKGS="$PR_REPO $PR_BRANCH
 alisw/alidist master"
+ALIBUILD_O2_TESTS=1


### PR DESCRIPTION
Already enabled on Mac.

This enables `-Werror`.