### PR TITLE
c++-code-formatting: Ignore 3rd party files when checking whitespace

### DIFF
--- a/.github/workflows/c++-code-formatting.yml
+++ b/.github/workflows/c++-code-formatting.yml
@@ -321,6 +321,8 @@ jobs:
           readarray -d '' files < \
             <(git diff -z --diff-filter d --name-only --merge-base "origin/$BASE_BRANCH" |
                 while read -rd '' filename; do
+                  # Skip 3rdparty files
+                  [[ "$filename" == */3rdparty/* ]] && continue
                   file -bi "$filename" | grep -q charset=binary ||
                     printf "%s\\0" "$filename"
                 done)


### PR DESCRIPTION
As reported by @davidrohr

https://github.com/AliceO2Group/AliceO2/pull/13999#issuecomment-2676244405
