### PR TITLE
Verify if pip install fails on PRs

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,34 @@
+name: Test PIP Installation
+
+on:
+  pull_request:
+    branches: [ '**' ]
+  push:
+    branches: [ master ]
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-24.04 # Required for Python 3.6
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: Run smoke test - pip install ali-bot[ci]
+      run: |
+        set -e
+        python -m venv venv
+        source venv/bin/activate
+        python -m pip install --upgrade pip
+        python -m pip install 'ali-bot[ci] @ git+https://github.com/alisw/ali-bot@${{ github.sha }}'


### PR DESCRIPTION
Should prevent issues like https://github.com/alisw/ali-bot/pull/1490

Not testing Python 3.6 because it requires ubuntu20, and the runner image will be EOL next month