### PR TITLE
Don't use remote store for Mac CI

### DIFF
--- a/ci/repo-config/macos/DEFAULTS.env
+++ b/ci/repo-config/macos/DEFAULTS.env
@@ -1,3 +1,4 @@
 TRUSTED_USERS=ktf,TimoWilken
 TRUST_COLLABORATORS=true
+REMOTE_STORE=
 JOBS=  # fall back to JOBS=$(nproc)

--- a/ci/repo-config/macos/alibuildmac04/DEFAULTS.env
+++ b/ci/repo-config/macos/alibuildmac04/DEFAULTS.env
@@ -1,1 +1,0 @@
-REMOTE_STORE=


### PR DESCRIPTION
There's nothing useful on it at the moment anyway, and it prevents us from using
system packages.

Cc: @MichaelLettrich 