### PR TITLE
Ignore 3rd party files when checking for copyright notice

### DIFF
--- a/.github/workflows/c++-code-formatting.yml
+++ b/.github/workflows/c++-code-formatting.yml
@@ -194,6 +194,7 @@ jobs:
           incorrect_files=()
           for file in "${files[@]}"; do
             case $file in
+              */3rdparty/*) continue ;;  # ignore vendored files
               *.cxx|*.h|*.C) first=$cpp_first rest=$cpp_rest ;;
               *.cmake|*CMakeLists.txt) first=$hash_first rest=$hash_rest ;;
               *) echo "error: unknown file type for $file" >&2; exit 1 ;;


### PR DESCRIPTION
Should stop the CI from complaining about 3rd party headers not having the CERN copyright.

Look like it's been broken for a while, some older PRs have the same issue (e.g. https://github.com/AliceO2Group/AliceO2/pull/13490)

CC @ktf @ChSonnabend
