### PR TITLE
Clean up unused builds after 2 days

### DIFF
--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -19,9 +19,9 @@ function influxdb_push () {
     # If INFLUXDB_WRITE_URL starts with insecure_https://, then strip
     # "insecure_" and send the --insecure/-k option to curl.
     insecure_*)
-      curl -fSs --max-time 20 -XPOST --data-raw "$data" -k "${INFLUXDB_WRITE_URL#insecure_}" || :;;
+      curl -fSs --max-time 20 -XPOST --data-binary "$data" -k "${INFLUXDB_WRITE_URL#insecure_}" || :;;
     *)
-      curl -fSs --max-time 20 -XPOST --data-raw "$data" "$INFLUXDB_WRITE_URL" || :;;
+      curl -fSs --max-time 20 -XPOST --data-binary "$data" "$INFLUXDB_WRITE_URL" || :;;
   esac
 }
 

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -285,6 +285,7 @@ aliBuild clean --debug --aggressive-cleanup
 kib_avail_after=$(df -kP . | awk 'END { print $4 }')
 influxdb_push cleanup "host=$(hostname -s)" \
               "os=$(uname -s | tr '[:upper:]' '[:lower:]')" \
+              "checkname=$CHECK_NAME" "repo=$PR_REPO" \
               -- "duration_sec=$(("$(date +%s)" - cleanup_start))" \
               "num_symlinks_deleted=$symlinks_deleted" \
               "kib_freed=$((kib_avail_before - kib_avail_after))" \

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -282,11 +282,12 @@ done
 aliBuild clean --debug --aggressive-cleanup
 
 # Monitor how long cleanup takes, in case it slows builds down too much.
+cleanup_end=$(date +%s)
 kib_avail_after=$(df -kP . | awk 'END { print $4 }')
 influxdb_push cleanup "host=$(hostname -s)" \
               "os=$(uname -s | tr '[:upper:]' '[:lower:]')" \
               "checkname=$CHECK_NAME" "repo=$PR_REPO" \
-              -- "duration_sec=$(("$(date +%s)" - cleanup_start))" \
+              -- "duration_sec=$((cleanup_end - cleanup_start))" \
               "num_symlinks_deleted=$symlinks_deleted" \
               "kib_freed=$((kib_avail_before - kib_avail_after))" \
               "kib_avail=$kib_avail_after"

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -284,12 +284,15 @@ aliBuild clean --debug --aggressive-cleanup
 # Monitor how long cleanup takes, in case it slows builds down too much.
 cleanup_end=$(date +%s)
 kib_avail_after=$(df -kP . | awk 'END { print $4 }')
+# A caveat for the kib_freed_approx metric: if there are multiple builders
+# running on the same machine, then we'll actually measure how many KiB we freed
+# minus how many the other builders filled during our cleanup.
 influxdb_push cleanup "host=$(hostname -s)" \
               "os=$(uname -s | tr '[:upper:]' '[:lower:]')" \
               "checkname=$CHECK_NAME" "repo=$PR_REPO" \
               -- "duration_sec=$((cleanup_end - cleanup_start))" \
               "num_symlinks_deleted=$symlinks_deleted" \
-              "kib_freed=$((kib_avail_before - kib_avail_after))" \
+              "kib_freed_approx=$((kib_avail_after - kib_avail_before))" \
               "kib_avail=$kib_avail_after"
 
 (


### PR DESCRIPTION
After every build, delete builds and installations of development packages that haven't been touched in two days. This should hopefully keep disk usage under control.

A better solution would probably be to monitor the absolute disk usage of the CI builder and delete as many old builds as we have to to stay within our limit, but that would be much more complicated, and counting our own disk usage would take a long time.

Also, monitor the time taken by the cleanup process. For this purpose, factor out a function for pushing to InfluxDB, which could be used to push additional metrics in the future.

Untested so far.