### PR TITLE
Allow specifying extra build env variables

### DIFF
--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -124,6 +124,10 @@ alibuild_args=(
   build "$main_pkg"
 )
 
+for var in $BUILD_ENV_VARS; do
+  alibuild_args+=(-e "$var")
+done
+
 # Process the pattern as a jinja2 template with aliBuild's templating plugin.
 # Fetch the source repos now, so they're available for the "real" build later.
 AUTOTAG_PATTERN=$(aliBuild --debug --plugin templating --fetch-repos "${alibuild_args[@]}" << EOF


### PR DESCRIPTION
For some daily builds (e.g. WeeklyO2Release), we may want to specify some extra, custom env vars during the build.

This patch allows using a Jenkins parameter such as `BUILD_ENV_VARS='FOO=1 BAR=2'` to accomplish this.

Cc: @davidrohr 