### PR TITLE
[O2-5385] Check which packages are not currently tested

### DIFF
--- a/tested_pkgs.py
+++ b/tested_pkgs.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+import re
+import glob
+import logging
+import argparse
+import json
+from pathlib import Path
+from typing import Set, List
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+# Configure logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(levelname)s: %(message)s',
+    stream=sys.stderr
+)
+logger = logging.getLogger(__name__)
+
+
+def find_alidist_config_files() -> List[str]:
+    """Find all .env files in ci/repo-config that have PR_REPO=alisw/alidist"""
+    config_files = []
+    
+    # Search for all .env files in ci/repo-config
+    pattern = "ci/repo-config/**/*.env"
+    env_files = glob.glob(pattern, recursive=True)
+    
+    for env_file in env_files:
+        try:
+            with open(env_file) as f:
+                content = f.read()
+                if 'PR_REPO=alisw/alidist' in content:
+                    config_files.append(env_file)
+        except Exception as e:
+            logger.warning(f"Could not read {env_file}: {e}")
+    
+    return config_files
+
+
+def extract_packages_from_configs(config_files: List[str]) -> Set[str]:
+    """Extract PACKAGE= values from config files"""
+    packages = set()
+    
+    for config_file in config_files:
+        logger.debug(f"Processing {config_file}")
+        try:
+            with open(config_file) as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith('PACKAGE='):
+                        package = line.split('=', 1)[1]
+                        packages.add(package)
+        except Exception as e:
+            logger.warning(f"Could not process {config_file}: {e}")
+    
+    return packages
+
+
+def get_all_alidist_packages() -> Set[str]:
+    """Get all packages defined in alidist directory"""
+    packages = set()
+    package_case_map = {}  # Maps lowercase -> original case
+    
+    # Search for package: lines in alidist directory
+    alidist_files = glob.glob("alidist/*.sh")
+    
+    for alidist_file in alidist_files:
+        try:
+            with open(alidist_file) as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith('package:'):
+                        package = line.split(':', 1)[1].strip()
+                        package_lower = package.lower()
+                        packages.add(package_lower)
+                        package_case_map[package_lower] = package
+        except Exception as e:
+            logger.warning(f"Could not read {alidist_file}: {e}")
+    
+    # Also search in ci/repo-config for package: lines
+    config_files = glob.glob("ci/repo-config/**/*", recursive=True)
+    for config_file in config_files:
+        if os.path.isfile(config_file):
+            try:
+                with open(config_file) as f:
+                    for line in f:
+                        line = line.strip()
+                        if line.startswith('package:'):
+                            package = line.split(':', 1)[1].strip()
+                            package_lower = package.lower()
+                            packages.add(package_lower)
+                            package_case_map[package_lower] = package
+            except Exception as e:
+                # Skip files that can't be read
+                pass
+    
+    return packages
+
+
+def run_alidoctor(package: str) -> Set[str]:
+    """Run aliDoctor for a package and extract packages that will be built"""
+    tested_packages = set()
+    
+    logger.debug(f"Testing {package}")
+    
+    try:
+        # Run aliDoctor and capture output
+        result = subprocess.run(['aliDoctor', package, "--no-system"],
+                              text=True, 
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.STDOUT)
+        
+        output = result.stdout
+        
+        # Parse the output to extract packages that will be built
+        in_build_section = False
+        for line in output.split('\n'):
+            line = line.strip()
+            
+            if 'The following packages will be built by aliBuild' in line:
+                in_build_section = True
+                continue
+            elif ('The following packages will be picked up from the system' in line or
+                  'This is not a real issue, but it might take longer' in line):
+                in_build_section = False
+                continue
+            
+            if in_build_section and line.startswith('- '):
+                # Extract package name (remove "- " prefix) and normalize to lowercase
+                package_name = line[2:].strip().lower()
+                tested_packages.add(package_name)
+    
+    except subprocess.CalledProcessError as e:
+        logger.warning(f"aliDoctor failed for {package}: {e}")
+    except FileNotFoundError:
+        logger.error("aliDoctor command not found. Make sure it's installed and in PATH.")
+        sys.exit(1)
+    except Exception as e:
+        logger.warning(f"Error running aliDoctor for {package}: {e}")
+    
+    return tested_packages
+
+
+def analyze_packages(max_workers: int = 4) -> dict:
+    """
+    Analyze packages tested by CI and return structured results.
+    
+    Args:
+        max_workers: Maximum number of parallel aliDoctor processes
+        
+    Returns:
+        Dictionary containing statistics, tested packages, untested packages, etc.
+    """
+    # Change to script directory
+    script_dir = Path(__file__).parent
+    original_cwd = os.getcwd()
+    os.chdir(script_dir)
+    
+    try:
+        # Verify we're in the right directory
+        if not os.path.isdir('ci/repo-config'):
+            raise FileNotFoundError("ci/repo-config directory not found")
+        
+        if not os.path.isdir('alidist'):
+            raise FileNotFoundError("alidist directory not found")
+        
+        # Find config files with PR_REPO=alisw/alidist
+        config_files = find_alidist_config_files()
+        logger.debug(f"Found {len(config_files)} config files with PR_REPO=alisw/alidist")
+        for config_file in config_files:
+            logger.debug(config_file)
+        
+        # Extract packages to test
+        packages_to_test = extract_packages_from_configs(config_files)
+        logger.debug(f"Packages to test: {sorted(packages_to_test)}")
+        
+        # Get all packages from alidist (normalized to lowercase)
+        all_alidist_packages_lower = get_all_alidist_packages()
+        logger.debug(f"Found {len(all_alidist_packages_lower)} packages in alidist")
+        
+        # Build case mapping for output (to preserve original case from alidist)
+        package_case_map = {}
+        alidist_files = glob.glob("alidist/*.sh")
+        for alidist_file in alidist_files:
+            try:
+                with open(alidist_file) as f:
+                    for line in f:
+                        line = line.strip()
+                        if line.startswith('package:'):
+                            package = line.split(':', 1)[1].strip()
+                            package_case_map[package.lower()] = package
+            except Exception:
+                pass
+        
+        # Run aliDoctor for each package in parallel and collect tested packages
+        all_tested_packages_lower = set()
+        
+        logger.debug(f"Running aliDoctor for {len(packages_to_test)} packages with {max_workers} workers...")
+        
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            # Submit all aliDoctor tasks
+            future_to_package = {
+                executor.submit(run_alidoctor, package): package 
+                for package in sorted(packages_to_test)
+            }
+            
+            # Collect results as they complete
+            for future in as_completed(future_to_package):
+                package = future_to_package[future]
+                try:
+                    tested_packages = future.result()
+                    all_tested_packages_lower.update(tested_packages)
+                    logger.debug(f"Completed {package}: found {len(tested_packages)} tested packages")
+                except Exception as e:
+                    logger.warning(f"Error processing {package}: {e}")
+        
+        # Find untested packages (using lowercase comparison)
+        untested_packages_lower = all_alidist_packages_lower - all_tested_packages_lower
+        
+        # Convert back to original case for output
+        tested_packages_original = [
+            package_case_map.get(pkg, pkg) for pkg in sorted(all_tested_packages_lower)
+        ]
+        untested_packages_original = [
+            package_case_map.get(pkg, pkg) for pkg in sorted(untested_packages_lower)
+        ]
+        
+        # Return structured results
+        return {
+            "statistics": {
+                "total_alidist_packages": len(all_alidist_packages_lower),
+                "tested_packages_count": len(all_tested_packages_lower),
+                "untested_packages_count": len(untested_packages_lower),
+                "config_files_found": len(config_files),
+                "packages_to_test_count": len(packages_to_test)
+            },
+            "tested_packages": tested_packages_original,
+            "untested_packages": untested_packages_original,
+            "packages_to_test": sorted(list(packages_to_test)),
+            "config_files": config_files
+        }
+    
+    finally:
+        # Restore original working directory
+        os.chdir(original_cwd)
+
+
+def main():
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description='Find packages tested by CI and identify untested ones')
+    parser.add_argument('--json', action='store_true', 
+                       help='Output results in JSON format for easier parsing')
+    parser.add_argument('--max-workers', type=int, default=4,
+                       help='Maximum number of parallel aliDoctor processes (default: 4)')
+    args = parser.parse_args()
+    
+    # Configure logging level based on output mode
+    if args.json:
+        # Suppress debug logs for JSON output
+        logging.getLogger().setLevel(logging.WARNING)
+    
+    try:
+        # Get the analysis results
+        result = analyze_packages(max_workers=args.max_workers)
+        
+        if args.json:
+            # Output structured JSON
+            print(json.dumps(result, indent=2))
+        else:
+            # Original text output
+            stats = result["statistics"]
+            logger.debug("--- Comparison ---")
+            logger.debug(f"Total alidist packages: {stats['total_alidist_packages']}")
+            logger.debug(f"Tested packages: {stats['tested_packages_count']}")
+            logger.debug(f"Untested packages: {stats['untested_packages_count']}")
+            
+            untested_packages = result["untested_packages"]
+            if untested_packages:
+                logger.info("Untested packages in alidist:")
+                for package in untested_packages:
+                    print(package)
+    
+    except Exception as e:
+        logger.error(f"Analysis failed: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
*Not ready for merge*

This is my first draft for https://its.cern.ch/jira/browse/O2-5385, the flow is like this

- Ali-bot picks up a PR
- Before testing, it checks all modified files in the PR
- **Runs this new script**
	- Find all .env files in ci/repo-config that have PR_REPO=alisw/alidist
	- Extract PACKAGE= values from those config files
	- Get all packages defined in alidist directory
	- Run aliDoctor for a package and extract packages that will be built
	- Find out which ones are untested (untested is defined as present in alidist but not child of any top level package)
- If any modified package is in that list, post a comment warning about it
- [ continue with normal flow]

@ktf could you confirm whether you agree with this flow? I'll add the integration in the normal `continuous-builder.sh` once you do

CC @sawenzel 

My current output (NB this script catches EPOS4HQ being untested properly)

```json
{
  "statistics": {
    "total_alidist_packages": 278,
    "tested_packages_count": 141,
    "untested_packages_count": 137,
    "config_files_found": 9,
    "packages_to_test_count": 4
  },
  "tested_packages": [
    "abseil",
    "AEGIS",
    "alibuild-recipe-tools",
    "Alice-GRID-Utils",
    "AliEn-CAs",
    "AliEn-Runtime",
    "AliGenerators",
    "aligenmc",
    "AliRoot",
    "AMPT",
    "ApMon-CPP",
    "arrow",
    "bookkeeping-api",
    "boost",
    "bz2",
    "c-ares",
    "cgal",
    "Clang",
    "CMake",
    "coconut",
    "CodingGuidelines",
    "Common-O2",
    "Configuration",
    "Control-Core",
    "Control-OCCPlugin",
    "CRMC",
    "curl",
    "date",
    "DebugGUI",
    "defaults-release",
    "double-conversion",
    "DPMJET",
    "Eigen3",
    "EPOS",
    "EPOS4",
    "FairCMakeModules",
    "FairLogger",
    "FairMQ",
    "FairRoot",
    "fastjet",
    "FFTW3",
    "flatbuffers",
    "fmt",
    "FONLL",
    "FreeType",
    "GEANT3",
    "GEANT4",
    "GEANT4_VMC",
    "generators",
    "GLFW",
    "GMP",
    "golang",
    "googlebenchmark",
    "gpu-system",
    "grpc",
    "GSL",
    "hdf5",
    "HepMC",
    "HepMC3",
    "hijing",
    "ITSResponse",
    "JAliEn-ROOT",
    "JETSCAPE",
    "JEWEL",
    "jq",
    "json-c",
    "KFParticle",
    "lhapdf",
    "lhapdf-pdfsets",
    "lhapdf5",
    "libffi",
    "libInfoLogger",
    "libjalienO2",
    "libpng",
    "librdkafka",
    "libuv",
    "libwebsockets",
    "libxml2",
    "looptools",
    "lz4",
    "lzma",
    "MCStepLogger",
    "MLModels",
    "moderncppkafka",
    "Monitoring",
    "MPFR",
    "ms_gsl",
    "ninja",
    "nlohmann_json",
    "O2",
    "O2-customization",
    "O2-full-system-test",
    "O2-RTC-test",
    "O2-sim-challenge-test",
    "o2checkcode",
    "o2codechecker",
    "O2DPG",
    "O2FullCI",
    "O2Physics",
    "O2sim",
    "O2Suite",
    "oniguruma",
    "onnx",
    "ONNXRuntime",
    "Openloops",
    "POWHEG",
    "Ppconsul",
    "protobuf",
    "pythia",
    "pythia6",
    "Python",
    "Python-modules",
    "Python-modules-list",
    "pytorch_cpuinfo",
    "QualityControl",
    "RapidJSON",
    "re2",
    "Readout",
    "Rivet",
    "ROOT",
    "Sacrifice",
    "safe_int",
    "SHERPA",
    "simulation",
    "sqlite",
    "STARlight",
    "TBB",
    "ThePEG",
    "Therminator2",
    "utf8proc",
    "UUID",
    "Vc",
    "vgm",
    "VMC",
    "xercesc",
    "xjalienfs",
    "XRootD",
    "xsimd",
    "YODA",
    "ZeroMQ",
    "zlib"
  ],
  "untested_packages": [
    "ACTS",
    "AGILe",
    "ALF",
    "alibuild-variant-support",
    "AliDPG",
    "AliEn-ROOT-Legacy",
    "AliEn-WorkQueue",
    "AliGenO2",
    "AliPhysics",
    "AliRoot-coverage",
    "AliRoot-csa",
    "AliRoot-guntest",
    "AliRoot-OCDB",
    "AliRoot-test",
    "alo-aliroot",
    "alo-o2",
    "aurora",
    "autotools",
    "bloaty",
    "capstone",
    "Catch2",
    "cctools",
    "CLHEP",
    "Control",
    "cpprestsdk",
    "cppzmq",
    "DataDistribution",
    "DDS",
    "defaults-ali",
    "defaults-coverage",
    "defaults-generators",
    "defaults-jalien",
    "defaults-o2",
    "defaults-o2-dataflow",
    "defaults-o2-epn",
    "Delphes",
    "DelphesO2",
    "dim",
    "DimRpcParallel",
    "EPOS-test",
    "EPOS4HQ",
    "EVTGEN",
    "FLPSuiteDevEnv",
    "FLUKA",
    "FLUKA_VMC",
    "FOCAL",
    "GCC-Toolchain",
    "GEANT-VMC-test",
    "geant3_vmc-examples",
    "Geekbench",
    "GenTopo",
    "gfortran-system",
    "glog",
    "googletest",
    "Graniitti",
    "grid-base-packages",
    "Herwig",
    "IgProf",
    "IgProf-packaging",
    "InfoLogger",
    "JAliEn",
    "JDK",
    "jemalloc",
    "kernel-devel",
    "lcov",
    "libatomic_ops",
    "libjalienws",
    "libperl",
    "libtirpc",
    "libunwind",
    "LLA",
    "localccdb",
    "MachineLearningHEP",
    "madgraph",
    "make",
    "mesos",
    "mesos-dds",
    "mesos-workqueue",
    "Millepede-II",
    "MonALISA",
    "motif",
    "msgpack",
    "MySQL",
    "ndmspc",
    "ninja-fortran",
    "nOOn",
    "O2DPG-sim-tests",
    "O2PDPSuite",
    "ObjCmp",
    "OCDB-test",
    "ODC",
    "OpenBLAS",
    "opengl",
    "openmp",
    "OpenSSL",
    "osx-system-openssl",
    "PCRE",
    "PDA",
    "Perl-modules",
    "PHOTOS",
    "PyTorch",
    "rdma-core",
    "ReadoutCard",
    "Rivet-hi",
    "Rivet-test",
    "RivetTask",
    "RooUnfold",
    "rpm-test",
    "rsync",
    "SAS",
    "sip-check",
    "snappy",
    "sodium",
    "SWIG",
    "system-apr",
    "system-apr-util",
    "system-cyrus-sasl",
    "system-openssl",
    "system-subversion",
    "TAUOLA",
    "Template-Recipe    # e.g. MyGenerator",
    "termcap",
    "ThePEG-test",
    "thrift",
    "Toolchain",
    "TpcFecUtils",
    "treelite",
    "ucx",
    "Upcgen",
    "valgrind",
    "VecGeom",
    "xalienfs",
    "Xcode",
    "Xdevel",
    "yacc-like",
    "yaml-cpp",
    "zlib-cloudflare"
  ],
  "packages_to_test": [
    "AliGenerators",
    "AliRoot",
    "O2FullCI",
    "O2Suite"
  ],
  "config_files": [
    "ci/repo-config/macos/alibuildmac02/alidist-o2.env",
    "ci/repo-config/macos/osx_arm64/alidist-o2.env",
    "ci/repo-config/mesosci/cs8/o2-alidist-dataflow.env",
    "ci/repo-config/mesosci/slc9-gpu/o2-fullci-alidist.env",
    "ci/repo-config/mesosci/slc9/o2-alidist.env",
    "ci/repo-config/mesosci/slc7/aligenerators.env",
    "ci/repo-config/mesosci/slc7/aliroot-alidist.env",
    "ci/repo-config/mesosci/ubuntu2204/o2-alidist.env",
    "ci/repo-config/mesosci/slc9-arm/o2-alidist.env"
  ]
}
```