### PR TITLE
Publish AliPhysics and FOCAL releases on slc7

### DIFF
--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -185,7 +185,9 @@ architectures:
         - ^v7\.3\.0-alice1-9$
       AliPhysics:
         - ^vAN-20[12][0-9](0[0-9]|1[012])([012][0-9]|3[01])(_ROOT6)?-[0-9]+$
+        - ^v5-09-[0-9]+[a-z]*-01$
         - ^v5-09-[0-9]+[a-z]*-01_FLUKA-1$
+      FOCAL: true
       MonALISA:
         - ^20[0-9]+-[0-9]+$
       JAliEn:


### PR DESCRIPTION
The AliPhysics nightlies are already all built on slc7, so migrate release builds over as well.

@ktf is this OK or should AliPhysics releases stay on slc6?