### PR TITLE
Don't upgrade pip twice

### DIFF
--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -20,7 +20,7 @@ edit_package_tag () {
   # Patch defaults definition (e.g. defaults-o2.sh)
   # Process overrides by changing in-place the given defaults. This requires
   # some YAML processing so we are better off with Python.
-  package=$package defaults=$defaults tag=$tag version=$version python3 <<EOF
+  package=$package defaults=$defaults tag=$tag version=$version python3 <<\EOF
 import os, yaml
 f = "alidist/defaults-%s.sh" % os.environ["defaults"].lower()
 with open(f, "r") as recipef:
@@ -58,13 +58,6 @@ rm -rf alidist/
 git config --global user.name 'ALICE Builder'
 git config --global user.email alibuild@cern.ch
 
-PYTHON_USER_OPT=""
-if [[ -z "$VIRTUAL_ENV" ]]; then
-    PYTHON_USER_OPT="--user"
-fi
-
-# Install the latest release if ALIBUILD_SLUG is not provided
-python3 -m pip install ${PYTHON_USER_OPT} --upgrade "${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild}"
 aliBuild analytics off
 
 # The alidist branches are always named with a trailing .0 instead of the

--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -63,8 +63,6 @@ if [[ -z "$VIRTUAL_ENV" ]]; then
     PYTHON_USER_OPT="--user"
 fi
 
-# Upgrade pip
-python3 -m pip install ${PYTHON_USER_OPT} --upgrade pip
 # Install the latest release if ALIBUILD_SLUG is not provided
 python3 -m pip install ${PYTHON_USER_OPT} --upgrade "${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild}"
 aliBuild analytics off

--- a/daily-tags.sh
+++ b/daily-tags.sh
@@ -20,7 +20,7 @@ edit_package_tag () {
   # Patch defaults definition (e.g. defaults-o2.sh)
   # Process overrides by changing in-place the given defaults. This requires
   # some YAML processing so we are better off with Python.
-  package=$package defaults=$defaults tag=$tag version=$version python3 <<\EOF
+  package=$package defaults=$defaults tag=$tag version=$version python3 <<EOF
 import os, yaml
 f = "alidist/defaults-%s.sh" % os.environ["defaults"].lower()
 with open(f, "r") as recipef:

--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -34,6 +34,7 @@ try {
               mkdir -p /local/tmp
               case $ARCHITECTURE in
                 ubuntu24*)
+                  # Bypass PEP 668
                   PYTHON_USER_OPT="--break-system-packages --user"
                   ;;
                 *)
@@ -116,6 +117,7 @@ try {
               mkdir -p /local/tmp
               case $ARCHITECTURE in
                 ubuntu24*)
+                  # Bypass PEP 668
                   PYTHON_USER_OPT="--break-system-packages --user"
                   ;;
                 *)

--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -43,6 +43,7 @@ try {
               esac
               TMPDIR=/local/tmp python3 -m pip install ${PYTHON_USER_OPT} --upgrade pip
               TMPDIR=/local/tmp python3 -m pip install ${PYTHON_USER_OPT} --upgrade "${ALIBOT_SLUG:+git+https://github.com/${ALIBOT_SLUG}}"
+              TMPDIR=/local/tmp python3 -m pip install --upgrade ${PYTHON_USER_OPT} aliBuild
               type check-open-pr
               if [ "${PACKAGES%% *}" = AliPhysics ]; then
                 WAIT_TESTS="build/AliPhysics/release build/AliPhysics/root6"
@@ -126,6 +127,7 @@ try {
               esac
               TMPDIR=/local/tmp python3 -m pip install --upgrade ${PYTHON_USER_OPT} pip
               TMPDIR=/local/tmp python3 -m pip install --upgrade ${PYTHON_USER_OPT} "git+https://github.com/$ALIBOT_SLUG"
+              TMPDIR=/local/tmp python3 -m pip install --upgrade ${PYTHON_USER_OPT} aliBuild
               [ -f /opt/rh/rh-git218/enable ] && source /opt/rh/rh-git218/enable
               daily-tags.sh || err=$?
               rm -rf alidist daily-tags.?????????? mirror

--- a/jenkins/daily-tags
+++ b/jenkins/daily-tags
@@ -17,6 +17,7 @@ try {
     node ("slc9_x86-64-light") {
       timeout (240) {
         withEnv(["ALIBOT_SLUG=${ALIBOT_SLUG}",
+                 "ALIBUILD_SLUG=${ALIBUILD_SLUG}",
                  "WAIT_PR_LIMIT=${WAIT_PR_LIMIT}",
                  "PACKAGES=${PACKAGES}"]) {
           withCredentials([[$class: 'StringBinding',
@@ -43,7 +44,7 @@ try {
               esac
               TMPDIR=/local/tmp python3 -m pip install ${PYTHON_USER_OPT} --upgrade pip
               TMPDIR=/local/tmp python3 -m pip install ${PYTHON_USER_OPT} --upgrade "${ALIBOT_SLUG:+git+https://github.com/${ALIBOT_SLUG}}"
-              TMPDIR=/local/tmp python3 -m pip install --upgrade ${PYTHON_USER_OPT} aliBuild
+              TMPDIR=/local/tmp python3 -m pip install --upgrade ${PYTHON_USER_OPT} "${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild}"
               type check-open-pr
               if [ "${PACKAGES%% *}" = AliPhysics ]; then
                 WAIT_TESTS="build/AliPhysics/release build/AliPhysics/root6"
@@ -127,7 +128,7 @@ try {
               esac
               TMPDIR=/local/tmp python3 -m pip install --upgrade ${PYTHON_USER_OPT} pip
               TMPDIR=/local/tmp python3 -m pip install --upgrade ${PYTHON_USER_OPT} "git+https://github.com/$ALIBOT_SLUG"
-              TMPDIR=/local/tmp python3 -m pip install --upgrade ${PYTHON_USER_OPT} aliBuild
+              TMPDIR=/local/tmp python3 -m pip install --upgrade ${PYTHON_USER_OPT} "${ALIBUILD_SLUG:+git+https://github.com/}${ALIBUILD_SLUG:-alibuild}"
               [ -f /opt/rh/rh-git218/enable ] && source /opt/rh/rh-git218/enable
               daily-tags.sh || err=$?
               rm -rf alidist daily-tags.?????????? mirror


### PR DESCRIPTION
Yet another attempt to fix Ubuntu24 installs. The whole daily tags setup could probably be simplified