### PR TITLE
Make build failure notification more informative

### DIFF
--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -132,7 +132,7 @@ try {
   }
 } catch (e) {
   // Notify failures
-  emailext(subject: "Daily ${PACKAGES} tag failed",
+  emailext(subject: "${env.JOB_NAME}#${env.BUILD_NUMBER}: daily tag failed for ${PACKAGES}",
            body: "More details here: ${env.BUILD_URL}",
            to: "${NOTIFY_EMAILS}")
   throw e


### PR DESCRIPTION
Add the job name and number (e.g. DailyO2Physics#42) to the subject.