### PR TITLE
Exclude packages depending on broken bookkeeping version

### DIFF
--- a/publish/aliPublish-rpms-cc8.conf
+++ b/publish/aliPublish-rpms-cc8.conf
@@ -82,6 +82,14 @@ architectures:
       bookkeeping-api:
         # These cannot be packaged as RPMs due to the "@" in the version field.
         - "^bookkeeping@"
+      # The following three depend on the bookkeeping-api version
+      # bookkeeping@0.49.1-1, which can't be published as an RPM.
+      O2PDPSuite:
+        - ^epn-20230308-1$
+      O2sim:
+        - ^v20230308-3$
+      QualityControl:
+        - ^v1.92.0-9$
 
 # What packages to publish
 auto_include_deps: True

--- a/publish/test-rpms-cc8.yaml
+++ b/publish/test-rpms-cc8.yaml
@@ -1,4 +1,10 @@
 ---
 slc8_x86-64:
+  O2PDPSuite:
+    epn-20230308-1: false
+  O2sim:
+    v20230308-3: false
+  QualityControl:
+    v1.92.0-9: false
   bookkeeping-api:
     bookkeeping@0.49.1-1: false


### PR DESCRIPTION
The broken package from #1235 is still being published, as it's being pulled in by other packages. Exclude them, since there's no point in publishing them.