### PR TITLE
Update requirements.txt to PyGithub==1.46

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyGithub==1.45
+PyGithub==1.46
 argparse
 requests
 pytz


### PR DESCRIPTION
pip now complains when trying to install the old 1.45 version with:

```
Collecting PyGithub==1.45
  Using cached PyGithub-1.45.tar.gz (113 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [11 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 14, in <module>
        File "/Users/alibuild/venv/lib/python3.12/site-packages/setuptools/__init__.py", line 16, in <module>
          import setuptools.version
        File "/Users/alibuild/venv/lib/python3.12/site-packages/setuptools/version.py", line 1, in <module>
          import pkg_resources
        File "/Users/alibuild/venv/lib/python3.12/site-packages/pkg_resources/__init__.py", line 2178, in <module>
          register_finder(pkgutil.ImpImporter, find_on_path)
                          ^^^^^^^^^^^^^^^^^^^
      AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```

this is most likely due to the removed support for python2