### PR TITLE
Publish jemalloc on slc7 as well

### DIFF
--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -180,6 +180,8 @@ architectures:
         - ^20[0-9]+-[0-9]+$
       JAliEn:
         - ^1\..*-[0-9]+$
+      jemalloc:
+       - ^v5\.1\.0-[0-9]+$
       CMake: true
       libtirpc: true
       autotools: true


### PR DESCRIPTION
This is needed to run analysis trains using AliPhysics versions compiled on slc7.