### PR TITLE
Upgrade alibuild tag for old centOS versions

### DIFF
--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -27,10 +27,10 @@ jobs:
         include:
           - el_version: el7
             container: centos:7
-            alibuild_tag: v1.17.7
+            alibuild_tag: v1.17.8
           - el_version: el8
             container: almalinux:8
-            alibuild_tag: v1.17.7
+            alibuild_tag: v1.17.8
           - el_version: el9
             container: almalinux:9
             alibuild_tag: v1.17.7


### PR DESCRIPTION
Bypasses the setuptools_scm `from __future__ import annotations` issue. 

We're not bumping it for all versions in case it brings other problems