### PR TITLE
Remove Ubuntu 18.04 from apt repository

### DIFF
--- a/.github/workflows/clean-pr-checks.yml
+++ b/.github/workflows/clean-pr-checks.yml
@@ -76,9 +76,10 @@ jobs:
                 }
               }
             }
-          owner: ${{ inputs.owner }}
-          name: ${{ inputs.repo }}
-          pr: ${{ inputs.pr }}
+          variables: |
+            owner: ${{ inputs.owner }}
+            name: ${{ inputs.repo }}
+            pr: ${{ inputs.pr }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -95,7 +95,6 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_codename:
-          - bionic  # 18.04
           - focal   # 20.04
           - jammy   # 22.04
           - mantic  # 23.10

--- a/.github/workflows/pr-security-approval.yml
+++ b/.github/workflows/pr-security-approval.yml
@@ -50,9 +50,10 @@ jobs:
                 }
               }
             }
-          owner: ${{ github.event.repository.owner.login }}
-          name: ${{ github.event.repository.name }}
-          pr: ${{ github.event.pull_request.number }}
+          variables: |
+            owner: ${{ github.event.repository.owner.login }}
+            name: ${{ github.event.repository.name }}
+            pr: ${{ github.event.pull_request.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Recently removed from the docs as a supported distro
https://github.com/alice-doc/alice-analysis-tutorial/pull/168

The build on Ubuntu 18 is currently failing because of a pip issue anyway, it's probably not worth fixing it if we don't support it