### PR TITLE
Exclude bookkeeping-api versions with @ from RPM publishing

### DIFF
--- a/publish/aliPublish-rpms-cc8.conf
+++ b/publish/aliPublish-rpms-cc8.conf
@@ -79,6 +79,9 @@ architectures:
         - -18d7f0d6f3-
         - -38c51d6edf-
         - -8112bb1d4c-
+      bookkeeping-api:
+        # These cannot be packaged as RPMs due to the "@" in the version field.
+        - "^bookkeeping@"
 
 # What packages to publish
 auto_include_deps: True

--- a/publish/test-rpms-cc8.yaml
+++ b/publish/test-rpms-cc8.yaml
@@ -1,0 +1,4 @@
+---
+slc8_x86-64:
+  bookkeeping-api:
+    bookkeeping@0.49.1-1: false


### PR DESCRIPTION
I think this is causing the repeated publishing failures for the `bookkeeping-api` version `bookkeeping@0.49.1-1`.