### PR TITLE
Publish aarch64 packages

### DIFF
--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -243,6 +243,14 @@ architectures:
         - '^v1\.0-[12]$'
         - '^v1\.1-1$'
 
+  slc7_aarch64:
+    CVMFS: el7-aarch64
+    AliEn: false
+    RPM: false
+    include:
+      O2sim: true
+      HEPscore-CCDB: true
+
   ubt14_x86-64:
     CVMFS: ubuntu1404-x86_64
     AliEn: false

--- a/publish/test.yaml
+++ b/publish/test.yaml
@@ -308,6 +308,10 @@ slc7_x86-64:
     nightly-20221125-3     : True
     daily-20221125-1515-1  : True
 
+slc7_aarch64:
+  O2sim:
+    O2sim@v20221215-1      : True
+
 ubt14_x86-64:
   GCC-Toolchain:
     v4.9.3-8               : False

--- a/publish/test.yaml
+++ b/publish/test.yaml
@@ -310,7 +310,7 @@ slc7_x86-64:
 
 slc7_aarch64:
   O2sim:
-    O2sim@v20221215-1      : True
+    v20221215-1      : True
 
 ubt14_x86-64:
   GCC-Toolchain:


### PR DESCRIPTION
Publish O2sim, HEPscore-CCDB and dependencies for slc7_aarch64 on CVMFS.