### PR TITLE
Change the logic for publishing releases

### DIFF
--- a/publish/aliPublish-rpms-cc8.conf
+++ b/publish/aliPublish-rpms-cc8.conf
@@ -9,102 +9,31 @@ conn_timeout_s: 6.05
 conn_retries: 6
 conn_dethrottle_s: 0.5
 
+# Explicitly list the packages which we need to publish
+# to avoid ending up with a gigantic RPM repo for no good reason
 architectures:
   slc8_x86-64:
     RPM: el8.x86_64
     include:
-      Toolchain:
-        - ^v.*$
       rpm-test: True
-      mesos-workqueue: True
-      flpproto: True
-      FLPSuiteDevEnv: True
-      Monitoring: True
-      Configuration: True
-      Configuration-Benchmark: True
-      ReadoutCard: True
-      Readout: True
-      Control: True
-      TpcFecUtils: True
-      O2Suite: True
-      ALF: True
-      CMake: True
-      FreeType: True
-      GCC-Toolchain: True
-      O2-customization: True
-      O2PDPSuite: True
-      OpenSSL: True
-      Python-modules-list: True
-      RapidJSON: True
-      alibuild-recipe-tools: True
-      autotools: True
-      bz2: True
-      capstone: True
-      cub: True
-      defaults-release: True
-      double-conversion: True
-      googlebenchmark: True
-      googletest: True
-      libffi: True
-      libxml2: True
-      lz4: True
-      lzma: True
-      ms_gsl: True
-      ofi: True
-      re2: True
-      sqlite: True
-      zlib: True
-      ecsg:
-        - ^v.*
-      qcg:
-        - ^v.*
-      QualityControl: True
-      DataDistribution: True
-      ODC: True
-      O2:
-        - ^v[0-9]{2}\.[0-9]{2}-[0-9]+$
-        - ^[a-f0-9]{10}_O2_(DAQ|DATAFLOW)-[0-9]+$
-    exclude:
-      # ancient releases (pre 2024)
-      DataDistribution:
-        - ^v1\.[0-5].*
-        - ^v1\.6\.[0-3].*
-      ReadoutCard:
-        - ^v0\.8\.8-2$
-      Common-O2:
-        - ^v1\.2\.5-1$
-      InfoLogger:
-        - ^v1\.0\.5-2$
-      flpproto:
-        - ^v20170915-1$
-      O2:
-        - ^fa3ea88837_O2_DAQ-1$
-        - ^nightly-202[0123].*$
-        - ^epn-202[0123].*$
-        - ^gpu-nightly-202[0-3].*$
-      mesos-workqueue:
-        - -18d7f0d6f3-
-        - -38c51d6edf-
-        - -8112bb1d4c-
-      bookkeeping-api:
-        # These cannot be packaged as RPMs due to the "@" in the version field.
-        - "^bookkeeping@"
-      # The following three depend on the bookkeeping-api version
-      # bookkeeping@0.49.1-1, which can't be published as an RPM.
       O2PDPSuite:
-        - ^epn-202[0123].*$
-      O2sim:
-        - ^v20230308-3$
-        - ^v20230309-2$
+        - ^epn-20240[9].*$
+        - ^epn-20241[12].*$
+        - ^epn-2025.*$
+    exclude:
+      DataDistribution:
+        - ^.*$
+      O2:
+        - ^.*$
+      O2PDPSuite:
+        - ^.*$
       # Do not publish ancient releases
       QualityControl:
-        - ^v1.92.0-9$
-        - ^v1.93.0-1$
-        - ^nightly-202[0-3].*$
+        - ^.*$
 
 # What packages to publish
 auto_include_deps: True
-filter_order: include,exclude
+filter_order: exclude,include
 
 notification_email:
   server: cernmx.cern.ch


### PR DESCRIPTION

From now nothing but whitelisted packages will be published, to avoid
ending up with a gigantic repository.
