### PR TITLE
Use alibuild v1.9.6

### DIFF
--- a/ci/repo-config/DEFAULTS.env
+++ b/ci/repo-config/DEFAULTS.env
@@ -6,7 +6,7 @@ BUILD_SUFFIX=master
 MAX_DIFF_SIZE=20000000
 TIMEOUT=600
 LONG_TIMEOUT=36000
-INSTALL_ALIBUILD=alisw/alibuild@v1.9.5
+INSTALL_ALIBUILD=alisw/alibuild@v1.9.6
 INSTALL_ALIBOT=alisw/ali-bot@master
 # On alissandra machines, use 28 cores instead as we have the capacity there to
 # use that many, and they will only have one builder running on them at a time.


### PR DESCRIPTION
It's a bugfix release which cleans up `INSTALLROOT` and fixes and encoding issue in `getstatusoutput`.