### PR TITLE
Bump alibuild to 1.17.7 on centos&ubuntu repos

### DIFF
--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -43,7 +43,7 @@ jobs:
     env:
       ALIBUILD_TAG: ${{ matrix.alibuild_tag }}
       DISTRO: ${{ matrix.el_version }}
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true' # Only required for CentOS 7
 
     steps:
       # For rpms/*.spec

--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -35,7 +35,7 @@ jobs:
             container: almalinux:9
             alibuild_tag: v1.17.7
           - el_version: fedora
-            container: fedora:33
+            container: fedora:40
             alibuild_tag: v1.17.7
 
     name: RPM (${{ matrix.el_version }})

--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -43,11 +43,11 @@ jobs:
     env:
       ALIBUILD_TAG: ${{ matrix.alibuild_tag }}
       DISTRO: ${{ matrix.el_version }}
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
 
     steps:
       # For rpms/*.spec
       - uses: actions/checkout@v3
-
       - name: Install prerequisites
         run: |
           set -ex

--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install prerequisites
         run: |
-          set -x
+          set -ex
           yum clean all
           yum update -y
           yum install -y rpm-build scl-utils-build createrepo unzip git python3 python3-pip python3-setuptools
@@ -61,17 +61,17 @@ jobs:
 
       - name: Build the ${{ matrix.el_version }} RPM and create a yum repo
         run: |
-          set -x
+          set -ex
           rpmbuild -ba "rpms/o2-prereq-$DISTRO.spec"
           git clone -b "$ALIBUILD_TAG" https://github.com/alisw/alibuild
-          cd alibuild || exit
+          cd alibuild
           case "$DISTRO" in
             el7) deps=python3,git,python3-PyYAML,python3-requests,python3-distro ;;
             *)   deps=python3,git,python3-pyyaml,python3-requests,python3-distro ;;
           esac
           python3 setup.py bdist_rpm --requires "$deps"
           cp dist/alibuild-*.noarch.rpm ~/rpmbuild/RPMS/"$(uname -m)"/
-          cd  ~/rpmbuild/RPMS/"$(uname -m)"/ || exit
+          cd  ~/rpmbuild/RPMS/"$(uname -m)"/
           createrepo .
           ls -la
           case "$DISTRO" in

--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -27,16 +27,16 @@ jobs:
         include:
           - el_version: el7
             container: centos:7
-            alibuild_tag: v1.16.1
+            alibuild_tag: v1.17.7
           - el_version: el8
             container: almalinux:8
-            alibuild_tag: v1.16.1
+            alibuild_tag: v1.17.7
           - el_version: el9
             container: almalinux:9
-            alibuild_tag: v1.16.1
+            alibuild_tag: v1.17.7
           - el_version: fedora
             container: fedora:33
-            alibuild_tag: v1.16.1
+            alibuild_tag: v1.17.7
 
     name: RPM (${{ matrix.el_version }})
     container: ${{ matrix.container }}
@@ -92,11 +92,12 @@ jobs:
           - focal   # 20.04
           - jammy   # 22.04
           - mantic  # 23.10
+          - noble   # 24.04
 
     name: DEB (${{ matrix.ubuntu_codename }})
     container: ubuntu:${{ matrix.ubuntu_codename }}
     env:
-      ALIBUILD_TAG: v1.16.1
+      ALIBUILD_TAG: v1.17.7
       ALIBUILD_DISTRO: ${{ matrix.ubuntu_codename }}
       DEBIAN_FRONTEND: noninteractive
 

--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Install prerequisites
         run: |
           set -ex
+          if [[ "$DISTRO" == "el7" ]]; then
+            sed -i.bak -e 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+            sed -i.bak -r -e 's|# ?baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+            find /etc/yum.repos.d -name "*.bak" -delete
+            yum clean all
+            yum update -y
+          fi
           yum clean all
           yum update -y
           yum install -y rpm-build scl-utils-build createrepo unzip git python3 python3-pip python3-setuptools

--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -64,14 +64,14 @@ jobs:
           set -x
           rpmbuild -ba "rpms/o2-prereq-$DISTRO.spec"
           git clone -b "$ALIBUILD_TAG" https://github.com/alisw/alibuild
-          cd alibuild
+          cd alibuild || exit
           case "$DISTRO" in
             el7) deps=python3,git,python3-PyYAML,python3-requests,python3-distro ;;
             *)   deps=python3,git,python3-pyyaml,python3-requests,python3-distro ;;
           esac
           python3 setup.py bdist_rpm --requires "$deps"
-          cp dist/alibuild-*.noarch.rpm ~/rpmbuild/RPMS/$(uname -m)/
-          cd  ~/rpmbuild/RPMS/$(uname -m)/
+          cp dist/alibuild-*.noarch.rpm ~/rpmbuild/RPMS/"$(uname -m)"/
+          cd  ~/rpmbuild/RPMS/"$(uname -m)"/ || exit
           createrepo .
           ls -la
           case "$DISTRO" in


### PR DESCRIPTION
This version has been available for a while and seems stable. The most
notable change is managing the git repos with --filter=tree:0, which
should mean a notably smaller sw/ folder size

Setting it to draft as centos7 is now EOL, so the action might fail when trying to deploy to those repos