### PR TITLE
Fix ubuntu24 daily tags

### DIFF
--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -34,9 +34,7 @@ try {
               mkdir -p /local/tmp
               case $ARCHITECTURE in
                 ubuntu24*)
-                  python -m venv --clear --copies /local/tmp/venv
-                  source /local/tmp/venv/bin/activate
-                  PYTHON_USER_OPT=""
+                  PYTHON_USER_OPT="--break-system-packages"
                   ;;
                 *)
                   PYTHON_USER_OPT="--user"
@@ -118,9 +116,7 @@ try {
               mkdir -p /local/tmp
               case $ARCHITECTURE in
                 ubuntu24*)
-                  python -m venv --clear --copies /local/tmp/venv
-                  source /local/tmp/venv/bin/activate
-                  PYTHON_USER_OPT=""
+                  PYTHON_USER_OPT="--break-system-packages"
                   ;;
                 *)
                   PYTHON_USER_OPT="--user"


### PR DESCRIPTION
We've tried several workarounds to fix the issues with the venv, but
haven't managed. The install runs in a docker container anyway, so there
shouldn't be any problem with installing this way, and it will better
match the other architectures

CC @ktf
