### PR TITLE
Unify handling of GitHub cache file

### DIFF
--- a/report-pr-errors
+++ b/report-pr-errors
@@ -17,7 +17,7 @@ import shutil
 import sys
 import datetime
 
-from alibot_helpers.github_utilities import calculateMessageHash, github_token
+from alibot_helpers.github_utilities import calculateMessageHash
 from alibot_helpers.github_utilities import setGithubStatus, parseGithubRef
 from alibot_helpers.github_utilities import GithubCachedClient, PickledCache
 from alibot_helpers.utilities import to_unicode
@@ -127,7 +127,7 @@ def parse_args():
                         default="https://ali-ci.cern.ch/repo/logs",
                         help="Destination path for logs")
 
-    parser.add_argument("--github-cache-file", default=expanduser("~/.cached-commits"),
+    parser.add_argument("--github-cache-file", default=PickledCache.default_cache_location(),
                         help="Where to cache GitHub API responses (default %(default)s)")
 
     parser.add_argument("--debug", "-d",
@@ -538,8 +538,7 @@ def main():
     if not args.message and not args.pending:
         logs.parse()
 
-    cache = PickledCache(args.github_cache_file)
-    with GithubCachedClient(token=github_token(), cache=cache) as cgh:
+    with GithubCachedClient(cache=PickledCache(args.github_cache_file)) as cgh:
         # If the branch is not a PR, we should look for open issues
         # for the branch. This should really folded as a special case
         # of the PR case.

--- a/set-github-status
+++ b/set-github-status
@@ -5,8 +5,7 @@ from argparse import ArgumentParser
 import logging
 import sys
 
-from alibot_helpers.github_utilities import setGithubStatus, github_token
-from alibot_helpers.github_utilities import GithubCachedClient, PickledCache
+from alibot_helpers.github_utilities import setGithubStatus, GithubCachedClient
 
 
 # Just for the moment
@@ -63,10 +62,8 @@ def main():
     if args.dryRun:
         print("Dry run specified. Not executing")
         sys.exit(0)
-    token = github_token()
 
-    cache = PickledCache(".cached-commits")
-    with GithubCachedClient(token=token, cache=cache) as cgh:
+    with GithubCachedClient() as cgh:
         try:
             setGithubStatus(cgh, args)
         except RuntimeError as e:

--- a/summary-pr-report
+++ b/summary-pr-report
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 # A script which prepares a report of the pending PRs
 from argparse import ArgumentParser
-from datetime import date, datetime, timedelta
-from alibot_helpers.github_utilities import GithubCachedClient, PickledCache
-from alibot_helpers.github_utilities import github_token
+from datetime import datetime, timedelta
+from alibot_helpers.github_utilities import GithubCachedClient
 
 def from_iso(d):
   return datetime.strptime(d, "%Y-%m-%dT%H:%M:%SZ")
@@ -27,8 +26,7 @@ def getPrStatus(cgh, repo_name, ref):
 
 if __name__ == "__main__":
   args = parse_args()
-  cache = PickledCache('.cached-commits')
-  with GithubCachedClient(token=github_token(), cache=cache) as cgh:
+  with GithubCachedClient() as cgh:
     openIssues = cgh.get('/repos/{repo_name}/pulls?state=open',
                          repo_name=args.repo_name)
     # Print PRs which have an error state for more than 1h

--- a/utils/bulk-change-pr-status
+++ b/utils/bulk-change-pr-status
@@ -13,7 +13,6 @@ from __future__ import print_function
 from argparse import ArgumentParser, Namespace
 from collections import defaultdict
 from datetime import datetime, timezone
-from os.path import expanduser
 from sys import stderr
 
 import alibot_helpers.github_utilities as ghutil
@@ -99,9 +98,8 @@ def process_pr(cgh, args, repo, pull):
 
 def main(args):
     '''Application entry point.'''
-    token = ghutil.github_token()
     cache = ghutil.PickledCache(args.github_cache_file)
-    with ghutil.GithubCachedClient(token=token, cache=cache) as cgh:
+    with ghutil.GithubCachedClient(cache=cache) as cgh:
         for repo in args.repo_name:
             for pull in cgh.get('/repos/{repo}/pulls', repo=repo):
                 process_pr(cgh, args, repo, pull)
@@ -132,7 +130,7 @@ def parse_args():
                         help=("don't clear statuses' result URLs, for "
                               'inspection of previous build results'))
     parser.add_argument('-C', '--github-cache-file', metavar='GHCACHE',
-                        default=expanduser('~/.github-cached-commits'),
+                        default=ghutil.PickledCache.default_cache_location(),
                         help='GitHub cache location; default %(default)s')
     parser.add_argument('-b', '--before', metavar='DATE', type=datetime.fromisoformat,
                         default=datetime.now(), dest='filter_before',


### PR DESCRIPTION
This makes all scripts using the GitHub REST API use the same cache file, hopefully reducing the number of API requests slightly overall, and leaving fewer cache files all over the disk.