### PR TITLE
Bump all CI builders to alibuild v1.17.12

### DIFF
--- a/ci/repo-config/DEFAULTS.env
+++ b/ci/repo-config/DEFAULTS.env
@@ -7,5 +7,5 @@ MAX_DIFF_SIZE=20000000
 TIMEOUT=120
 LONG_TIMEOUT=36000
 DOCKER_EXTRA_ARGS='--tmpfs=/dev/shm:rw,size=8g,mode=1777'
-INSTALL_ALIBUILD='alisw/alibuild@v1.17.11#egg=alibuild'
+INSTALL_ALIBUILD='alisw/alibuild@v1.17.12#egg=alibuild'
 INSTALL_ALIBOT='alisw/ali-bot@master#egg=ali-bot'

--- a/ci/repo-config/macos/DEFAULTS.env
+++ b/ci/repo-config/macos/DEFAULTS.env
@@ -1,5 +1,4 @@
 TRUSTED_USERS=ktf,TimoWilken
 TRUST_COLLABORATORS=true
-INSTALL_ALIBUILD='alisw/alibuild@v1.17.12#egg=alibuild'
 REMOTE_STORE=
 DOCKER_EXTRA_ARGS=


### PR DESCRIPTION
The tests for the new alibuild syntax on macOS seem to be successful, so I'm bumping all builders to the new version

If all https://github.com/alisw/alidist/pull/5660 Linux tests pass with this new version, I think it's okay to go ahead with bumping to alibuild@v1.17.12 on RPM/APT and merging that PR.

CC @ktf