### PR TITLE
Gradually re-index RPMs if they are missing from the repo index

### DIFF
--- a/publish/aliPublishS3
+++ b/publish/aliPublishS3
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
 
-import logging, sys, json, yaml, errno, boto3, requests
+import logging, gzip, sys, json, yaml, errno, boto3, requests
+import botocore.exceptions
 from glob import glob
 from argparse import ArgumentParser
+from datetime import datetime, timedelta, timezone
 from time import time
 from logging import debug, info, warning, error
 from re import search, escape
-from os.path import isdir, isfile, realpath, dirname, getmtime, join, basename, abspath
+from os.path import isdir, isfile, realpath, dirname, getmtime, join, basename, abspath, exists
 from os import chmod, remove, getcwd, getpid, kill, makedirs, environ, listdir
 from tempfile import NamedTemporaryFile, mkdtemp
 from subprocess import Popen, PIPE, STDOUT, DEVNULL, getstatusoutput
 from smtplib import SMTP
+from xml.etree.ElementTree import ElementTree
 
 def format(s, **kwds):
   return s % kwds
@@ -114,7 +117,7 @@ class PlainFilesystem(object):
   def abort(self, force=False):
     return True
 
-  def publish(self):
+  def publish(self, architectures):
     return True
 
 
@@ -160,7 +163,7 @@ class CvmfsServer(PlainFilesystem):
     error("%s: cannot abort transaction", self._repository)
     return False
 
-  def publish(self):
+  def publish(self, architectures):
     if not self._inCvmfsTransaction:
       debug("%s: not in a transaction", self._repository)
       return True
@@ -266,7 +269,7 @@ class AliEn:
   def abort(self, force=False):
     return True
 
-  def publish(self):
+  def publish(self, architectures):
     return True
 
 class RPM(object):
@@ -279,7 +282,6 @@ class RPM(object):
     self._publishScriptTpl = publishScriptTpl
     self._countChanges = 0
     self._connParams = connParams
-    self._archs = []
     self._inRpmTransaction = False
     self._s3 = s3Client
     self._baseUrl = baseUrl
@@ -346,8 +348,6 @@ class RPM(object):
 
     rv = runInstallScript(self._publishScriptTpl, self._dryRun, **kw)
     if rv == 0:
-      if not arch in self._archs:
-        self._archs.append(arch)
       self._countChanges += 1
     debug("RPM: removing temporary working directory %(workdir)s" % kw)
     rmrf(workDir)
@@ -375,19 +375,92 @@ class RPM(object):
       self._inRpmTransaction = False
     return True
 
-  def publish(self):
-    if self._countChanges <= 0:
-      debug("RPM: nothing new to publish")
-      return True
-    info("RPM: updating repository: %s new package(s)", self._countChanges)
+  def publish(self, architectures):
     if self._dryRun:
       info("RPM: not updating repository, dry run")
       return True
+    info("RPM: updating repository: %d new package(s) in %d architecture(s)",
+         self._countChanges, len(architectures))
 
-    for arch in self._archs:
+    for arch in architectures:
       stagedir = join(self._stageDir, arch)
       mergedir = join(self._stageDir, "merged", arch)
 
+      # Get the list of RPMs to upload now, before we download existing ones.
+      new_rpms = glob(join(stagedir, "*.rpm"))
+      debug("RPM: %d new RPMs to publish for %s", len(new_rpms), arch)
+
+      # 1. Download (up to 10G) RPMs that are not listed in metadata.
+      nonindexed_rpms = set()
+      repomd_xml = "/".join((self._s3_path, arch, "repodata", "repomd.xml"))
+      try:
+        repomd_xml_content = self._s3.get_object(Bucket=self._bucket, Key=repomd_xml)["Body"].read()
+      except botocore.exceptions.ClientError as exc:
+        warning("No existing repomd.xml found at %s", repomd_xml, exc_info=exc)
+      else:
+        index_name_match = search(rb"repodata/[0-9a-f]+-primary\.xml\.gz", repomd_xml_content)
+        if not index_name_match:
+          warning("No reference to primary.xml.gz found in repomd.xml")
+        else:
+          index_key = "/".join((self._s3_path, arch, index_name_match.group(0).decode("utf-8")))
+          try:
+            index_file = self._s3.get_object(Bucket=self._bucket, Key=index_key)
+          except botocore.exceptions.ClientError as exc:
+            warning("Index file at %s not found", index_key, exc_info=exc)
+          else:
+            with gzip.open(index_file["Body"]) as primary_xml:
+              index_rpms = {
+                installed_pkg.attrib["href"]   # basename only, even though it's called "href"
+                for installed_pkg in ElementTree(file=primary_xml).iterfind(
+                    "./c:package/c:location",
+                    {"c": "http://linux.duke.edu/metadata/common"},
+                )
+              }
+            have_rpms = {
+              basename(rpm_file["Key"])
+              for page in self._s3.get_paginator("list_objects_v2").paginate(
+                Bucket=self._bucket, Delimiter="/",
+                Prefix="%s/%s/" % (self._s3_path, arch),
+              )
+              for rpm_file in page.get("Contents", ())
+              if rpm_file["Key"].endswith(".rpm")
+            }
+            nonindexed_rpms = have_rpms - index_rpms
+
+      if not new_rpms and not nonindexed_rpms:
+        debug("RPM: nothing new to publish for %s; skipping", arch)
+        continue
+      debug("RPM: found %d non-indexed RPMs for %s", len(nonindexed_rpms), arch)
+
+      downloaded_size = 0
+
+      def update_downloaded_size(n_bytes):
+        nonlocal downloaded_size
+        downloaded_size += n_bytes
+
+      debug("RPM: creating staging directory %s", stagedir)
+      try:
+        makedirs(stagedir)
+      except OSError as exc:
+        if not isdir(stagedir) or exc.errno != errno.EEXIST:
+          error("RPM: error creating staging directory %s", stagedir)
+          continue
+
+      for rpm_name in nonindexed_rpms:
+        if exists(join(stagedir, rpm_name)):
+          continue
+        debug("RPM: downloading non-indexed RPM: %s", rpm_name)
+        self._s3.download_file(
+          Filename=join(stagedir, rpm_name),
+          Bucket=self._bucket,
+          Key="/".join((self._s3_path, arch, rpm_name)),
+          Callback=update_downloaded_size,
+        )
+        if downloaded_size > 10 * 1024**3:   # 10 GiB
+          debug("RPM: downloaded %.2f GiB, stopping now", downloaded_size / 1024**3)
+          break
+
+      # Create a temporary repo with only the new (and unindexed) RPMs.
       baseUrl = self._baseUrl.rstrip("/") + "/" + self._s3_path + "/" + arch
       createrepo = ["createrepo", "--baseurl", baseUrl, stagedir]
       debug("RPM: %s", " ".join(createrepo))
@@ -398,6 +471,7 @@ class RPM(object):
         error("RPM: error creating repository for %s", arch)
         return False
 
+      # Merge the temporary repo with the existing metadata.
       mergerepo = ["mergerepo", "--verbose", "--all",
                    "--nogroups", "--noupdateinfo",
                    "--repo", baseUrl,
@@ -411,25 +485,43 @@ class RPM(object):
         error("RPM: error merging repositories for %s", arch)
         return False
 
+      # Upload new RPMs.
       debug("RPM: uploading new RPMs and merged metadata to S3")
-      # 1. Upload new RPMs.
-      for rpm in glob(join(stagedir, "*.rpm")):
+      for rpm in new_rpms:
         info("RPM: uploading new RPM %s", basename(rpm))
         self._s3.upload_file(Filename=rpm, Bucket=self._bucket,
                              Key=join(self._s3_path, arch, basename(rpm)))
-      # 2. Delete current metadata files on S3.
-      info("RPM: deleting old repo metadata")
-      self._s3.delete_objects(Bucket=self._bucket, Delete={"Objects": [
-        {"Key": old_file["Key"]} for old_file in self._s3.list_objects_v2(
-          Bucket=self._bucket, Delimiter="/",
-          Prefix="%s/%s/repodata/" % (self._s3_path, arch)).get("Contents", ())
-      ]})
-      # 3. Upload new, merged metadata files.
-      for new_file in listdir(join(mergedir, "repodata")):
+      # Backup repomd.xml separately, since we overwrite it later.
+      new_repomd = repomd_xml + "." + datetime.utcnow().isoformat(timespec="seconds")
+      info("RPM: creating backup %s", new_repomd)
+      self._s3.copy_object(CopySource={"Bucket": self._bucket, "Key": repomd_xml},
+                           Bucket=self._bucket, Key=new_repomd)
+      # Upload new, merged metadata files.
+      new_files = listdir(join(mergedir, "repodata"))
+      # Sort repomd.xml last, so that it is only replaced once the files it
+      # refers to are in place.
+      new_files.sort(key=lambda name: name == "repomd.xml")
+      for new_file in new_files:
         info("RPM: uploading new repo metadata: %s", new_file)
         self._s3.upload_file(Bucket=self._bucket,
                              Filename=join(mergedir, "repodata", new_file),
                              Key=join(self._s3_path, arch, "repodata", new_file))
+      # Delete old metadata files on S3.
+      cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+      old_metadata = [
+        old_file["Key"]
+        for page in self._s3.get_paginator("list_objects_v2").paginate(
+          Bucket=self._bucket, Delimiter="/",
+          Prefix="%s/%s/repodata/" % (self._s3_path, arch),
+        )
+        for old_file in page.get("Contents", ())
+        if old_file["LastModified"] < cutoff
+        and basename(old_file["Key"]) not in new_files
+      ]
+      info("RPM: deleting %d old repo metadata files", len(old_metadata))
+      self._s3.delete_objects(Bucket=self._bucket, Delete={"Objects": [
+        {"Key": old_file} for old_file in old_metadata
+      ]})
 
     # Errors here are not fatal.
     debug("RPM: removing staging directory %s", self._stageDir)
@@ -652,7 +744,7 @@ def sync(pub, architectures, s3Client, bucket, baseUrl, basePrefix, rules,
               arch, pack["name"], pack["ver"], rv)
 
   # Publish eventually
-  if pub.publish():
+  if pub.publish(architectures.values()):
     totSuccess = 0
     totFail = 0
     for arch, packStatus in newPackages.items():
@@ -773,6 +865,7 @@ def main():
   logging.getLogger("boto3").setLevel(logging.WARNING)
   logging.getLogger("botocore").setLevel(logging.WARNING)
   logging.getLogger("urllib3").setLevel(logging.WARNING)
+  logging.getLogger("s3transfer").setLevel(logging.WARNING)
 
   progDir = dirname(realpath(__file__))
 


### PR DESCRIPTION
Change `aliPublishS3` for RPMs to download the latest package index file, and if it finds any uploaded `.rpm` files that are not in the index, download up to ~10GiB of them and add them to the index.

This will gradually rebuild the index to include all uploaded RPMs.

Also, backup old index files before replacing them (so we never catastropically lose the entire index), cleaning up index files that are older than a month.

Tested and working with the el8 RPM repo.