### PR TITLE
Update pip before running the check for PRs

### DIFF
--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -31,6 +31,7 @@ try {
               export PATH="$PYTHONUSERBASE/bin:$PATH"
               rm -rf "$PYTHONUSERBASE"
               yum install -y python3-pip python3-devel python3-setuptools
+              pip3 install --user --upgrade pip
               pip3 install --user --upgrade "${ALIBOT_SLUG:+git+https://github.com/${ALIBOT_SLUG}}"
               type check-open-pr
               if [ "${PACKAGES%% *}" = AliPhysics ]; then


### PR DESCRIPTION
Update pip before running the check for PRs

Needed on obsolete platforms
