### PR TITLE
Set a status message when commits are untrusted

### DIFF
--- a/list-branch-pr
+++ b/list-branch-pr
@@ -22,13 +22,15 @@ import os.path
 import random
 import sys
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
 from collections import defaultdict
 from datetime import datetime, timezone
 
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 from alibot_helpers.utilities import parse_env_file
+from alibot_helpers.github_utilities import \
+    github_token, GithubCachedClient, setGithubStatus
 
 DEFAULTENV_NAME = "DEFAULTS.env"
 
@@ -130,15 +132,18 @@ class RepoConfig:
         intended_worker = int(sha.hexdigest(), 16) % self.worker_pool_size
         return intended_worker == self.worker_index
 
-    def trust_pr(self, session, pull):
+    def trust_pr(self, cgh, session, pull):
         """Determine whether the PR is trustworthy and can be built.
 
         If we specified a list of trusted users, teams or if we trust
         contributors, we need to check if this is the case for the given PR.
         Some of these options (notably trusting a team) will actually consume
         API calls, so you need to be careful about what you enable.
+
+        If the PR is not trusted, an appropriate status is set on its latest
+        commit.
         """
-        return bool(
+        trusted = bool(
             # If this PR has any approving reviews, trust it.
             # We only include approving reviews in pull["reviews"].
             pull["reviews"]["isApproved"] or
@@ -156,6 +161,18 @@ class RepoConfig:
                 session, self.repo_name.split("/")[0], self.trusted_team_slug
             )
         )
+        if not trusted:
+            setGithubStatus(cgh, Namespace(
+                commit="{repo}#{pr}@{commit}".format(
+                    repo=self.repo_name,
+                    pr=pull["number"],
+                    commit=pull["commits"]["nodes"][0]["commit"]["oid"],
+                ),
+                status="{}/pending".format(self.check_name),
+                message="Security: approval needed, not starting",
+                url=None,
+            ), debug_print=False)
+        return trusted
 
     def process_single_pr(self, pull_number, last_commit, pr_created,
                           is_draft=False, is_trusted=False):
@@ -198,14 +215,14 @@ class RepoConfig:
             "waiting_since": waiting_since,
         })
 
-    def process_pulls(self, session, repo_info, show_base_branch=False):
+    def process_pulls(self, cgh, session, repo_info, show_base_branch=False):
         """Return pull requests we can process, with relevant attributes."""
         for pull in repo_info["pullRequests"]["nodes"]:
             item = self.process_single_pr(
                 pull["number"], pull["commits"]["nodes"][0]["commit"],
                 pull["createdAt"],
                 is_draft=pull["isDraft"] or pull["title"].startswith("[WIP]"),
-                is_trusted=self.trust_pr(session, pull),
+                is_trusted=self.trust_pr(cgh, session, pull),
             )
             if item is not None:
                 yield item
@@ -223,38 +240,37 @@ class RepoConfig:
 def main(args):
     """Script entry point."""
     grouped = defaultdict(list)
-    transport = RequestsHTTPTransport(
-        url="https://api.github.com/graphql",
-        auth=("bearer", os.environ["GITHUB_TOKEN"]),
-    )
-    with Client(transport=transport) as session:
-        # Find .env files for this worker, parse them and find PRs to process
-        # for each build config.
-        env_files = glob.glob(os.path.join(
-            args.definitions_dir, args.mesos_role,
-            args.container_name + args.config_suffix, "*.env",
-        ))
-        for env_file in env_files:
-            env_file_name = os.path.basename(env_file)
-            if env_file_name == DEFAULTENV_NAME:
-                continue
+    # Find .env files for this worker, parse them and find PRs to process for
+    # each build config.
+    env_files = glob.glob(os.path.join(
+        args.definitions_dir, args.mesos_role,
+        args.container_name + args.config_suffix, "*.env",
+    ))
+    transport = RequestsHTTPTransport(url="https://api.github.com/graphql",
+                                      auth=("bearer", github_token()))
+    with GithubCachedClient() as cgh:
+        with Client(transport=transport) as session:
+            for env_file in env_files:
+                env_file_name = os.path.basename(env_file)
+                if env_file_name == DEFAULTENV_NAME:
+                    continue
 
-            try:
-                repo = RepoConfig(env_file_name[:-4],
-                                  args.definitions_dir, args.mesos_role,
-                                  args.container_name, args.config_suffix,
-                                  args.worker_index, args.worker_pool_size)
-            except ValueError as err:
-                print(env_file_name, err, sep=": ", file=sys.stderr)
-            else:
-                # Extend PR groups with PRs from this repo.
-                org, _, repo_name = repo.repo_name.partition("/")
-                repo_info = query_repo_info(session, org, repo_name,
-                                            repo.branch_ref,
-                                            args.show_base_branch)
-                for state, item in repo.process_pulls(session, repo_info,
-                                                      args.show_base_branch):
-                    grouped[state].append(item)
+                try:
+                    repo = RepoConfig(env_file_name[:-4],
+                                      args.definitions_dir, args.mesos_role,
+                                      args.container_name, args.config_suffix,
+                                      args.worker_index, args.worker_pool_size)
+                except ValueError as err:
+                    print(env_file_name, err, sep=": ", file=sys.stderr)
+                else:
+                    # Extend PR groups with PRs from this repo.
+                    org, _, repo_name = repo.repo_name.partition("/")
+                    repo_info = query_repo_info(session, org, repo_name,
+                                                repo.branch_ref,
+                                                args.show_base_branch)
+                    for state, item in repo.process_pulls(cgh, session, repo_info,
+                                                          args.show_base_branch):
+                        grouped[state].append(item)
 
     def print_prs(group, number=None):
         """Print N randomly chosen PRs from group on stdout."""


### PR DESCRIPTION
People's first contributions to O2 are not tested automatically for security reasons. This often leads to confusion, so set a message on those commits to let people know that they need a PR approval.