### PR TITLE
Remove Mesos-specific DNS feature from aliPublish

### DIFF
--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -762,22 +762,6 @@ def notify(conf, archs, pack, dryRun):
           error(format("Cannot send email notification for %(package)s %(version)s (%(arch)s)",
                        package=p["name"], version=p["ver"], arch=archs[arch]))
 
-def hostport(s, defaultPort):
-  host = s.split(":", 1)
-  try:
-    port = len(host) == 2 and int(host[1]) or defaultPort
-  except ValueError:
-    port = defaultPort
-  host = host[0]
-  return host,port
-
-def mesos_resolve(host, dns, jget):
-  for d in sorted(dns, key=lambda k: random()):
-    ips = [ x["ip"] for x in jget(format("http://%(dns)s/v1/hosts/%(host)s", dns=d, host=host))
-                    if x.get("ip", None) ]
-    if ips:
-      return ips
-  return [host]  # fallback to input on error
 
 def main():
   parser = ArgumentParser()
@@ -849,9 +833,6 @@ def main():
 
   doExit = False
 
-  conf["mesos_dns"] = [ ":".join(map(str, hostport(x, 8123))) for x in conf.get("mesos_dns", []) ]
-  shuffle(conf["mesos_dns"])
-
   # Connection handler
   connParams = dict((k, conf[k]) for k in [ "http_ssl_verify", "conn_timeout_s",
                                             "conn_retries", "conn_dethrottle_s" ])
@@ -880,12 +861,6 @@ def main():
     doExit = True
 
   if doExit: exit(1)
-
-  # Resolve base_url name via Mesos
-  us = urlsplit(conf["base_url"])
-  if us.netloc.endswith(".mesos") and conf["mesos_dns"] and args.action != "test-rules":
-    us = us._replace( netloc=choice(mesos_resolve(us.netloc, conf["mesos_dns"], jget)) )
-    conf["base_url"] = urlunsplit(us)
 
   debug("Configuration: " + json.dumps(conf, indent=2))
   incexc = conf.get("filter_order", "include,exclude")

--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -2,9 +2,6 @@
 ---
 base_url: http://ali-ci.cern.ch/TARS
 
-# Mesos DNSes. Used via the API for .mesos domains.
-mesos_dns: [ "alimesos01.cern.ch", "alimesos02.cern.ch", "alimesos03.cern.ch" ]
-
 # YAML variables. Not aliPublish-specific.
 alice_email_notif_conf: &alice_email_notif alice-analysis-operations@cern.ch
 experts_email_notif_conf: &experts_email_notif


### PR DESCRIPTION
This is not used anymore.