### PR TITLE
Use alibuild 1.11.4

### DIFF
--- a/ci/repo-config/DEFAULTS.env
+++ b/ci/repo-config/DEFAULTS.env
@@ -6,7 +6,7 @@ BUILD_SUFFIX=master
 MAX_DIFF_SIZE=20000000
 TIMEOUT=600
 LONG_TIMEOUT=36000
-INSTALL_ALIBUILD='alisw/alibuild@v1.11.0#egg=alibuild'
+INSTALL_ALIBUILD='alisw/alibuild@v1.11.4#egg=alibuild'
 INSTALL_ALIBOT='alisw/ali-bot@master#egg=ali-bot'
 # On alissandra machines, use 28 cores instead as we have the capacity there to
 # use that many, and they will only have one builder running on them at a time.


### PR DESCRIPTION
Fixed issue with leftover go installs, plus a few more.