### PR TITLE
Remove workarounds for invalid Python version numbers

### DIFF
--- a/ci/continuous-builder.sh
+++ b/ci/continuous-builder.sh
@@ -94,14 +94,9 @@ if [ -n "$HASHES" ]; then
 
       # Allow overriding the ali-bot/alibuild version to install -- this is useful
       # for testing changes to those with a few workers before deploying widely.
-      # Building a wheel for alibuild and/or ali-bot will fail, as they have an
-      # invalid version string ("LAST_TAG"). This messes up shebang mangling on
-      # some platforms, so use --no-binary for those packages. Also, we need to
-      # install ali-bot and alibuild as editable, else pip doesn't update them
-      # properly (perhaps because the version string is always "LAST_TAG").
-      short_timeout python3 -m pip install --upgrade --no-binary=alibuild,ali-bot \
-          -e "git+https://github.com/$(get_config_value install-alibot   "$INSTALL_ALIBOT")[ci]" \
-          -e "git+https://github.com/$(get_config_value install-alibuild "$INSTALL_ALIBUILD")" ||
+      short_timeout python3 -m pip install --upgrade \
+          "git+https://github.com/$(get_config_value install-alibot   "$INSTALL_ALIBOT")[ci]" \
+          "git+https://github.com/$(get_config_value install-alibuild "$INSTALL_ALIBUILD")" ||
         exit 1
 
       # Run the build


### PR DESCRIPTION
Once both alibuild and ali-bot use setuptools_scm versioning, we can remove these workarounds. This ought to make our venvs simpler and reduce failures from e.g. changing which repository to install from.

Depends on #1245 in ali-bot; alibuild already uses setuptools_scm.