### PR TITLE
Tweak some scripts to get them running under macOS

### DIFF
--- a/utils/ci-status-history
+++ b/utils/ci-status-history
@@ -15,9 +15,20 @@ fi
 
 [ -z "$check" ] && show_check=true
 
+# The temporary file lets us format the output nicely
+tmpfile=$(mktemp)
+trap 'rm -f $tmpfile' EXIT
+
+if [ "$show_check" = true ]; then
+  printf "DATE\tTIME\tUSER\tSTATUS\tCHECK\tDESCRIPTION\n" > "$tmpfile"
+else
+  printf "DATE\tTIME\tUSER\tSTATUS\tDESCRIPTION\n" > "$tmpfile"
+fi
+
 curl -fsS "$api_url" | jq -r "[.[]
    ${check:+| select(.context == \"$check\")}
    | [(.created_at | sub(\"T\"; \"\\t\")), .creator.login, .state, ${show_check+.context,} .description]
    | join(\"\\t\")
-] | sort | .[]" |
-  column -tN "DATE,TIME,USER,STATUS,${show_check+CHECK,}DESCRIPTION" -s '	'  # literal tab char!
+] | sort | .[]" >> "$tmpfile"
+
+column -t -s "	" < "$tmpfile" # literal tab char!

--- a/utils/ciqueues
+++ b/utils/ciqueues
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S bash -e
 if [ "$1" = -h ] || [ "$1" = --help ]; then
-  cat << EOF; exit
+  cat << EoF
 usage: $(basename "$0") [-h] ROLE CONTAINER [SUFFIX]
 
   -h, --help    show this help message and exit
@@ -9,7 +9,8 @@ usage: $(basename "$0") [-h] ROLE CONTAINER [SUFFIX]
   CONTAINER     container arch, e.g. "slc7"
   SUFFIX        optional suffix for multiple builders with the same role and
                 container, e.g. "-o2physics"
-EOF
+EoF
+    exit
 fi
 
 readonly role=$1 container=$2 suffix=$3


### PR DESCRIPTION
`ciqueues` is broken when running a pip installed version, but it works when using a local clone