### PR TITLE
Bump all CI builders to alibuild v1.17.13

### DIFF
--- a/ci/repo-config/DEFAULTS.env
+++ b/ci/repo-config/DEFAULTS.env
@@ -7,5 +7,5 @@ MAX_DIFF_SIZE=20000000
 TIMEOUT=120
 LONG_TIMEOUT=36000
 DOCKER_EXTRA_ARGS='--tmpfs=/dev/shm:rw,size=10g,mode=1777'
-INSTALL_ALIBUILD='alisw/alibuild@v1.17.12#egg=alibuild'
+INSTALL_ALIBUILD='alisw/alibuild@v1.17.13#egg=alibuild'
 INSTALL_ALIBOT='alisw/ali-bot@master#egg=ali-bot'


### PR DESCRIPTION
Updating builders to latest aliBuild. The only relevant change for CI builders is https://github.com/alisw/alibuild/pull/884
