### PR TITLE
Update alibuild to 1.17.6

### DIFF
--- a/ci/repo-config/DEFAULTS.env
+++ b/ci/repo-config/DEFAULTS.env
@@ -7,5 +7,5 @@ MAX_DIFF_SIZE=20000000
 TIMEOUT=120
 LONG_TIMEOUT=36000
 DOCKER_EXTRA_ARGS='--tmpfs=/dev/shm:rw,size=8g,mode=1777'
-INSTALL_ALIBUILD='alisw/alibuild@v1.17.4#egg=alibuild'
+INSTALL_ALIBUILD='alisw/alibuild@v1.17.6#egg=alibuild'
 INSTALL_ALIBOT='alisw/ali-bot@master#egg=ali-bot'

--- a/ci/repo-config/mesosci/cs8/o2-dataflow.env
+++ b/ci/repo-config/mesosci/cs8/o2-dataflow.env
@@ -11,5 +11,4 @@ DEVEL_PKGS="$PR_REPO $PR_BRANCH $PR_REPO_CHECKOUT
 AliceO2Group/O2Physics master
 alisw/alidist master"
 ALIBUILD_O2_TESTS=1
-INSTALL_ALIBUILD='singiamtel/alibuild@ef3015e#egg=alibuild'
 


### PR DESCRIPTION
The previous git fix seems to be working properly, so we're bumping the
version for all builders #1347
