### PR TITLE
Show PR URL in the message of the formatting PR

### DIFF
--- a/.github/workflows/c++-code-formatting.yml
+++ b/.github/workflows/c++-code-formatting.yml
@@ -135,7 +135,7 @@ jobs:
             Please consider the following formatting changes to
             #${{ github.event.pull_request.number }}
           pr_body: >-
-            This PR cannot be merged as is. You should either run `clang-format`
+            Your PR ${{ github.event.pull_request.html_url }} cannot be merged as is. You should either run `clang-format`
             yourself and update the pull request, or merge this PR in yours.
 
             You can find the AliceO2 coding conventions at


### PR DESCRIPTION
Users still often miss that a formatting PR has been made to fix their PR. Linking user's PR in the message of the formatting PR automatically makes the reference appear in the conversation of the original PR, which makes the formatting PR more visible to the user.