### PR TITLE
Formatting workflow improvements

### DIFF
--- a/.github/workflows/c++-code-formatting.yml
+++ b/.github/workflows/c++-code-formatting.yml
@@ -88,7 +88,6 @@ jobs:
           if patch=$(git-clang-format --commit "$base_commit" --diff \
                                       --style file "${commit_files[@]}")
           then
-            echo 'clang-format passed.' >> "$GITHUB_STEP_SUMMARY"
             echo cleanup_commit= >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -206,15 +205,15 @@ jobs:
           done
 
           # Tell user what to do in case of copyright notice error
-          if [ ${#incorrect_files[@]} -gt 0 ]; then
-            cat << EOF >> "$GITHUB_STEP_SUMMARY"
+          [ ${#incorrect_files[@]} -gt 0 ] || exit 0
+          cat << EOF >> "$GITHUB_STEP_SUMMARY"
           The following files are missing the correct copyright notice:
 
           EOF
-            for file in "${incorrect_files[@]}"; do
-              echo "- \`$file\`" >> "$GITHUB_STEP_SUMMARY"
-            done
-            cat << EOF >> "$GITHUB_STEP_SUMMARY"
+          for file in "${incorrect_files[@]}"; do
+            echo "- \`$file\`" >> "$GITHUB_STEP_SUMMARY"
+          done
+          cat << EOF >> "$GITHUB_STEP_SUMMARY"
 
           Make sure all of your C++ and CMake source files begin with the
           following exact lines (but replace the \`//\` at the beginning of each
@@ -228,10 +227,7 @@ jobs:
 
           (The year numbers on the first line aren't checked.)
           EOF
-            exit 1
-          else
-            echo 'Copyright check passed.' >> "$GITHUB_STEP_SUMMARY"
-          fi
+          exit 1
 
   line-endings:
     name: line endings
@@ -261,9 +257,9 @@ jobs:
                function error(title, message) {
                  printf "The following error is for file %s:\n", $6
                  printf "::error file=%s,title=%s::%s\n", $6, title, message
-                 exit_code = 1
+                 exit_code = 0
                }
-               BEGIN { exit_code = 0 }
+               BEGIN { exit_code = 1 }
                END { exit exit_code }
                ($5 != "text") { next }
                ($4 != "no_bom") {
@@ -283,8 +279,6 @@ jobs:
                }
              '
           then
-            echo 'Line endings check passed.' >> "$GITHUB_STEP_SUMMARY"
-          else
             cat << EOF >> "$GITHUB_STEP_SUMMARY"
           # Line ending and/or encoding errors found
 
@@ -330,13 +324,13 @@ jobs:
           # Find tabs and trailing whitespaces in modified text files and show
           # where they are.
           if awk '
-            BEGIN { exit_code = 0 }
+            BEGIN { exit_code = 1 }
             function error(title, message) {
               printf "The following error is for file %s, line %i, column %i:\n",
                      FILENAME, FNR, RSTART
               printf "::error file=%s,line=%i,col=%i,endColumn=%i,title=%s::%s\n",
                      FILENAME, FNR, RSTART, RSTART + RLENGTH, title, message
-              exit_code = 1
+              exit_code = 0
             }
             match($0, / +$/) {
               error("Trailing spaces",
@@ -351,8 +345,6 @@ jobs:
             }
           ' "${files[@]}"
           then
-            echo 'Whitespace check passed.' >> "$GITHUB_STEP_SUMMARY"
-          else
             cat << EOF >> "$GITHUB_STEP_SUMMARY"
           # Whitespace errors found.
 
@@ -394,21 +386,17 @@ jobs:
 
       - name: Run pragma check
         run: |
-          if git --no-pager grep -q '#pragma once' -- '*.h'; then
-            # Some files have #pragma once.
-            cat << EOF >> "$GITHUB_STEP_SUMMARY"
+          git --no-pager grep -q '#pragma once' -- '*.h' || exit 0
+          # Some files have #pragma once.
+          cat << EOF >> "$GITHUB_STEP_SUMMARY"
           The following files use \`#pragma once\`. Please change them.
 
           EOF
-            git --no-pager grep --line-number --column '#pragma once' -- '*.h' |
-              while IFS=: read -r file line column _; do
-                echo "The following error is for file $file, line $line:"
-                echo -n "::error file=$file,line=$line,column=$column,"
-                echo 'title=#pragma once::Do not use #pragma once.'
-                echo "- \`$file\`" >> "$GITHUB_STEP_SUMMARY"
-              done
-            exit 1
-          else
-            # No #pragma once found.
-            echo "\`#pragma once\` check passed." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          git --no-pager grep --line-number --column '#pragma once' -- '*.h' |
+            while IFS=: read -r file line column _; do
+              echo "The following error is for file $file, line $line:"
+              echo -n "::error file=$file,line=$line,column=$column,"
+              echo 'title=#pragma once::Do not use #pragma once.'
+              echo "- \`$file\`" >> "$GITHUB_STEP_SUMMARY"
+            done
+          exit 1

--- a/.github/workflows/c++-code-formatting.yml
+++ b/.github/workflows/c++-code-formatting.yml
@@ -77,6 +77,7 @@ jobs:
             case $file in
               */3rdparty/*) ;;   # ignore vendored files
               *.hxx|*.cc|*.hpp)
+                echo "The following error is for file $file:"
                 echo "::error file=$file::$file uses non-allowed extension"
                 have_invalid_extension=true ;;
             esac
@@ -197,6 +198,7 @@ jobs:
                [ "$(head -n "$total_lines" "$file" | tail -n +2)" != "$rest" ]
             then
               incorrect_files+=("$file")
+              echo "The following error is for file $file:"
               echo -n "::error file=$file,line=1,endLine=$total_lines,"
               echo -n "title=Missing or malformed copyright notice::"
               echo "This source file is missing the correct copyright notice."
@@ -257,6 +259,7 @@ jobs:
              xargs -0 dos2unix -i |
              awk '
                function error(title, message) {
+                 printf "The following error is for file %s:\n", $6
                  printf "::error file=%s,title=%s::%s\n", $6, title, message
                  exit_code = 1
                }
@@ -329,6 +332,8 @@ jobs:
           if awk '
             BEGIN { exit_code = 0 }
             function error(title, message) {
+              printf "The following error is for file %s, line %i, column %i:\n",
+                     FILENAME, FNR, RSTART
               printf "::error file=%s,line=%i,col=%i,endColumn=%i,title=%s::%s\n",
                      FILENAME, FNR, RSTART, RSTART + RLENGTH, title, message
               exit_code = 1
@@ -397,6 +402,7 @@ jobs:
           EOF
             git --no-pager grep --line-number --column '#pragma once' -- '*.h' |
               while IFS=: read -r file line column _; do
+                echo "The following error is for file $file, line $line:"
                 echo -n "::error file=$file,line=$line,column=$column,"
                 echo 'title=#pragma once::Do not use #pragma once.'
                 echo "- \`$file\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Both changes are pretty simple, so it seemed easier to bundle them into one PR.

See commits below for more details.

1. 'Annotate error messages with file/line number in output log': as requested by @davidrohr.
2. 'Remove unneeded "check passed" summaries': These only take up space on the summary page, and since GitHub only renders the first few step summaries, a few "check passed" summaries can mask errors further down the page.

Hide whitespace/indentation changes in the diff to make it even simpler.