### PR TITLE
Centralize Gitlab credentials in Vault

### DIFF
--- a/ci/run-http.sh
+++ b/ci/run-http.sh
@@ -25,9 +25,9 @@ pip3 install --user --upgrade pip
 pip3 install --ignore-installed --upgrade --user -e "${ALI_BOT_DIR}[services]"
 
 # Setup GitLab credentials (to push new data)
-printf 'protocol=https\nhost=gitlab.cern.ch\nusername=alibuild\npassword=%s\n' "$GITLAB_TOKEN" |
-  git credential-store --file git-creds store
-git config --global credential.helper "store --file $PWD/git-creds"
+printf 'protocol=https\nhost=gitlab.cern.ch\nusername=%s\npassword=%s\n' "$GITLAB_USER" "$GITLAB_PASS" |
+git credential-store --file ~/.git-creds store
+git config --global credential.helper 'store --file ~/.git-creds'
 
 # Setup GitHub API credentials (to communicate with PRs)
 echo "$PR_TOKEN" > ~/.github-token


### PR DESCRIPTION
The process-pull-requests-http job is failing again when trying to authenticate
against GitLab. This PR makes it use the same credentials as the CI runners, so
they only have to be rotated in one place

Should fix the issues with AliPhysics PR jobs stuck in the "pending" state

CC @ktf
