### PR TITLE
Allow users to specify build comments for Jenkins builds

### DIFF
--- a/build-any-ib.sh
+++ b/build-any-ib.sh
@@ -127,7 +127,11 @@ case "$REMOTE_STORE" in
     set -x ;;
 esac
 
-FETCH_REPOS="$(aliBuild build --help | grep fetch-repos || true)"
+# Feature detection
+FETCH_REPOS='' ANNOTATE=''
+aliBuild build --help | grep -q -- --fetch-repos && FETCH_REPOS=1
+aliBuild build --help | grep -q -- --annotate && ANNOTATE=1
+
 aliBuild --reference-sources "$MIRROR"                    \
          --debug                                          \
          --work-dir "$WORKAREA/$WORKAREA_INDEX"           \
@@ -137,7 +141,7 @@ aliBuild --reference-sources "$MIRROR"                    \
          ${REMOTE_STORE:+--remote-store "$REMOTE_STORE"}  \
          ${DEFAULTS:+--defaults "$DEFAULTS"}              \
          ${DISABLE:+--disable "$DISABLE"}                 \
-         ${BUILD_COMMENT:+--annotate "$PACKAGE_NAME=$BUILD_COMMENT"} \
+         ${ANNOTATE:+${BUILD_COMMENT:+--annotate "$PACKAGE_NAME=$BUILD_COMMENT"}} \
          build "$PACKAGE_NAME" || BUILDERR=$?
 
 for logf in "$WORKAREA/$WORKAREA_INDEX/BUILD"/*/*/*.log; do

--- a/build-any-ib.sh
+++ b/build-any-ib.sh
@@ -137,6 +137,7 @@ aliBuild --reference-sources "$MIRROR"                    \
          ${REMOTE_STORE:+--remote-store "$REMOTE_STORE"}  \
          ${DEFAULTS:+--defaults "$DEFAULTS"}              \
          ${DISABLE:+--disable "$DISABLE"}                 \
+         ${BUILD_COMMENT:+--annotate "$PACKAGE_NAME=$BUILD_COMMENT"} \
          build "$PACKAGE_NAME" || BUILDERR=$?
 
 for logf in "$WORKAREA/$WORKAREA_INDEX/BUILD"/*/*/*.log; do

--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -142,7 +142,9 @@ while read -r assignment; do
 done <<< "$BUILD_ENV_VARS"
 
 # Attach any user-specified comment to all top-level packages.
-if [ -n "$BUILD_COMMENT" ]; then
+if [ -n "$BUILD_COMMENT" ] &&
+     # Make sure that this aliBuild supports --annotate.
+     aliBuild build --help | grep -q -- --annotate; then
   for package in $PACKAGES; do
     alibuild_args+=(--annotate "$package=$BUILD_COMMENT")
   done

--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -141,6 +141,13 @@ while read -r assignment; do
   fi
 done <<< "$BUILD_ENV_VARS"
 
+# Attach any user-specified comment to all top-level packages.
+if [ -n "$BUILD_COMMENT" ]; then
+  for package in $PACKAGES; do
+    alibuild_args+=(--annotate "$package=$BUILD_COMMENT")
+  done
+fi
+
 # Process the pattern as a jinja2 template with aliBuild's templating plugin.
 # Fetch the source repos now, so they're available for the "real" build later.
 AUTOTAG_PATTERN=$(aliBuild --plugin templating --fetch-repos "${alibuild_args[@]}" << EOF


### PR DESCRIPTION
This will attach any given comment to the top-level package(s) to be built.