### PR TITLE
Build QC as CI for alibuild pull requests

### DIFF
--- a/ci/repo-config/mesosci/slc7/o2-alibuild.env
+++ b/ci/repo-config/mesosci/slc7/o2-alibuild.env
@@ -1,0 +1,16 @@
+CI_NAME=build_QualityControl_alibuild
+# Build QualityControl because it depends on a bunch of FLP packages that use
+# fancy things like git submodules, and we want to make sure all of that
+# works. O2Suite depends on O2Physics, which takes too long and doesn't really
+# test any extra alibuild behaviour.
+PACKAGE=QualityControl
+ALIBUILD_DEFAULTS=o2
+PR_REPO=alisw/alibuild
+PR_BRANCH=master
+NO_ASSUME_CONSISTENT_EXTERNALS=
+TRUST_COLLABORATORS=true
+CHECK_NAME=build/QualityControl/alibuild
+DONT_USE_COMMENTS=1
+INSTALL_ALIBUILD="$PR_REPO@$PR_HASH#egg=alibuild"
+DEVEL_PKGS="alisw/alidist master"
+ALIBUILD_O2_TESTS=1


### PR DESCRIPTION
This installs the alibuild version with changes proposed in the PR, then builds QC with that alibuild version to test it.

This is fine to run on the same build machines as other CI, since we isolate the Python environment in a venv and the next build will overwrite alibuild with its own version.