### PR TITLE
Avoid rebuilding so fast we run out of GitHub API requests

### DIFF
--- a/ci/repo-config/DEFAULTS.env
+++ b/ci/repo-config/DEFAULTS.env
@@ -4,7 +4,7 @@ TRUSTED_USERS=ktf,davidrohr
 NO_ASSUME_CONSISTENT_EXTERNALS=true
 BUILD_SUFFIX=master
 MAX_DIFF_SIZE=20000000
-TIMEOUT=600
+TIMEOUT=120
 LONG_TIMEOUT=36000
 INSTALL_ALIBUILD='alisw/alibuild@v1.11.5#egg=alibuild'
 INSTALL_ALIBOT='alisw/ali-bot@master#egg=ali-bot[ci]'


### PR DESCRIPTION
If builds complete too fast, throttle them (so that there are at least 2 minutes, configurable, between the start of each build), so that we don't burn through our GitHub API request quota too quickly.