### PR TITLE
Use temporary alibuild version for debugging

### DIFF
--- a/ci/repo-config/mesosci/cs8/o2-dataflow.env
+++ b/ci/repo-config/mesosci/cs8/o2-dataflow.env
@@ -11,3 +11,5 @@ DEVEL_PKGS="$PR_REPO $PR_BRANCH $PR_REPO_CHECKOUT
 AliceO2Group/O2Physics master
 alisw/alidist master"
 ALIBUILD_O2_TESTS=1
+INSTALL_ALIBUILD='singiamtel/alibuild@v1.17.6#egg=alibuild'
+


### PR DESCRIPTION
Testing a git fetch fix for [this job](https://ali-ci.cern.ch/alice-build-logs/AliceO2Group/AliceO2/13209/5854e2592a992c329b06cad6f1374b666874c4a0/build_O2_o2-dataflow-cs8/pretty.html)

If it works properly we'll merge the change to alibuild and bump the version for the other jobs

Tagging @ktf 