### PR TITLE
Publish packages built on ARM to CVMFS

### DIFF
--- a/publish/aliPublish-s3.conf
+++ b/publish/aliPublish-s3.conf
@@ -1,6 +1,7 @@
 # vim: set filetype=yaml:
-# Publish configuration for packages needed for the asynchronous reconstruction. This cannot be folded in aliPublish.conf because
-# that one looks at the old rsync repository.
+# Publish configuration for packages needed for the asynchronous reconstruction,
+# and for packages built on ARM. This cannot be folded into aliPublish.conf
+# because that one looks at the old rsync repository.
 ---
 s3_endpoint_url: https://s3.cern.ch
 s3_bucket: alibuild-repo
@@ -20,6 +21,57 @@ architectures:
       O2PDPSuite:
         - ^async-.*$
       jq: true
+
+  slc7_aarch64:
+    CVMFS: el7-aarch64
+    AliEn: false
+    RPM: false
+    include:
+      JAliEn:
+        - ^1\..*-[0-9]+$
+      jemalloc:
+        - ^v5\.1\.0-[0-9]+$
+      CMake: true
+      libtirpc: true
+      autotools: true
+      defaults-release: true
+      Python-modules-list: true
+      RapidJSON: true
+      double-conversion: true
+      re2: true
+      fmt: true
+      jq: true
+      flatbuffers: true
+      FairCMakeModules: true
+      O2-customization: true
+      capstone: true
+      alibuild-recipe-tools: true
+      json-c: true
+      libwebsockets: true
+      Alice-GRID-Utils: true
+      GMP: true
+      MPFR: true
+      googlebenchmark: true
+      cub: true
+      ninja: true
+      AliEn-CAs: true
+      UUID: true
+      googletest: true
+      bz2: true
+      abseil: true
+      HEPscore-CCDB: true
+      MCSingContainer: true
+      O2PDPSuite: true
+      O2DPG:
+        - ^prod-20[0-9]{2}(0[0-9]|1[012])-[0-9]{2}[a-z]?-[0-9]+$
+      O2:
+        - ^v[0-9][0-9]\.[0-9]+-[0-9]+$
+        - ^daily-[0-9]{8}-[0-9]+$
+        - ^nighly-[0-9]{8}-[0-9]+$
+      O2Physics:
+        - ^nightly-[0-9]{8}-[0-9]+$
+        - ^daily-[0-9]{8}-[0-9]{4}-[0-9]+$
+        - ^sim-[0-9]{8}-[0-9]+$
 
 # CVMFS-specific configuration
 cvmfs_repository: alice.cern.ch

--- a/publish/publish-all.sh
+++ b/publish/publish-all.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 # This is for the rsync repository
 $HOME/publisher/get-and-run.sh
-# This is for the S3 / el8 repository
-ALIPUBLISH=aliPublishS3 CONF=aliPublish-async.conf $HOME/publisher/get-and-run.sh
+# This is for the S3 / el8 and ARM repository
+ALIPUBLISH=aliPublishS3 CONF=aliPublish-s3.conf $HOME/publisher/get-and-run.sh
 # This is for the noarch repository
 ALIPUBLISH=aliPublishS3 CONF=aliPublish-noarch.conf $HOME/publisher/get-and-run.sh


### PR DESCRIPTION
These packages are created from tarballs on S3, so I extended the existing `aliPublish-async.conf` to avoid adding another config file.

I've tested this manually and it works; it's already published O2Physics/nightly-20221107-1 on ARM.

Cc: @sawenzel 