### PR TITLE
Revert "Bump alibuild to 1.17.14 (#1462)"

### DIFF
--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -27,16 +27,16 @@ jobs:
         include:
           - el_version: el7
             container: centos:7
-            alibuild_tag: v1.17.14
+            alibuild_tag: v1.17.13
           - el_version: el8
             container: almalinux:8
-            alibuild_tag: v1.17.14
+            alibuild_tag: v1.17.13
           - el_version: el9
             container: almalinux:9
-            alibuild_tag: v1.17.14
+            alibuild_tag: v1.17.13
           - el_version: fedora
             container: fedora:40
-            alibuild_tag: v1.17.14
+            alibuild_tag: v1.17.13
 
     name: "RPM (${{ matrix.el_version }})"
     container: ${{ matrix.container }}
@@ -104,7 +104,7 @@ jobs:
     name: DEB (${{ matrix.ubuntu_codename }})
     container: ubuntu:${{ matrix.ubuntu_codename }}
     env:
-      ALIBUILD_TAG: v1.17.14
+      ALIBUILD_TAG: v1.17.13
       ALIBUILD_DISTRO: ${{ matrix.ubuntu_codename }}
       DEBIAN_FRONTEND: noninteractive
     steps:

--- a/ci/repo-config/DEFAULTS.env
+++ b/ci/repo-config/DEFAULTS.env
@@ -7,5 +7,5 @@ MAX_DIFF_SIZE=20000000
 TIMEOUT=120
 LONG_TIMEOUT=36000
 DOCKER_EXTRA_ARGS='--tmpfs=/dev/shm:rw,size=10g,mode=1777'
-INSTALL_ALIBUILD='alisw/alibuild@v1.17.14#egg=alibuild'
+INSTALL_ALIBUILD='alisw/alibuild@v1.17.13#egg=alibuild'
 INSTALL_ALIBOT='alisw/ali-bot@master#egg=ali-bot'


### PR DESCRIPTION
This reverts commit 71e5ed80418437129f7e1fb9b9a0d239f096255a.

This broke the CI testers, so I'm reverting it for now

ERROR: Cannot install ali-bot and alibuild==1.17.14 because these package versions have conflicting dependencies.

Apologies for the oversight

CC @ktf
