### PR TITLE
Remove python2 support in imports

### DIFF
--- a/analytics/report-analytics
+++ b/analytics/report-analytics
@@ -4,12 +4,8 @@ import argparse
 import os
 import subprocess
 import sys
-try:
-    from commands import getstatusoutput
-    from urllib import urlopen
-except ImportError:
-    from subprocess import getstatusoutput
-    from urllib.request import urlopen
+from subprocess import getstatusoutput
+from urllib.request import urlopen
 
 
 def python_version():

--- a/ci/sync-mapusers.py
+++ b/ci/sync-mapusers.py
@@ -3,10 +3,7 @@ from __future__ import print_function
 from requests import get
 from random import choice
 import yaml,sys
-try:
-  from urlparse import urlsplit,urlunsplit
-except ImportError:
-  from urllib.parse import urlsplit,urlunsplit
+from urllib.parse import urlsplit,urlunsplit
 
 url = sys.argv[1]
 mesos_dns = "leader.mesos:8123"

--- a/report-pr-errors
+++ b/report-pr-errors
@@ -2,10 +2,7 @@
 from __future__ import print_function
 
 from argparse import ArgumentParser, Namespace
-try:
-    from commands import getstatusoutput
-except ImportError:
-    from subprocess import getstatusoutput
+from subprocess import getstatusoutput
 from collections import deque
 from fnmatch import fnmatch
 from glob import glob


### PR DESCRIPTION
We don't use python2 anywhere anymore, and these imports are tough to
analize for LSP (694396ea0b923a52dab72fe3c643e634e4b44e41)
