### PR TITLE
Handle 2X.* versions of Ubuntu in alienv

### DIFF
--- a/.github/workflows/check-cvmfs.yml
+++ b/.github/workflows/check-cvmfs.yml
@@ -104,7 +104,7 @@ jobs:
               # shellcheck disable=SC2030
               export PATH=$np:$PATH
               ALIENV_DEBUG=1 alienv printenv AliPhysics/v5-09-59o-01_O2-1
-            )
+            ) || exit $?
           done
 
           np=/tmp/alienv_symlink/bin
@@ -114,7 +114,7 @@ jobs:
             # shellcheck disable=SC2030,SC2031
             export PATH=$np:$PATH
             ALIENV_DEBUG=1 alienv printenv AliPhysics/v5-09-59o-01_O2-1
-          )
+          ) || exit $?
           unset np
           # shellcheck disable=SC2031
           PATH=$(dirname "$ALIENV"):$PATH
@@ -122,7 +122,8 @@ jobs:
           [ "$(command -v alienv)" = "$ALIENV" ]
 
           pt "test package reordering"
-          ALIENV_DEBUG=1 alienv setenv VO_ALICE@AliEn-Runtime::v2-19-le-21,VO_ALICE@ROOT::v5-34-30-alice7-2,VO_ALICE@AliPhysics::vAN-20170301-1 -c true 2>&1 |
+          (ALIENV_DEBUG=1 alienv setenv VO_ALICE@AliEn-Runtime::v2-19-le-21,VO_ALICE@ROOT::v5-34-30-alice7-2,VO_ALICE@AliPhysics::vAN-20170301-1 -c true 2>&1 || :) |
+            tee /dev/stderr |
             grep 'normalized to AliPhysics/vAN-20170301-1 ROOT/v5-34-30-alice7-2 AliEn-Runtime/v2-19-le-21'
 
           pt "test checkenv command with a successful combination"

--- a/.github/workflows/check-cvmfs.yml
+++ b/.github/workflows/check-cvmfs.yml
@@ -103,7 +103,7 @@ jobs:
               ln -nfs "$ALIENV" "$np/alienv"
               # shellcheck disable=SC2030
               export PATH=$np:$PATH
-              ALIENV_DEBUG=1 alienv q | grep AliPhysics | tail -n1
+              ALIENV_DEBUG=1 alienv printenv AliPhysics/v5-09-59o-01_O2-1
             )
           done
 
@@ -113,7 +113,7 @@ jobs:
             ln -nfs "$(dn=$(dirname "$ALIENV"); while [ "$dn" != / ]; do dn=$(dirname "$dn"); printf ../; done)$ALIENV" "$np/alienv"
             # shellcheck disable=SC2030,SC2031
             export PATH=$np:$PATH
-            ALIENV_DEBUG=1 alienv q | grep AliPhysics | tail -n1
+            ALIENV_DEBUG=1 alienv printenv AliPhysics/v5-09-59o-01_O2-1
           )
           unset np
           # shellcheck disable=SC2031
@@ -142,8 +142,10 @@ jobs:
           alienv checkenv AliGenerators/v20180424-1 ||
             pe "expected 0, returned $?"
 
-          pt "list AliPhysics packages"
-          alienv q | grep AliPhysics | tail -n5
+          # "alienv q" takes too long in a GitHub workflow (>45 min).
+          # pt "list AliPhysics packages"
+          # alienv q | grep AliPhysics | tail -n5
+
           alienv_test () {
             local method=$1 package=$2 command=$3
             case $method in

--- a/cvmfs/alienv
+++ b/cvmfs/alienv
@@ -140,7 +140,7 @@ case $distro_name in
               distro_xrelease=6.x
               platform=ubuntu1404
               ;;
-           16.*|17.*|18.*)
+           16.*|17.*|18.*|2?.*)
               # Required from system: apt install libx11-6 environment-modules
               distro_xrelease=
               platform=ubuntu1604


### PR DESCRIPTION
Might be best to just use a wildcard. If you prefer explicitly listing version numbers instead, let me know @ktf.