### PR TITLE
Use setuptools_scm for automatic versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,17 @@ if sys.version_info >= (3, 6):
 setup(
     name='ali-bot',
 
-    # Versions should comply with PEP440.  For a discussion on single-sourcing
-    # the version across setup.py and the project code, see
-    # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.0',
+    # Single-source our package version using setuptools_scm. This makes it
+    # PEP440-compliant, and it always references the ali-bot commit that each
+    # script was built from.
+    use_scm_version=True,
+    setup_requires=[
+        # The 6.* series removed support for Python 2.7.
+        'setuptools_scm<6.0.0' if sys.version_info < (3, 0) else
+        # The 7.* series removed support for Python 3.6.
+        'setuptools_scm<7.0.0' if sys.version_info < (3, 7) else
+        'setuptools_scm'
+    ],
 
     description='ALICE Multipurpose bot',
     long_description=long_description,


### PR DESCRIPTION
This is the same approach that alibuild already uses.

Recent pip versions have stopped accepting "LAST_TAG" as a valid version number. We used a constant "0.0.0" version as a stop-gap, but this still had problems -- pip didn't update the installed ali-bot version sometimes, since it assumed that the right version was already installed.

This new, proper versioning scheme encodes the commit number (and hash) in the autogenerated version number, so auto-updates (e.g. in CI) should work properly.

This will allow us to get rid of some hacky workarounds in the CI scripts as well.

Tested and working on CentOS 7 and above under Python 3.6+.