### PR TITLE
Publish build time dependencies

### DIFF
--- a/publish/aliPublish.conf
+++ b/publish/aliPublish.conf
@@ -343,6 +343,16 @@ architectures:
     RPM: false
     include:
       grid-base-packages: true
+      googlebenchmark: true
+      json-c: true
+      MPFR: true
+      ITSResponse: true
+      Python-modules-list: true
+      double-conversion: true
+      FairCMakeModules: true
+      Alice-GRID-Utils: true
+      abseil: true
+      bz2: true
       O2PDPSuite:
         - ^async-.*$
         # Tags for testing compatibility with Hyperloop.


### PR DESCRIPTION
Publish build time dependencies

Apparently something (AliGenerators?) pulls them in as actual dependencies
