### PR TITLE
Fix listing installed AliEn packages

### DIFF
--- a/publish/aliPublish
+++ b/publish/aliPublish
@@ -310,8 +310,7 @@ class AliEnPackMan(object):
         if not m: continue
         pkg = m.group(1)
         ver = m.group(2)
-        if pkg in self._packs:
-          self._packs[pkg].setdefault(ver, []).append(arch)
+        self._packs.setdefault(pkg, {}).setdefault(ver, []).append(arch)
       self._cachedArchs.append(arch)
 
     return arch in self._packs.get(pkgName, {}).get(pkgVer, [])

--- a/publish/aliPublishS3
+++ b/publish/aliPublishS3
@@ -221,8 +221,7 @@ class AliEnPackMan(object):
         if not m: continue
         pkg = m.group(1)
         ver = m.group(2)
-        if pkg in self._packs:
-          self._packs[pkg].setdefault(ver, []).append(arch)
+        self._packs.setdefault(pkg, {}).setdefault(ver, []).append(arch)
       self._cachedArchs.append(arch)
 
     return arch in self._packs.get(pkgName, {}).get(pkgVer, [])


### PR DESCRIPTION
If a package was completely missing from the output of `alien -exec packman list -all -force`, it was previously ignored completely (and always taken to be uninstalled). However, packman doesn't list defaults-release, UUID and O2-customization for some reason, causing aliPublish to keep republishing these.