### PR TITLE
Separate PR checkers, add a few and only check under Python 3

### DIFF
--- a/.github/workflows/c++-code-formatting.yml
+++ b/.github/workflows/c++-code-formatting.yml
@@ -229,6 +229,7 @@ jobs:
 
       - name: Check for incorrect line endings
         run: |
+          # shellcheck disable=SC1004
           if find . \( -path ./.git -prune -false \) -o -type f \( \
                -name '*.c' -o -name '*.C' -o -name '*.cpp' -o -name '*.cxx' -o \
                -name '*.cl' -o -name '*.h' -o -name '*.hpp' -o -name '*.py' -o \

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -1,0 +1,57 @@
+---
+# Check commits and incoming PRs that change anything under ci/.
+name: Check CI
+
+'on':
+  push:
+    paths:
+      - 'ci/**'
+  pull_request:
+    paths:
+      - 'ci/**'
+    types:
+      - opened
+      - reopened
+      - edited
+      - ready_for_review
+      - synchronize
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install prerequisites
+        run: |
+          sudo apt update -y
+          sudo apt install -y shellcheck jq
+          mkdir ~/bin
+          cat <<\EOF > ~/bin/sc2github
+          #!/usr/bin/jq -rf
+          .comments[] |
+          .gh_level = {"error": "error", "warning": "warning",
+                       "info": "notice", "style": "notice"}[.level] |
+          "::\(.gh_level) title=SC\(.code),file=\(.file),line=\(.line)," +
+          "col=\(.column),endLine=\(.endLine),endColumn=\(.endColumn)::\(.message)"
+          EOF
+          chmod +x ~/bin/sc2github
+          echo ~/bin >> "$GITHUB_PATH"
+
+      - name: Check CI shell scripts
+        run: |
+          find ci -type f -name '*.sh' -print0 |
+            xargs -r0 shellcheck -f json1 |
+            sc2github
+
+      - name: Check .env files
+        # Run even if the previous step failed. A failure in the previous step
+        # will still fail the job as a whole.
+        if: ${{ success() || failure() }}
+        run: |
+          find ci/repo-config -type f -name '*.env' -print0 |
+            # SC2034 is the "$VAR appears unused" warning.
+            xargs -r0 shellcheck -f json1 -s bash --exclude=SC2034 |
+            sc2github

--- a/.github/workflows/check-cvmfs.yml
+++ b/.github/workflows/check-cvmfs.yml
@@ -1,9 +1,14 @@
-# Check incoming PRs.
+---
+# Check commits and incoming PRs that change scripts under cvmfs/.
+name: Check CVMFS scripts
 
-name: PR checker
-
-on:
+'on':
+  push:
+    paths:
+      - 'cvmfs/**'
   pull_request:
+    paths:
+      - 'cvmfs/**'
     types:
       - opened
       - reopened
@@ -12,64 +17,37 @@ on:
       - synchronize
 
 jobs:
-  build:
-    runs-on: ubuntu-18.04
+  alienv:
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v3
 
       - name: Install prerequisites
         run: |
           sudo apt update -y
           sudo apt install -y build-essential libldap2-dev libsasl2-dev environment-modules \
-                              python3-dev python3-pip python3-setuptools python3-wheel \
-                              python-dev python-pip python-setuptools python-wheel
-          pip3 install -r requirements.txt
-          pip2 install -r requirements.txt
+                              python3-dev python3-pip python3-setuptools python3-wheel
+          python3 -m pip install -r requirements.txt
 
-      - name: Check publish/
+      - name: Install an old bash
         run: |
-          git diff --name-only "$(git merge-base HEAD ${{ github.event.pull_request.base.sha }})" |
-             grep -q '^publish/' ||
-             exit 0
-          pushd publish
-            for conf in aliPublish*.conf; do
-              test=test${conf#aliPublish}
-              test=${test%.conf}.yaml
-              [ -r "$test" ] || continue
-              if ! ./aliPublish test-rules --conf "$conf" --test-conf "$test" --debug; then
-                echo "Testing $conf against $test failed." >&2
-                exit 1
-              fi
-            done
-          popd
-
-      - name: Check cvmfs/
-        run: |
-          git diff --name-only "$(git merge-base HEAD ${{ github.event.pull_request.base.sha }})" |
-             grep -q '^cvmfs/' ||
-             exit 0
           # Install and configure an old bash
-          rm -rf "$HOME/cached" "$HOME/scratch"
-          mkdir -p "$HOME/cached" "$HOME/scratch"
-          pushd "$HOME/scratch"
-            wget -q https://ftp.gnu.org/gnu/bash/bash-3.2.48.tar.gz
-            tar xzf bash-3.2.48.tar.gz
-            pushd bash-3.2.48
-              ./configure "--prefix=$HOME/cached"
-              make -j4
-              make install
-            popd
+          rm -rf ~/cached ~/scratch
+          mkdir -p ~/cached ~/scratch
+          curl -fSsL https://ftp.gnu.org/gnu/bash/bash-3.2.48.tar.gz |
+            tar -xzC ~/scratch
+          pushd ~/scratch/bash-3.2.48
+            ./configure "--prefix=$HOME/cached"
+            make -j4
+            make install
           popd
           # Patch alienv and make it use our own, old, bash
-          pushd cvmfs
-            sed -i.deleteme -e "1 s|^#!/bin/bash\(.*\)$|#!$HOME/cached/bin/bash\1|" alienv
-            rm -f *.deleteme
-            git diff
-          popd
+          sed -i "1s|^#\!/bin/bash|#\!$HOME/cached/bin/bash|" cvmfs/alienv
+          git diff
+
+      - name: Install CVMFS
+        run: |
           # Install and configure CVMFS
           url=https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
           wget -q "$url" || case $? in
@@ -88,11 +66,13 @@ jobs:
           ls -l /cvmfs/alice.cern.ch
           # Override remote alienv with ours
           md5sum /cvmfs/alice.cern.ch/bin/alienv
-          md5sum $PWD/cvmfs/alienv
-          sudo mount --bind $PWD/cvmfs/alienv /cvmfs/alice.cern.ch/bin/alienv
+          md5sum "$PWD/cvmfs/alienv"
+          sudo mount --bind "$PWD/cvmfs/alienv" /cvmfs/alice.cern.ch/bin/alienv
           md5sum /cvmfs/alice.cern.ch/bin/alienv
-          cmp /cvmfs/alice.cern.ch/bin/alienv $PWD/cvmfs/alienv
+          cmp /cvmfs/alice.cern.ch/bin/alienv "$PWD/cvmfs/alienv"
 
+      - name: Test alienv script
+        run: |
           # Run the actual test
           set -exo pipefail
 

--- a/.github/workflows/check-publisher.yml
+++ b/.github/workflows/check-publisher.yml
@@ -1,0 +1,46 @@
+---
+# Check commits and incoming PRs that change anything under publish/.
+name: Check publisher
+
+'on':
+  push:
+    paths:
+      - 'publish/**'
+  pull_request:
+    paths:
+      - 'publish/**'
+    types:
+      - opened
+      - reopened
+      - edited
+      - ready_for_review
+      - synchronize
+
+jobs:
+  rules:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install prerequisites
+        run: |
+          sudo apt update -y
+          sudo apt install -y python3-dev python3-pip python3-setuptools python3-wheel
+          python3 -m pip install -r requirements.txt
+
+      - name: Test publishing rules
+        run: |
+          cd publish
+          err=0
+          for conf in aliPublish*.conf; do
+            test=test${conf#aliPublish}
+            test=${test%.conf}.yaml
+            [ -r "$test" ] || continue
+            if ! ./aliPublish test-rules --conf "$conf" --test-conf "$test" --debug; then
+              echo -n "::error file=publish/$conf,line=1,title=Rules validation failed"
+              echo "::Testing $conf against $test failed."
+              err=1
+            fi
+          done
+          exit $err

--- a/.github/workflows/check-workflows.yml
+++ b/.github/workflows/check-workflows.yml
@@ -1,0 +1,44 @@
+---
+# Check commits and incoming PRs that change workflows under .github/workflows/.
+name: Check GitHub workflows
+
+'on':
+  push:
+    paths:
+      - '.github/workflows/*.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/*.yml'
+    types:
+      - opened
+      - reopened
+      - edited
+      - ready_for_review
+      - synchronize
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install prerequisites
+        run: |
+          sudo apt update -y
+          sudo apt install -y shellcheck pyflakes3
+          # Install actionlint separately. It's not packaged, unfortunately.
+          mkdir ~/bin
+          curl -fSsL "$ACTIONLINT_URL" | tar -xvvzC ~/bin actionlint
+          echo ~/bin >> "$GITHUB_PATH"
+        env:
+          ACTIONLINT_URL: |-
+            https://github.com/rhysd/actionlint/releases/download/v1.6.21/actionlint_1.6.21_linux_amd64.tar.gz
+
+      - name: Check CI shell scripts
+        run: |
+          actionlint -pyflakes="$(command -v pyflakes3)" \
+                     -format "$GITHUB_FORMAT" .github/workflows/*.yml
+        env:
+          GITHUB_FORMAT: >-
+            {{range $e := .}}::error file={{$e.Filepath}},line={{$e.Line}},col={{$e.Column}}::{{$e.Message}}%0A```%0A{{replace $e.Snippet "\\n" "%0A"}}%0A```\n{{end}}


### PR DESCRIPTION
This is so we can use GitHub's change-detection to only run the checks when something in the relevant directory has changed, without waiting to install lots of software when it hasn't.

Also, add a code formatting checker for CI scripts and GitHub workflows.