### PR TITLE
Add readline-devel to alice-o2-full-deps

### DIFF
--- a/rpms/o2-prereq-el7.spec
+++ b/rpms/o2-prereq-el7.spec
@@ -14,7 +14,7 @@ Name: %scl_name
 Version: 1
 Release: 1%{?dist}
 License: GPLv2+
-Requires: make rsync glew-devel epel-release python-requests python-yaml pigz which git mysql-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libXi-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed environment-modules tk-devel libXinerama-devel libXcursor-devel libXrandr-devel
+Requires: make rsync glew-devel epel-release python-requests python-yaml pigz which git mysql-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libXi-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed environment-modules tk-devel libXinerama-devel libXcursor-devel libXrandr-devel readline-devel
 BuildRequires: scl-utils-build
 
 %description

--- a/rpms/o2-prereq-el8.spec
+++ b/rpms/o2-prereq-el8.spec
@@ -14,7 +14,7 @@ Name: %scl_name
 Version: 1
 Release: 1%{?dist}
 License: GPLv2+
-Requires: make rsync glew-devel python3-requests python3-yaml pigz which git mysql-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libXi-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed environment-modules tk-devel libXinerama-devel libXcursor-devel libXrandr-devel subversion-devel apr-util-devel apr-devel
+Requires: make rsync glew-devel python3-requests python3-yaml pigz which git mysql-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libXi-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed environment-modules tk-devel libXinerama-devel libXcursor-devel libXrandr-devel subversion-devel apr-util-devel apr-devel readline-devel
 BuildRequires: scl-utils-build
 
 %description

--- a/rpms/o2-prereq-el9.spec
+++ b/rpms/o2-prereq-el9.spec
@@ -14,7 +14,7 @@ Name: %scl_name
 Version: 1
 Release: 1%{?dist}
 License: GPLv2+
-Requires: make rsync glew-devel pigz which git mariadb-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libXi-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed perl-FindBin environment-modules tk-devel libXinerama-devel libXcursor-devel libXrandr-devel subversion-devel apr-util-devel apr-devel
+Requires: make rsync glew-devel pigz which git mariadb-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libXi-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed perl-FindBin environment-modules tk-devel libXinerama-devel libXcursor-devel libXrandr-devel subversion-devel apr-util-devel apr-devel readline-devel
 BuildRequires: scl-utils-build
 
 %description

--- a/rpms/o2-prereq-fedora.spec
+++ b/rpms/o2-prereq-fedora.spec
@@ -15,7 +15,7 @@ Name: %scl_name
 Version: 1
 Release: 1%{?dist}
 License: GPLv2+
-Requires: make python3-requests python3-yaml pigz which git mariadb-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libXi-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed environment-modules tk-devel libXinerama-devel libXcursor-devel libXrandr-devel
+Requires: make python3-requests python3-yaml pigz which git mariadb-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libXi-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed environment-modules tk-devel libXinerama-devel libXcursor-devel libXrandr-devel readline-devel
 BuildRequires: scl-utils-build
 
 %description


### PR DESCRIPTION
Without readline-devel the shells built with alibuild are very annoying to use.

This would add it to both the builders and anyone building via [the official guide](https://alice-doc.github.io/alice-analysis-tutorial/building/prereq-alma9.html)