### PR TITLE
Remove ROOT5 CI checks

### DIFF
--- a/ci/repo-config/DEFAULTS.env
+++ b/ci/repo-config/DEFAULTS.env
@@ -1,4 +1,4 @@
-ALIBUILD_DEFAULTS=release
+ALIBUILD_DEFAULTS=o2
 REMOTE_STORE=https://s3.cern.ch/swift/v1/alibuild-repo
 TRUSTED_USERS=ktf,davidrohr
 NO_ASSUME_CONSISTENT_EXTERNALS=true

--- a/ci/repo-config/mesosci/slc7-aliphysics/aliphysics-release.env
+++ b/ci/repo-config/mesosci/slc7-aliphysics/aliphysics-release.env
@@ -1,9 +1,0 @@
-CI_NAME=build_AliPhysics_release
-PACKAGE=AliPhysics
-ALIBUILD_DEFAULTS=prod-latest
-PR_REPO=alisw/AliPhysics
-PR_BRANCH=master
-TRUSTED_USERS=
-CHECK_NAME=build/AliPhysics/release
-DEVEL_PKGS="$PR_REPO $PR_BRANCH
-alisw/alidist master"

--- a/ci/repo-config/mesosci/slc7/aliroot-alidist.env
+++ b/ci/repo-config/mesosci/slc7/aliroot-alidist.env
@@ -1,6 +1,6 @@
 CI_NAME=build_AliRoot_alidist
 PACKAGE=AliRoot
-ALIBUILD_DEFAULTS=prod-latest
+ALIBUILD_DEFAULTS=o2
 PR_REPO=alisw/alidist
 PR_BRANCH=master
 NO_ASSUME_CONSISTENT_EXTERNALS=

--- a/ci/repo-config/mesosci/slc7/aliroot.env
+++ b/ci/repo-config/mesosci/slc7/aliroot.env
@@ -1,10 +1,11 @@
-CI_NAME=build_AliRoot_release
+CI_NAME=build_AliRoot_o2
 PACKAGE=AliRoot-guntest
 PR_REPO=alisw/AliRoot
 PR_BRANCH=master
+ALIBUILD_DEFAULTS=o2
 TRUSTED_USERS=
 TASK_PRIORITY=10
 NO_ASSUME_CONSISTENT_EXTERNALS=
-CHECK_NAME=build/AliRoot/release
+CHECK_NAME=build/AliRoot/o2
 DEVEL_PKGS="$PR_REPO $PR_BRANCH
 alisw/alidist master"


### PR DESCRIPTION
Move remaining AliRoot ROOT5 checks to ROOT6 and delete the ROOT5 AliPhysics check, where we already have a ROOT6 one.