### PR TITLE
Publish async-* tags of O2 to CVMFS

### DIFF
--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -248,6 +248,14 @@ architectures:
       # lacks modulefile
         - ^3.3-090b16bfae-1$
 
+  slc8_x86-64:
+    CVMFS: el8-x86_64
+    AliEn: false
+    RPM: false
+    include:
+      O2:
+        - ^async-.*$
+
   ubt14_x86-64:
     CVMFS: ubuntu1404-x86_64
     AliEn: false


### PR DESCRIPTION
These tags must be built on slc8 as they require GPU support.