### PR TITLE
Fix GPG input

### DIFF
--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -111,7 +111,8 @@ jobs:
         run: |
           apt update
           apt install -y vim git devscripts build-essential lintian debhelper dh-python python3-all python3-setuptools python3-setuptools-scm
-          export GPG_TTY=$(tty)
+          GPG_TTY=$(tty)
+          export GPG_TTY
           mkdir -p ~/.gnupg
           chmod 700 ~/.gnupg
           echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
@@ -119,7 +120,8 @@ jobs:
 
       - name: Build a DEB for Ubuntu and push it to the PPA
         run: |
-          export GPG_TTY=$(tty)
+          GPG_TTY=$(tty)
+          export GPG_TTY
           set -x
           git clone  https://github.com/alisw/alibuild
           cd alibuild

--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -106,21 +106,24 @@ jobs:
       ALIBUILD_TAG: v1.17.11
       ALIBUILD_DISTRO: ${{ matrix.ubuntu_codename }}
       DEBIAN_FRONTEND: noninteractive
-
     steps:
       - name: Install prerequisites
         run: |
           apt update
           apt install -y vim git devscripts build-essential lintian debhelper dh-python python3-all python3-setuptools python3-setuptools-scm
-          cat <<\EOF | gpg --import
-          ${{ secrets.LAUNCHPAD_PPA_GPG_KEY }}
-          EOF
+          export GPG_TTY=$(tty)
+          mkdir -p ~/.gnupg
+          chmod 700 ~/.gnupg
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          echo -n "${{ secrets.LAUNCHPAD_PPA_GPG_KEY }}" | gpg --no-tty --batch --import
 
       - name: Build a DEB for Ubuntu and push it to the PPA
         run: |
+          export GPG_TTY=$(tty)
           set -x
-          git clone -b "$ALIBUILD_TAG" https://github.com/alisw/alibuild
+          git clone  https://github.com/alisw/alibuild
           cd alibuild
+          rm -rf .git
           cat <<EOF > debian/changelog
           python3-alibuild (${ALIBUILD_TAG#v}+$ALIBUILD_DISTRO) $ALIBUILD_DISTRO; urgency=medium
 
@@ -128,5 +131,5 @@ jobs:
 
            -- Giulio Eulisse <giulio.eulisse@cern.ch>  $(date -R -u)
           EOF
-          debuild --no-lintian -k48F330BAFFA564EF2383E2B472E9262B5C0D9DE5 -S
+          debuild --no-lintian -kA3A177D7C6BAD5C044ACAC10F56D273E83B84A47 -S -p'gpg --no-tty --passphrase ${{ secrets.LAUNCHPAD_PPA_GPG_PASS }}'
           dput ppa:alisw/ppa "../python3-alibuild_${ALIBUILD_TAG#v}+${ALIBUILD_DISTRO}_source.changes"


### PR DESCRIPTION
Fix the builds in Ubuntu PPA

The GPG changes are done to allow importing the key non-interactively

In order to work properly, the GPG key must be added to both https://keyserver.ubuntu.com/ and the Ubuntu PPA https://launchpad.net/ubuntu/+ppas