### PR TITLE
Add correct platform check 

### DIFF
--- a/cvmfs/alienv
+++ b/cvmfs/alienv
@@ -313,7 +313,7 @@ for ARG in "$@"; do
   if [[ $EXPECT_PACKAGES == 1 ]]; then
     PACKAGES=$(normalize_sort_packages "$ARG")
     break
-  elif [[ "$ARG" == enter || "$ARG" == printenv || "$ARG" == setenv || "$ARG" == checkenv ]]; then
+  elif [[ "$ARG" == enter || "$ARG" == printenv || "$ARG" == setenv || "$ARG" == checkenv || "$ARG" == load ]]; then
     EXPECT_PACKAGES=1
   else
     EXPECT_PACKAGES=


### PR DESCRIPTION
Currently, if a user runs "/cvmfs/alice.cern.ch/bin/alienv load O2Physics" from EL9 (e.g. lxplus), alienv skips the platform check and tries to load the latest EL7 build (since `*)` simply passes the "load" command through to environment modules and "el7" is higher on the default $moduledirs list).

Adding "load" to the list of arguments for the "EXPECT_PACKAGES" check does the correct checking of the module directories before it passes the load command through to `module`.

I'm not sure if it is preferred to do it this way, or to otherwise add some defined behaviour for the "alienv load" command, but ideally "alienv load" by itself shouldn't be trying to load modules from the wrong arch.

See discussion in https://mattermost.web.cern.ch/alice/pl/abagkh3oypdf8komxrgfffr9qy for details