### PR TITLE
Fix caching of installed AliEn packages in aliPublish and aliPublishS3

### DIFF
--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -299,9 +299,7 @@ class AliEnPackMan(object):
         if not m: continue
         pkg = m.group(1)
         ver = m.group(2)
-        if not pkg in self._packs:
-          self._packs[pkg] = {}
-        self._packs[pkg].update({ver: []})
+        self._packs.setdefault(pkg, {}).update({ver: []})
 
     if not self._packs:
       raise PublishException("PackMan: could not get list of packages from AliEn this time")
@@ -312,8 +310,8 @@ class AliEnPackMan(object):
         if not m: continue
         pkg = m.group(1)
         ver = m.group(2)
-        if not pkg in self._packs: continue
-        self._packs[pkg].get(ver, []).append(arch)
+        if pkg in self._packs:
+          self._packs[pkg].setdefault(ver, []).append(arch)
       self._cachedArchs.append(arch)
 
     return arch in self._packs.get(pkgName, {}).get(pkgVer, [])

--- a/publish/aliPublishS3
+++ b/publish/aliPublishS3
@@ -210,9 +210,7 @@ class AliEnPackMan(object):
         if not m: continue
         pkg = m.group(1)
         ver = m.group(2)
-        if not pkg in self._packs:
-          self._packs[pkg] = {}
-        self._packs[pkg].update({ver: []})
+        self._packs.setdefault(pkg, {}).update({ver: []})
 
     if not self._packs:
       raise PublishException("PackMan: could not get list of packages from AliEn this time")
@@ -223,8 +221,8 @@ class AliEnPackMan(object):
         if not m: continue
         pkg = m.group(1)
         ver = m.group(2)
-        if not pkg in self._packs: continue
-        self._packs[pkg].get(ver, []).append(arch)
+        if pkg in self._packs:
+          self._packs[pkg].setdefault(ver, []).append(arch)
       self._cachedArchs.append(arch)
 
     return arch in self._packs.get(pkgName, {}).get(pkgVer, [])


### PR DESCRIPTION
Changing `dict.get(_, [])` to `dict.setdefault(_, [])` ensures the cached value is actually assigned in the dictionary and isn't immediately dropped.

Tested and working with the AliEn publisher. With this patch, the time it takes to run `get-and-run.sh` with nothing to publish goes from 3 min to 2 min.

Some things, like O2-customization, still get needlessly reinstalled even with this patch applied because they don't appear in the output of `alien -exec packman list -all -force`. I don't know why.