### PR TITLE
Abort "pip install" in publisher if it takes too long

### DIFF
--- a/publish/get-and-run.sh
+++ b/publish/get-and-run.sh
@@ -65,7 +65,7 @@ python3 -m venv "$venv"
 . "$venv/bin/activate"
 # If DEST is in the cwd, it might be confused for a PyPI package, so make it
 # an absolute path.
-pip install -U "$(realpath "$DEST")"
+timeout 300 python3 -m pip install -U "$(realpath "$DEST")"
 
 ln -nfs "$(basename "$LOG.error")" "$logdir/latest"
 cachedir=${NOMAD_TASK_DIR-$PWD}/cache


### PR DESCRIPTION
Over the weekend, some "pip install" invocations took forever, for unknown reasons. Wrap the "pip install" invocation in a timeout, so that it is aborted and retried if it hangs.