### PR TITLE
Fix code paths for updatable RPMs

### DIFF
--- a/publish/aliPublish-rpms-cc8test.conf
+++ b/publish/aliPublish-rpms-cc8test.conf
@@ -1,0 +1,68 @@
+# vim: set filetype=yaml:
+---
+s3_endpoint_url: https://s3.cern.ch
+s3_bucket: alibuild-repo
+base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
+base_prefix: TARS
+http_ssl_verify: True
+conn_timeout_s: 6.05
+conn_retries: 6
+conn_dethrottle_s: 0.5
+
+architectures:
+  slc8_test:
+    RPM: el8test.x86_64
+    include:
+      Toolchain:
+        - ^v.*$
+      rpm-test: True
+      mesos-workqueue: True
+      flpproto: True
+      FLPSuiteDevEnv: True
+      Monitoring: True
+      Configuration: True
+      Configuration-Benchmark: True
+      ReadoutCard: True
+      Readout: True
+      Control: True
+      TpcFecUtils: True
+      O2Suite: True
+      ALF: True
+      CMake: True
+      FreeType: True
+      GCC-Toolchain: True
+      O2-customization: True
+      O2PDPSuite: True
+      OpenSSL: True
+      Python-modules-list: True
+      RapidJSON: True
+      alibuild-recipe-tools: True
+      autotools: True
+      bz2: True
+      capstone: True
+      cub: True
+      defaults-release: True
+      double-conversion: True
+      googlebenchmark: True
+      googletest: True
+      libffi: True
+      libxml2: True
+      lz4: True
+      lzma: True
+      ms_gsl: True
+      ofi: True
+      re2: True
+      sqlite: True
+      zlib: True
+      ecsg:
+        - ^v.*
+      qcg:
+        - ^v.*
+      QualityControl: True
+      DataDistribution: True
+      ODC: True
+      O2: True
+
+# What packages to publish
+auto_include_deps: True
+filter_order: include,exclude

--- a/publish/aliPublish-s3-updatable-rpms.conf
+++ b/publish/aliPublish-s3-updatable-rpms.conf
@@ -1,0 +1,77 @@
+# vim: set filetype=yaml:
+---
+s3_endpoint_url: https://s3.cern.ch
+s3_bucket: alibuild-repo
+base_url: https://s3.cern.ch/swift/v1/alibuild-repo/
+base_prefix: TARS
+http_ssl_verify: true
+conn_timeout_s: 6.05
+conn_retries: 6
+conn_dethrottle_s: 0.5
+
+architectures:
+  slc8_x86-64:
+    RPM: el8.x86_64
+    include:
+      GenTopo:
+        - ^nightly-[0-9]{8}-[0-9]+$
+
+# RPM-specific configuration
+rpm_repo_dir: /repo/UpdRPMS
+rpm_updatable: true
+
+# What packages to publish
+auto_include_deps: true
+filter_order: include,exclude
+
+# Packages older than 7 days will be excluded (limits too many packages
+# published by mistake)
+exclude_older_d: 7
+
+notification_email:
+  server: cernmx.cern.ch
+  package_format: "  %(package)s %(version)s\n"
+  success:
+    body: |
+      Dear ALICE fellows,
+
+        Updatable RPM %(package)s %(version)s for architecture %(arch)s was created.
+
+      To install (you might need to force-refresh your cache):
+
+        yum -v clean expire-cache
+        yum install -y alisw-%(package)s
+
+      To use the newly created package:
+
+        aliswmod enter %(package)s/%(version)s
+
+      You can find the full set of instructions (including repo configuration) here:
+
+        https://aliceo2group.github.io/quickstart/binaries.html
+
+      The following dependencies will be automatically installed and loaded:
+
+      %(alldependencies_fmt)s
+
+      Enjoy,
+      --
+      The ALICE Build Infrastructure
+    subject: "[ALICE-UpdRPMs] %(package)s %(version)s created"
+    from: "ALICE Builder <noreply@cern.ch>"
+    to:
+      GenTopo:
+        - david.rohr@cern.ch
+  failure:
+    body: |
+      Creation of updatable RPM %(package)s %(version)s for architecture %(arch)s failed.
+      Please have a look.
+
+      Cheers,
+      --
+      The ALICE Build Infrastructure
+    subject: "[ALICE-UpdRPMS] Failed: %(package)s %(version)s"
+    from: "ALICE Builder <noreply@cern.ch>"
+    to:
+      - giulio.eulisse@cern.ch
+      - timo.wilken@cern.ch

--- a/publish/aliPublish-s3-updatable-rpms.conf
+++ b/publish/aliPublish-s3-updatable-rpms.conf
@@ -9,6 +9,9 @@ conn_timeout_s: 6.05
 conn_retries: 6
 conn_dethrottle_s: 0.5
 
+# RPM-specific configuration
+rpm_updatable: true
+
 architectures:
   slc8_x86-64:
     RPM: el8.x86_64
@@ -16,17 +19,13 @@ architectures:
       GenTopo:
         - ^nightly-[0-9]{8}-[0-9]+$
 
-# RPM-specific configuration
-rpm_repo_dir: /repo/UpdRPMS
-rpm_updatable: true
-
 # What packages to publish
 auto_include_deps: true
 filter_order: include,exclude
 
 # Packages older than 7 days will be excluded (limits too many packages
 # published by mistake)
-exclude_older_d: 7
+exclude_older_d: 30
 
 notification_email:
   server: cernmx.cern.ch
@@ -61,7 +60,8 @@ notification_email:
     from: "ALICE Builder <noreply@cern.ch>"
     to:
       GenTopo:
-        - david.rohr@cern.ch
+        # - david.rohr@cern.ch
+        - timo.wilken@cern.ch
   failure:
     body: |
       Creation of updatable RPM %(package)s %(version)s for architecture %(arch)s failed.
@@ -73,5 +73,5 @@ notification_email:
     subject: "[ALICE-UpdRPMS] Failed: %(package)s %(version)s"
     from: "ALICE Builder <noreply@cern.ch>"
     to:
-      - giulio.eulisse@cern.ch
+      # - giulio.eulisse@cern.ch
       - timo.wilken@cern.ch

--- a/publish/aliPublish-s3-updatable-rpms.conf
+++ b/publish/aliPublish-s3-updatable-rpms.conf
@@ -60,8 +60,7 @@ notification_email:
     from: "ALICE Builder <noreply@cern.ch>"
     to:
       GenTopo:
-        # - david.rohr@cern.ch
-        - timo.wilken@cern.ch
+        - david.rohr@cern.ch
   failure:
     body: |
       Creation of updatable RPM %(package)s %(version)s for architecture %(arch)s failed.
@@ -73,5 +72,5 @@ notification_email:
     subject: "[ALICE-UpdRPMS] Failed: %(package)s %(version)s"
     from: "ALICE Builder <noreply@cern.ch>"
     to:
-      # - giulio.eulisse@cern.ch
+      - giulio.eulisse@cern.ch
       - timo.wilken@cern.ch

--- a/publish/aliPublishS3
+++ b/publish/aliPublishS3
@@ -378,7 +378,8 @@ class RPM(object):
         error("RPM: error creating repository for %s", arch)
         return False
 
-      mergerepo = ["mergerepo", "--nogroups", "--noupdateinfo",
+      mergerepo = ["mergerepo", "--verbose", "--all",
+                   "--nogroups", "--noupdateinfo",
                    "--repo", baseUrl,
                    "--repo", "file://" + abspath(stagedir),
                    "--outputdir", mergedir]

--- a/publish/aliPublishS3
+++ b/publish/aliPublishS3
@@ -264,6 +264,7 @@ class RPM(object):
     self._s3 = s3Client
     self._baseUrl = baseUrl
     self._bucket = s3Bucket
+    self._s3_path = "UpdRPMS" if genUpdatableRpms else "RPMS"
     self._remoteRpms = {}
 
   def _kw(self, url, arch, pkgName, pkgVer, workDir=None, deps=None):
@@ -291,14 +292,16 @@ class RPM(object):
       self._remoteRpms[arch] = [
         item["Key"]
         for page in self._s3.get_paginator("list_objects_v2").paginate(
-            Bucket=self._bucket, Delimiter="/", Prefix="RPMS/%s/" % arch)
+            Bucket=self._bucket, Delimiter="/",
+            Prefix="%s/%s/" % (self._s3_path, arch))
         for item in page.get("Contents", ())
         if item["Key"].endswith(".rpm")
       ]
 
     kw = self._kw(None, arch, pkgName, pkgVer)
     debug("RPM: checking if %(rpm)s exists for %(package)s %(version)s on %(arch)s" % kw)
-    return ("RPMS/%(arch)s/%(rpm)s" % kw) in self._remoteRpms[arch]
+    s3_key = "{s3_path}/{arch}/{rpm}".format(s3_path=self._s3_path, **kw)
+    return s3_key in self._remoteRpms[arch]
 
   def install(self, url, arch, pkgName, pkgVer, deps, allDeps):
     # All RPMs are created in workDir (temporary, destroyed after creation).
@@ -365,7 +368,7 @@ class RPM(object):
       stagedir = join(self._stageDir, arch)
       mergedir = join(self._stageDir, "merged", arch)
 
-      baseUrl = self._baseUrl.rstrip("/") + "/RPMS/" + arch
+      baseUrl = self._baseUrl.rstrip("/") + "/" + self._s3_path + "/" + arch
       createrepo = ["createrepo", "--baseurl", baseUrl, stagedir]
       debug("RPM: %s", " ".join(createrepo))
 
@@ -392,20 +395,20 @@ class RPM(object):
       for rpm in glob(join(stagedir, "*.rpm")):
         info("RPM: uploading new RPM %s", basename(rpm))
         self._s3.upload_file(Filename=rpm, Bucket=self._bucket,
-                             Key=join("RPMS", arch, basename(rpm)))
+                             Key=join(self._s3_path, arch, basename(rpm)))
       # 2. Delete current metadata files on S3.
       info("RPM: deleting old repo metadata")
       self._s3.delete_objects(Bucket=self._bucket, Delete={"Objects": [
         {"Key": old_file["Key"]} for old_file in self._s3.list_objects_v2(
           Bucket=self._bucket, Delimiter="/",
-          Prefix="RPMS/%s/repodata/" % arch).get("Contents", ())
+          Prefix="%s/%s/repodata/" % (self._s3_path, arch)).get("Contents", ())
       ]})
       # 3. Upload new, merged metadata files.
       for new_file in listdir(join(mergedir, "repodata")):
         info("RPM: uploading new repo metadata: %s", new_file)
         self._s3.upload_file(Bucket=self._bucket,
                              Filename=join(mergedir, "repodata", new_file),
-                             Key=join("RPMS", arch, "repodata", new_file))
+                             Key=join(self._s3_path, arch, "repodata", new_file))
 
     # Errors here are not fatal.
     debug("RPM: removing staging directory %s", self._stageDir)

--- a/publish/aliPublishS3
+++ b/publish/aliPublishS3
@@ -883,7 +883,9 @@ def main():
     else:
       conf["rpm_updatable"] = conf.get("rpm_updatable", False)
       archKey = "RPM"
-      pub = RPM(publishScriptTpl=open(progDir+"/pub-rpms-template.sh").read(),
+      template = "pub-updatable-rpms-template.sh" if conf["rpm_updatable"] \
+        else "pub-rpms-template.sh"
+      pub = RPM(publishScriptTpl=open(progDir + "/" + template).read(),
                 connParams=connParams,
                 genUpdatableRpms=conf["rpm_updatable"],
                 baseUrl=conf["base_url"],

--- a/publish/pub-updatable-rpms-template.sh
+++ b/publish/pub-updatable-rpms-template.sh
@@ -19,8 +19,9 @@ cd $TMPDIR
 
 if [[ $RPM_IS_UPDATABLE ]]; then
   case "%(dependencies)s" in
-    *AliEn-runtime*) ;;
-    *) echo "Not publishing %(package)s with version %(version)s as it has AliEn-Runtime as a dependency";  exit 0 ;;
+    *AliEn-Runtime*)
+      echo "Not publishing %(package)s with version %(version)s as it has AliEn-Runtime as a dependency"
+      exit 0 ;;
   esac
 fi
 

--- a/publish/pub-updatable-rpms-template.sh
+++ b/publish/pub-updatable-rpms-template.sh
@@ -106,11 +106,12 @@ pushd unpack_rpm
     IFS="$OLD_IFS"
   fi
   # Remove useless files conflicting between packages
-  if [ ! "X$RPM_IS_UPDATABLE" = X ]; then
-    mv $RPM_ROOT/.build-hash $RPM_ROOT/.build-hash.%(package)s 
-    mv $RPM_ROOT/.rpm-extra-deps $RPM_ROOT/.rpm-extra-deps.%(package)s
-    mv $RPM_ROOT/.original-unrelocated $RPM_ROOT/.original-unrelocated.%(package)s 
-    mv $RPM_ROOT/etc/profile.d/init.sh $RPM_ROOT/etc/profile.d/init.sh.%(package)s  
+  if [ -n "$RPM_IS_UPDATABLE" ]; then
+    for conflict in .build-hash .rpm-extra-deps .original-unrelocated etc/profile.d/init.sh; do
+      if [ -e "$RPM_ROOT/$conflict" ]; then
+        mv "$RPM_ROOT/$conflict" "$RPM_ROOT/$conflict.%(package)s"
+      fi
+    done
   fi
 popd
 

--- a/publish/pub-updatable-rpms-template.sh
+++ b/publish/pub-updatable-rpms-template.sh
@@ -25,38 +25,9 @@ if [[ $RPM_IS_UPDATABLE ]]; then
   esac
 fi
 
-# Create aliswmod RPM
-ALISWMOD_VERSION=4
-ALISWMOD_RPM="alisw-aliswmod-$ALISWMOD_VERSION-1.%(arch)s.rpm"
-if [[ ! -e "%(repodir)s/$ALISWMOD_RPM" ]]; then
-  mkdir -p aliswmod/bin
-  mkdir -p aliswmod/etc/profile.d
-  cat > aliswmod/etc/profile.d/99-aliswmod.sh << EOF
-export LD_LIBRARY_PATH=/opt/alisw/el7/lib:/opt/alisw/el7/lib64:\$LD_LIBRARY_PATH
-export PATH=/opt/alisw/el7/bin:\$PATH
-export MODULEPATH=$INSTALLPREFIX/$FLAVOUR/modulefiles:$INSTALLPREFIX/$FLAVOUR/etc/Modules/modulefiles:\$MODULEPATH
-EOF
-  pushd aliswmod
-    fpm -s dir                                 \
-        -t rpm                                 \
-        --force                                \
-        --depends 'environment-modules >= 4.0' \
-        --prefix /                             \
-        --architecture $ARCHITECTURE           \
-        --version $ALISWMOD_VERSION            \
-        --iteration 1.$FLAVOUR                 \
-        --name alisw-aliswmod                  \
-        .
-  popd
-  mv aliswmod/$ALISWMOD_RPM .
-  rm -rf aliswmod/
-else
-  echo No need to create the package, skipping
-  ALISWMOD_RPM=
-fi
-
 DEPS=()
-DEPS+=("--depends" "alisw-aliswmod >= $ALISWMOD_VERSION")
+# Use env modules v4 instead of aliswmod
+DEPS+=("--depends" "environment-modules >= 4.0")
 
 # Updatable RPMs don't have the version number hardcoded in the package name
 if [[ $RPM_IS_UPDATABLE ]]; then
@@ -176,4 +147,4 @@ pushd unpack_rpm
   mkdir -vp %(repodir)s
   mv -v $RPM ../
 popd
-mv -v $RPM $ALISWMOD_RPM %(stagedir)s
+mv -v $RPM %(stagedir)s

--- a/publish/run-all-rpms.sh
+++ b/publish/run-all-rpms.sh
@@ -55,7 +55,7 @@ while true; do
   s3cmd ls "s3://alibuild-repo/rpmstatus/$arch/" | cut -b 32- > canaries.txt
 
   case "$arch" in
-    el8.*) publish=publish_s3 ;;
+    el8*) publish=publish_s3 ;;
     *) publish=publish_both ;;
   esac
 


### PR DESCRIPTION
This branch includes the changes to the CentOS 8 RPM publisher that I've been testing recently. Most importantly, this allows us to publish updatable RPMs for CentOS 8 (i.e. off S3).

At David's request, I also changed the updatable RPM publishing script to install stuff in package-specific (but not version-specific) subdirs, so e.g. O2 executables would go in `/opt/alisw/elX/O2/bin/`, instead of `/opt/alisw/el8/bin/`. Modulefiles still all go in `/opt/alisw/elX/etc/Modules/modulefiles/`.

Tested and working as far as I can tell, but comments/feedback would be appreciated.