### PR TITLE
Clean up old nightly tags in CI

### DIFF
--- a/ci/cleanup.py
+++ b/ci/cleanup.py
@@ -129,8 +129,12 @@ class CIEnvironment:
                     for pkg_dir in self.work_dir.glob("*_*/*")
                     # Path.glob("*/") doesn't only select directories,
                     # so explicitly filter for directories.
-                    if pkg_dir.is_dir() and pkg_dir.name in self.packages
+                    if pkg_dir.is_dir()
                     for entry in pkg_dir.iterdir()
+                    # Clean up old nightlies for non-dev packages as well.
+                    if pkg_dir.name in self.packages
+                    or "nightly" in entry.resolve().name
+                    or "daily" in entry.resolve().name
             ))
             if entry.is_symlink()
         )


### PR DESCRIPTION
Delete old nightlies for non-development packages as well, as they pile up and take up too much space otherwise.

Tested and working on a CI builder. Fine to merge after the weekend in my opinion.

Cc: @costing -- this should keep disk use under control a bit more.