### PR TITLE
Run AliEn publisher under Nomad using authenticated alimonitor API

### DIFF
--- a/publish/aliPublishS3
+++ b/publish/aliPublishS3
@@ -186,10 +186,16 @@ class CvmfsServer(PlainFilesystem):
 class AliEn:
 
   def __init__(self, connParams, dryRun=False):
-    self._req_params = {
-      "timeout": connParams["conn_timeout_s"],
-      "verify": bool(connParams["http_ssl_verify"]),
-    }
+    self._session = requests.Session()
+    self._session.timeout = connParams["conn_timeout_s"]
+    # "verify" can be a string pointing to a CA file or directory, or a
+    # boolean to switch host cert verification on or off.
+    self._session.verify = \
+      environ.get("ALIEN_CA_BUNDLE", bool(connParams["http_ssl_verify"]))
+    self._session.cert = \
+      (environ["ALIEN_CLIENT_CERT"], environ["ALIEN_CLIENT_KEY"])
+    self._session.auth = \
+      requests.auth.HTTPBasicAuth(environ["ALIEN_USER"], environ["ALIEN_TOKEN"])
     self._dryRun = dryRun
     self._packs = None
 
@@ -199,9 +205,7 @@ class AliEn:
       return self._packs
 
     debug("AliEn: fetching list of packages from alimonitor")
-    response = requests.get("http://alimonitor.cern.ch/export/packages.jsp",
-                            **self._req_params)
-
+    response = self._session.get("https://alimonitor.cern.ch/export/packages.jsp")
     if response.status_code != requests.codes.ok:
       error("AliEn: got HTTP %d from alimonitor when fetching package list; "
             "aborting", response.status_code)
@@ -250,11 +254,11 @@ class AliEn:
       debug("Dry run: would have registered %r with alimonitor", request_data)
     else:
       try:
-        # Our request is only accepted when running on alimonitor and
-        # requesting from localhost, for security reasons.
-        requests.get("http://127.0.0.1/packages/define.jsp",
-                     params=request_data, **self._req_params) \
-                .raise_for_status()
+        self._session.get("https://alimonitor.cern.ch/packages/define.jsp",
+                          # Set stream=False to read the response body and
+                          # release the connection back to the pool.
+                          params=request_data, stream=False) \
+                     .raise_for_status()
       except requests.HTTPError as exc:
         error("AliEn: failed to register new package", exc_info=exc)
         return 1

--- a/publish/get-and-run.sh
+++ b/publish/get-and-run.sh
@@ -10,7 +10,10 @@ NOTIFICATION_STATE_FILE=/tmp/publisher_notification_snoozer
 
 export LANG=C
 cd "$(dirname "$0")"
-if [[ -x /home/monalisa/bin/alien ]]; then
+if [ -n "$NOMAD_TASK_DIR" ] && [ -d "$NOMAD_TASK_DIR" ]; then
+  # We're running under Nomad, variables should be set by the job.
+  : "${CMD:?Please set CMD}" "${CONF:?Please set CONF}" "${NO_UPDATE=true}"
+elif [[ -x /home/monalisa/bin/alien ]]; then
   export PATH="/home/monalisa/bin:$PATH"
   CMD=sync-alien
   OVERRIDE='{"notification_email":{}}'

--- a/publish/get-and-run.sh
+++ b/publish/get-and-run.sh
@@ -63,7 +63,7 @@ venv=${NOMAD_TASK_DIR-$PWD}/venv
 rm -rf "$venv"
 python3 -m venv "$venv"
 . "$venv/bin/activate"
-pip install -Ue "$DEST"
+pip install -U "$DEST"
 
 ln -nfs "$(basename "$LOG.error")" "$logdir/latest"
 cachedir=${NOMAD_TASK_DIR-$PWD}/cache

--- a/publish/get-and-run.sh
+++ b/publish/get-and-run.sh
@@ -152,3 +152,5 @@ fi
 if [ -z "$NO_UPDATE" ] && [ -x "$DEST/publish/get-and-run.sh" ]; then
   cp -v "$DEST/publish/get-and-run.sh" .
 fi
+
+[ -z "$ERR" ]   # exit with failure if any errors occurred

--- a/publish/get-and-run.sh
+++ b/publish/get-and-run.sh
@@ -70,7 +70,7 @@ cachedir=${NOMAD_TASK_DIR-$PWD}/cache
 mkdir -p "$cachedir"
 pushd $DEST/publish
 
-  echo "Running version $(git rev-parse HEAD)"
+  echo "Running version $(pip list --format freeze | grep ali-bot)"
   ERR=
 
   # Packages publisher


### PR DESCRIPTION
This allows us to run the AliEn publisher elsewhere, e.g. through Nomad for better monitoring.

Draft and untested since the auth mechanism isn't implemented yet by @costing as far as I know.