### PR TITLE
More consistent platform priority

### DIFF
--- a/cvmfs/alienv
+++ b/cvmfs/alienv
@@ -67,7 +67,7 @@ case $distro_name in
               ;;
            8*)
               distro_xrelease=8.x
-              platform=el7
+              platform=el8
               ;;
            9*)
               distro_xrelease=8.x
@@ -303,9 +303,15 @@ alien="AliEn"
 
 # We cannot cross-pick pacakages among different platforms but we have to
 # pick all packages consistently from a certain platform tree. When listing
-# packages we show them all, when we load a package e define a priority list and
+# packages we show them all, when we load a package we define a priority list and
 # we always have a fallback for backward compatibility.
 PLATFORM_PRIORITY="el9-$uname_m el7-$uname_m el6-$uname_m el5-$uname_m el8-$uname_m"
+
+# The above priority is a general search priority. However, given a platform, we should actually 
+# start searching for software matching this precise platform and only later fall back to other
+# platforms. This prevents loading el9 or el7 software, when I am actually on el8 (and el8 software is available).
+PLATFORM_PRIORITY="${platform}-$uname_m ${PLATFORM_PRIORITY//${platform}-$uname_m/}"
+
 ARGS=("$@")
 PACKAGES=
 EXPECT_PACKAGES=


### PR DESCRIPTION
This fixes an inconsistency observed in GRID jobs when loading a software package "A".

The bug was:
- The GRID runtime determines available platforms (say el8 and el7) for package A 
- then launches an el8 apptainer container
- alienv executed inside el8 container loads el7 software, inconsistent with the choice of el8 container ... and despite the fact that el8 software A is actually available.

Bug fixed by slightly adjusting the platform priority: We always search the current platform first of all before going elsewhere.