### PR TITLE
Get an AliEn token and make it available to CI builds

### DIFF
--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -40,7 +40,10 @@ function report_state () {
 
 function clean_env () {
   # This function calls its arguments with access tokens removed from the environment.
-  GITLAB_USER='' GITLAB_PASS='' GITHUB_TOKEN='' INFLUXDB_WRITE_URL='' CODECOV_TOKEN='' "$@"
+  # The X509_USER_* vars might not apply if building inside a container, so
+  # remove them too. They shouldn't be used by the build anyway.
+  GITLAB_USER='' GITLAB_PASS='' GITHUB_TOKEN='' INFLUXDB_WRITE_URL='' CODECOV_TOKEN='' \
+    X509_USER_CERT='' X509_USER_KEY='' "$@"
 }
 
 function pipinst () {
@@ -48,7 +51,7 @@ function pipinst () {
   # that case: time out, skip and try again later.
   case $(uname -s) in
     Darwin) short_timeout pip install -U --install-option=--old-and-unmanageable "git+https://github.com/$1";;
-    *) short_timeout pip3 install --user --upgrade "git+https://github.com/$1";;
+    *) short_timeout python3 -m pip install --user --upgrade --editable "git+https://github.com/$1";;
   esac
 }
 

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -159,6 +159,14 @@ fi
 build_identifier=${NO_ASSUME_CONSISTENT_EXTERNALS:+${PR_NUMBER//-/_}}
 : "${build_identifier:=${CHECK_NAME//\//_}}"
 
+# Get a temporary JAliEn token certificate and key, to give anything we build
+# below access.
+if jalien_token=$(alien.py token -v 1); then
+  jalien_token_cert=$(echo "$jalien_token" | sed -n '/^-----BEGIN CERTIFICATE-----$/,/^-----END CERTIFICATE-----$/p')
+  jalien_token_key=$(echo "$jalien_token" | sed -n '/^-----BEGIN RSA PRIVATE KEY-----$/,/^-----END RSA PRIVATE KEY-----$/p')
+fi
+unset jalien_token
+
 # o2checkcode needs the ALIBUILD_{HEAD,BASE}_HASH variables.
 # We need "--no-auto-cleanup" so that build logs for dependencies are kept, too.
 # For instance, when building O2FullCI, we want to keep the o2checkcode log, as
@@ -173,6 +181,8 @@ if ALIBUILD_HEAD_HASH=$PR_HASH ALIBUILD_BASE_HASH=$base_hash \
      ${REMOTE_STORE:+--remote-store "$REMOTE_STORE"}         \
      -e "ALIBUILD_O2_TESTS=$ALIBUILD_O2_TESTS"               \
      -e "ALIBUILD_O2PHYSICS_TESTS=$ALIBUILD_O2PHYSICS_TESTS" \
+     ${jalien_token_cert:+-e "JALIEN_TOKEN_CERT=$jalien_token_cert"} \
+     ${jalien_token_key:+-e "JALIEN_TOKEN_KEY=$jalien_token_key"} \
      ${use_docker:+-e GIT_CONFIG_COUNT=1}                    \
      ${use_docker:+-e GIT_CONFIG_KEY_0=credential.helper}    \
      ${use_docker:+-e GIT_CONFIG_VALUE_0='store --file /.git-creds'} \

--- a/ci/repo-config/DEFAULTS.env
+++ b/ci/repo-config/DEFAULTS.env
@@ -6,8 +6,8 @@ BUILD_SUFFIX=master
 MAX_DIFF_SIZE=20000000
 TIMEOUT=600
 LONG_TIMEOUT=36000
-INSTALL_ALIBUILD=alisw/alibuild@v1.9.9
-INSTALL_ALIBOT=alisw/ali-bot@master
+INSTALL_ALIBUILD='alisw/alibuild@v1.10.1#egg=alibuild'
+INSTALL_ALIBOT='alisw/ali-bot@master#egg=ali-bot'
 # On alissandra machines, use 28 cores instead as we have the capacity there to
 # use that many, and they will only have one builder running on them at a time.
 # We have to use backticks instead of $() as bash 3.2 (installed on MacOS) gets


### PR DESCRIPTION
- If possible, get a temporary AliEn token and store it in env variables.
- We need an upgraded pip in order to install alienpy, but that breaks
  installation of ali-bot and alibuild on some platforms (e.g. Ubuntu).
  Installing them as editable solves this, but needs an `#egg=` fragment at the
  end of the URLs.

Tested and apparently working.