### PR TITLE
Publish ApMon for ARM

### DIFF
--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -275,6 +275,7 @@ architectures:
       jemalloc:
         - ^v5\.1\.0-[0-9]+$
       CMake: true
+      ApMon-CPP: true
       libtirpc: true
       autotools: true
       defaults-release: true


### PR DESCRIPTION
For some reason to be understood, it gets added as a dependency to a lot of modulefiles