### PR TITLE
Add async-label functionality

### DIFF
--- a/.github/workflows/async-auto-label.yml
+++ b/.github/workflows/async-auto-label.yml
@@ -1,0 +1,85 @@
+---
+name: Apply requested async label
+
+'on':
+  workflow_call:
+
+permissions:
+  pull-requests: write   # to update labels
+
+jobs:
+  apply-label:
+    name: Apply label
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request &&
+            startsWith(github.event.comment.body, '+async-label') }}
+
+    steps:
+      - name: Install prerequisites
+        run: python3 -m pip install --user pygithub
+
+      - name: Parse comment to find label name
+        shell: python
+        env:
+          comment: ${{ github.event.comment.body }}
+          requester: ${{ github.event.comment.user.login }}
+          repo: ${{ github.event.repository.full_name }}
+          pr: ${{ github.event.issue.number }}
+          token: ${{ github.token }}
+          association: ${{ github.event.comment.author_association }}
+        run: |
+          import re
+          import os
+          import github
+
+          accepted_associations = ['COLLABORATOR', 'CONTRIBUTOR', 'MEMBER', 'OWNER']
+          repo = github.Github(os.environ['token']).get_repo(os.environ['repo'])
+          pr = repo.get_pull(int(os.environ['pr']))
+          requester = os.environ['requester']
+
+          def modify_labels():
+            match = re.match(r'\+async-label\s+(.+)', os.environ['comment'])
+            assert match, f'could not parse comment: {os.environ["comment"]!r}'
+            labels = [label.strip() for label in match.group(1).split(',')]
+
+            # Since changing the labels may change which branches this PR is
+            # merged into, stay on the safe side and dismiss any approvals.
+            for review in pr.get_reviews():
+                if review.state == 'APPROVED':
+                    review.dismiss('Labels updated; please review again.')
+
+            possible_labels = {label.name: label for label in repo.get_labels() if label.name.startswith('async-')}
+            add_labels, invalid_labels = [], []
+            for label_name in labels:
+                delete = label_name.startswith('!')
+                label_name = label_name.lstrip('!')
+                try:
+                    label = possible_labels[label_name]
+                except KeyError:
+                    print(f'::warning::Ignoring unknown label {label_name!r}')
+                    invalid_labels.append(label_name)
+                    continue
+                if delete:
+                    pr.remove_from_labels(label)
+                else:
+                    add_labels.append(label)
+
+            pr.add_to_labels(*add_labels)
+
+            if invalid_labels:
+                pr.create_issue_comment(
+                    f'Hi @{requester}, the following label names '
+                    f'could not be recognised: {", ".join(invalid_labels)}'
+                )
+
+          if os.environ['association'] in accepted_associations:
+            modify_labels()
+
+          else:
+            pr.create_issue_comment(
+                f'Hi @{requester}, due to your association, '
+                 'labels are not added automatically. '
+                 'Probably, this is your first contribution. '
+                 'Please contact one of the reviewers or '
+                 'code owners.'
+            )

--- a/.github/workflows/async-list-label.yml
+++ b/.github/workflows/async-list-label.yml
@@ -1,0 +1,37 @@
+---
+name: Collect and print async labels
+
+'on':
+  workflow_call:
+
+permissions:
+  pull-requests: write   # to update labels
+
+jobs:
+  print-labels:
+    runs-on: ubuntu-latest
+    name: Print labels
+    steps:
+      - name: Collect labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          nr: ${{ github.event.pull_request.number }}
+
+        id: collect_labels
+        run: |
+          labels="$(gh label list --repo "${GITHUB_REPOSITORY}" --json name --jq '.[].name | select(startswith("async-"))')"
+          labels_line_break=
+          for l in ${labels} ; do
+            labels_line_break+="${l}\n"
+          done
+          body_text="**REQUEST FOR PRODUCTION RELEASES:**\nTo request your PR to be included in production software, \
+          please add the corresponding labels called \"async-<name>\" to your PR. \
+          Add the labels directly (if you have the permissions) or add a comment \
+          of the form \n \
+          \`\`\`\n \
+          +async-label <label1> <label2> !<label3> ...\n \
+          \`\`\`\n \
+          This will add \`<label1>\` and \`<label2>\` and removes \`<label3>\`.\n\n \
+          **The following labels are available**\n${labels_line_break}"
+          # read the body text from stdin
+          echo -e "${body_text}" | gh pr comment "${nr}" --body-file - --repo "${GITHUB_REPOSITORY}"


### PR DESCRIPTION
* add workflow that allows to add async-<name> labels by issuing a comment in a PR, e.g. ``` +async-label async-<name-add> !async-<name-remove> ... ``` Labels starting with a "!" shall be removed.

* add workflow that reminds developers to add async-<name> labels in case the development is needed for production software releases. A message is printed after the PR has been (re)opened