### PR TITLE
Update check message when rebuilding

### DIFF
--- a/alibot_helpers/github_utilities.py
+++ b/alibot_helpers/github_utilities.py
@@ -336,7 +336,7 @@ def setGithubStatus(cgh, args, debug_print=True):
         # If the state already exists and it's different, create a new one
         if (s["context"] == state_context and
             (s["state"] != state_value or
-             s["target_url"] != args.url or
+             (not args.keep_url and s["target_url"] != args.url) or
              s["description"] != args.message)):
             if debug_print:
                 print(s)
@@ -347,7 +347,7 @@ def setGithubStatus(cgh, args, debug_print=True):
                 "state": state_value,
                 "context": state_context,
                 "description": args.message,
-                "target_url": args.url
+                "target_url": s["target_url"] if args.keep_url else args.url
             }
             cgh.post("/repos/{repo_name}/statuses/{ref}",
                      data=data,
@@ -358,7 +358,7 @@ def setGithubStatus(cgh, args, debug_print=True):
         # If the state already exists and it's the same, exit
         if (s["context"] == state_context and
             s["state"] == state_value and
-            s["target_url"] == args.url and
+            (args.keep_url or s["target_url"] == args.url) and
             s["description"] == args.message):
             if debug_print:
                 print("Last status for %s is already matching. Exiting" % state_context, file=sys.stderr)
@@ -372,7 +372,7 @@ def setGithubStatus(cgh, args, debug_print=True):
         "state": state_value,
         "context": state_context,
         "description": args.message,
-        "target_url": args.url
+        "target_url": "" if args.keep_url else args.url
     }
     cgh.post(
         "/repos/{repo_name}/statuses/{ref}",

--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -106,6 +106,17 @@ function reset_git_repository () {
   fi
 }
 
+function build_type_to_status () {
+  # Translate a build type from list-branch-pr into a GitHub check status.
+  case "$1" in
+    untested) echo pending;;
+    failed) echo error;;
+    succeeded) echo success;;
+    *) echo "WARNING: unrecognised status $BUILD_TYPE, falling back to pending" >&2
+       echo pending;;
+  esac
+}
+
 function report_pr_errors () {
   # This is a wrapper for report-pr-errors with some default switches.
   local repo checkout_name extra_args=()

--- a/set-github-status
+++ b/set-github-status
@@ -3,8 +3,6 @@
 from __future__ import print_function
 from argparse import ArgumentParser
 import logging
-import os
-import re
 import sys
 
 from alibot_helpers.github_utilities import setGithubStatus, github_token
@@ -18,7 +16,7 @@ DEFAULT_USER = "alisw"
 
 def parse_args():
     usage = "set-github-status "
-    usage += "-c <commit> -s <status> [-m <status-message>] [-u <target-url>]"
+    usage += "[-d] [-n] -c <commit> -s <status> [-m <status-message>] [-u <target-url> | -k]"
     parser = ArgumentParser(usage=usage)
     parser.add_argument("--commit", "-c",
                         required=True,
@@ -33,9 +31,11 @@ def parse_args():
                         default="",
                         help="Message relative to the status (default='')")
 
-    parser.add_argument("--url", "-u",
-                        default="",
-                        help="Target url for the report (default='')")
+    url = parser.add_mutually_exclusive_group()
+    url.add_argument("--url", "-u", default="",
+                     help="Target URL for the report (default=%(default)s)")
+    url.add_argument("--keep-url", "-k", action="store_true",
+                     help="Copy the target URL from the existing status.")
 
     parser.add_argument("--debug", "-d",
                         action="store_true",


### PR DESCRIPTION
When we're automatically rebuilding a check, it would be helpful for users to have feedback about this, so change the existing status's message (keeping the red/green status and results URL intact).

This requires an extra option to set-github-status to keep the URL intact, which is added by this commit as well.

Untested so far, so I've made this a draft PR for now.