### PR TITLE
Create daily tags inside venv

### DIFF
--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -32,6 +32,8 @@ try {
               rm -rf "$PYTHONUSERBASE"
               yum install -y python3-pip python3-devel python3-setuptools
               mkdir -p /local/tmp
+              python -m venv /local/tmp/venv
+              source /local/tmp/venv/bin/activate
               TMPDIR=/local/tmp python3 -m pip install --user --upgrade pip
               TMPDIR=/local/tmp python3 -m pip install --user --upgrade "${ALIBOT_SLUG:+git+https://github.com/${ALIBOT_SLUG}}"
               type check-open-pr

--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -119,6 +119,8 @@ try {
 		  ;;
               esac
               mkdir -p /local/tmp
+              python -m venv /local/tmp/venv
+              source /local/tmp/venv/bin/activate
               TMPDIR=/local/tmp python3 -m pip install --upgrade --user pip
               TMPDIR=/local/tmp python3 -m pip install --upgrade --user "git+https://github.com/$ALIBOT_SLUG"
               [ -f /opt/rh/rh-git218/enable ] && source /opt/rh/rh-git218/enable

--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -32,8 +32,12 @@ try {
               rm -rf "$PYTHONUSERBASE"
               yum install -y python3-pip python3-devel python3-setuptools
               mkdir -p /local/tmp
-              python -m venv /local/tmp/venv
-              source /local/tmp/venv/bin/activate
+              case $ARCHITECTURE in
+                ubuntu24*)
+                  python -m venv /local/tmp/venv
+                  source /local/tmp/venv/bin/activate
+                  ;;
+              esac
               TMPDIR=/local/tmp python3 -m pip install --user --upgrade pip
               TMPDIR=/local/tmp python3 -m pip install --user --upgrade "${ALIBOT_SLUG:+git+https://github.com/${ALIBOT_SLUG}}"
               type check-open-pr
@@ -119,8 +123,12 @@ try {
 		  ;;
               esac
               mkdir -p /local/tmp
-              python -m venv /local/tmp/venv
-              source /local/tmp/venv/bin/activate
+              case $ARCHITECTURE in
+                ubuntu24*)
+                  python -m venv /local/tmp/venv
+                  source /local/tmp/venv/bin/activate
+                  ;;
+              esac
               TMPDIR=/local/tmp python3 -m pip install --upgrade --user pip
               TMPDIR=/local/tmp python3 -m pip install --upgrade --user "git+https://github.com/$ALIBOT_SLUG"
               [ -f /opt/rh/rh-git218/enable ] && source /opt/rh/rh-git218/enable


### PR DESCRIPTION
Needed for Ubuntu 24.04, otherwise fails because of the new "externally managed envs" (https://peps.python.org/pep-0668/)

I can look into how to make it specific for Ubuntu 24.04 only if you'd rather not have this on all daily releases

Tagging @ktf  
