### PR TITLE
Track number of commits on the base branch in CI

### DIFF
--- a/ci/build-helpers.sh
+++ b/ci/build-helpers.sh
@@ -42,6 +42,7 @@ function report_state () {
   # Push to InfluxDB if configured
   influxdb_push prcheck "repo=$PR_REPO" "checkname=$CHECK_NAME" \
                 "worker=$CHECK_NAME/$WORKER_INDEX/$WORKERS_POOL_SIZE" \
+                "num_base_commits=$NUM_BASE_COMMITS" \
                 -- "host=\"$(hostname -s)\"" "state=\"$current_state\"" \
                 "prid=\"$PR_NUMBER\"" ${prtime:+prtime=$prtime} ${PR_OK:+prok=$PR_OK} \
                 ${HAVE_JALIEN_TOKEN:+have_jalien_token=$HAVE_JALIEN_TOKEN}

--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -132,6 +132,7 @@ unset certdir jalien_token
 
 report_state pr_processing
 
+NUM_BASE_COMMITS=-1
 # Fetch the PR's changes to the git repository.
 if pushd "$PR_REPO_CHECKOUT"; then
   git config --add remote.origin.fetch '+refs/pull/*/head:refs/remotes/origin/pr/*'
@@ -144,6 +145,7 @@ if pushd "$PR_REPO_CHECKOUT"; then
   git clean -fxd
   old_size=$(du -sm . | cut -f1)
   base_hash=$(git rev-parse --verify HEAD)  # reference upstream hash
+  NUM_BASE_COMMITS=$(git rev-list --count HEAD)
 
   if ! git merge --no-edit "$PR_HASH"; then
     # clean up in case the merge fails


### PR DESCRIPTION
This metric would be useful to see which commits on the dev/master branch introduce regressions.