### PR TITLE
Use Python 3 by default, except on old platforms

### DIFF
--- a/build-any-ib.sh
+++ b/build-any-ib.sh
@@ -31,8 +31,8 @@ export PATH=$PYTHONUSERBASE/bin:$PATH
 export LD_LIBRARY_PATH=$PYTHONUSERBASE/lib:$LD_LIBRARY_PATH
 # Set the default python and pip depending on the architecture...
 case $ARCHITECTURE in
-  slc7*|slc8*) PIP=pip3 PYTHON=python3 ;;
-  *) PIP=pip PYTHON=python ;;
+  slc6*) PIP=pip PYTHON=python ;;
+  *) PIP=pip3 PYTHON=python3 ;;
 esac
 # ...and override it if PYTHON_VERSION is specified.
 case "$PYTHON_VERSION" in


### PR DESCRIPTION
This brings build-any-ib.sh in line with what daily-tags.sh already does.