### PR TITLE
Don't run the new list-branch-pr system on AliPhysics

### DIFF
--- a/ci/repo-config/mesosci/slc7-aliphysics/aliphysics-root6.env
+++ b/ci/repo-config/mesosci/slc7-aliphysics/aliphysics-root6.env
@@ -5,5 +5,6 @@ PR_REPO=alisw/AliPhysics
 PR_BRANCH=master
 TRUSTED_USERS=
 CHECK_NAME=build/AliPhysics/root6
+INSTALL_ALIBOT='alisw/ali-bot@noalibranch'
 DEVEL_PKGS="$PR_REPO $PR_BRANCH
 alisw/alidist master"


### PR DESCRIPTION
To try and fix the issue for the weekend, I'm updating only the Aliphysics
builder to the following patch:

```diff
diff --git a/list-branch-pr b/list-branch-pr
index 1117f702..860978fb 100755
--- a/list-branch-pr
+++ b/list-branch-pr
@@ -265,6 +265,12 @@ def main(args):
                 else:
                     # Extend PR groups with PRs from this repo.
                     org, _, repo_name = repo.repo_name.partition("/")
+                    
+                    # Skip processing for alisw/aliphysics repository
+                    if repo.repo_name.lower() == "alisw/aliphysics":
+                        print(f"Skipping ignored repository: {repo.repo_name}", file=sys.stderr)
+                        continue
+                        
                     repo_info = query_repo_info(session, org, repo_name,
                                                 repo.branch_ref,
                                                 args.show_base_branch)
```

It seems to affect other testers negatively somehow, I don't understand why
yet, so for now I'd only patch this one


CC @ktf
