### PR TITLE
Add CGI dependency explicitly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dependencies = [
   'pytz',
   's3cmd',
   'pyyaml',
-  'boto3<1.36.0'
+  'boto3<1.36.0',
+  'legacy-cgi' # for boto3, see https://docs.python.org/3/library/cgi.html
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ boto3==1.23.10; python_version >= '3.6' and python_version < '3.8'
 # Newer Pythons need a newer boto3.
 # https://github.com/boto/boto3/issues/4398
 boto3<1.36.0; python_version >= '3.8'
+legacy-cgi # for boto3, see https://docs.python.org/3/library/cgi.html
 Twisted[services]
 klein[services]
 python-ldap[services]

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,15 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-install_requires = ['PyGithub==1.45', 'argparse', 'requests', 'pytz', 's3cmd',
-                    'pyyaml']
+install_requires = [
+    'PyGithub==1.45',
+    'argparse',
+    'requests',
+    'pytz',
+    's3cmd',
+    'pyyaml',
+    'legacy-cgi' # for boto3, see https://docs.python.org/3/library/cgi.html
+]
 # Old setuptools versions (which pip2 uses) don't support range comparisons
 # (like :python_version >= "3.6") in extras_require, so do this ourselves here.
 if sys.version_info >= (3, 8):


### PR DESCRIPTION
It was removed in Python 3.13 and it breaks older versions of boto3, so we need
to add this workaround
