### PR TITLE
Move CI to use aliBuild v1.17.0

### DIFF
--- a/ci/repo-config/DEFAULTS.env
+++ b/ci/repo-config/DEFAULTS.env
@@ -7,5 +7,5 @@ MAX_DIFF_SIZE=20000000
 TIMEOUT=120
 LONG_TIMEOUT=36000
 DOCKER_EXTRA_ARGS='--tmpfs=/dev/shm:rw,size=8g,mode=1777'
-INSTALL_ALIBUILD='alisw/alibuild@v1.16.1#egg=alibuild'
+INSTALL_ALIBUILD='alisw/alibuild@v1.17.0#egg=alibuild'
 INSTALL_ALIBOT='alisw/ali-bot@master#egg=ali-bot'


### PR DESCRIPTION
Move CI to use aliBuild v1.17.0

- It should be much more performant
- Tested for over two weeks with the full-ci builds
