### PR TITLE
Timeout if `list-branch-pr` takes too long

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -69,7 +69,7 @@ fi
 HASHES=$(grep -Eve '^[[:blank:]]*(#|$)' force-hashes || true)
 if [ -z "$HASHES" ]; then
   get_config
-  HASHES=$(list-branch-pr)
+  HASHES=$(TIMEOUT=120 short_timeout list-branch-pr)
 fi
 
 run_start_time=$(date +%s)


### PR DESCRIPTION
Occasionally, `list-branch-pr` just seems to hang for a while. Timeout in that case, so we don't block builds forever.