### PR TITLE
Fix CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pyyaml
 boto3==1.23.10; python_version >= '3.6' and python_version < '3.8'
 # Newer Pythons need a newer boto3.
 boto3; python_version >= '3.8'
-Twisted[services]==18.9.0
+Twisted[services]
 klein[services]
 python-ldap[services]
 # For gql; by default it pulls in a typing-extensions version that isn't


### PR DESCRIPTION
Originally pinned to support python 3.5, which we don't need anymore

```
x86_64-linux-gnu-gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I/usr/include/python3.12 -c src/twisted/test/raiser.c -o build/temp.linux-x86_64-cpython-312/src/twisted/test/raiser.o
      src/twisted/test/raiser.c:181:12: fatal error: longintrepr.h: No such file or directory
        181 |   #include "longintrepr.h"
            |            ^~~~~~~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for Twisted
```
