### PR TITLE
Rename check names to slc9

### DIFF
--- a/ci/repo-config/mesosci/slc9/o2-alidist-dataflow.env
+++ b/ci/repo-config/mesosci/slc9/o2-alidist-dataflow.env
@@ -1,11 +1,11 @@
-CI_NAME=build_O2_alidist-dataflow-cs8
+CI_NAME=build_O2_alidist-dataflow-slc9
 PACKAGE=O2Suite
 ALIBUILD_DEFAULTS=o2-dataflow
 PR_REPO=alisw/alidist
 PR_BRANCH=master
 NO_ASSUME_CONSISTENT_EXTERNALS=
 TRUST_COLLABORATORS=true
-CHECK_NAME=build/O2/alidist-dataflow-cs8
+CHECK_NAME=build/O2/alidist-dataflow-slc9
 DONT_USE_COMMENTS=1
 DEVEL_PKGS="$PR_REPO $PR_BRANCH"
 ALIBUILD_O2_TESTS=1

--- a/ci/repo-config/mesosci/slc9/o2-dataflow.env
+++ b/ci/repo-config/mesosci/slc9/o2-dataflow.env
@@ -1,11 +1,11 @@
-CI_NAME=build_O2_o2-dataflow-cs8
+CI_NAME=build_O2_o2-dataflow-slc9
 PACKAGE=O2Suite
 ALIBUILD_DEFAULTS=o2-dataflow
 PR_REPO=AliceO2Group/AliceO2
 PR_REPO_CHECKOUT=O2
 PR_BRANCH=dev
 TRUST_COLLABORATORS=true
-CHECK_NAME=build/O2/o2-dataflow-cs8
+CHECK_NAME=build/O2/o2-dataflow-slc9
 DONT_USE_COMMENTS=1
 DEVEL_PKGS="$PR_REPO $PR_BRANCH $PR_REPO_CHECKOUT
 AliceO2Group/O2Physics master

--- a/ci/repo-config/mesosdaq/slc9/qualitycontrol-dataflow.env
+++ b/ci/repo-config/mesosdaq/slc9/qualitycontrol-dataflow.env
@@ -1,4 +1,4 @@
-CI_NAME=build_QualityControl_o2-dataflow-cs8
+CI_NAME=build_QualityControl_o2-dataflow-slc9
 PACKAGE=QualityControl
 ALIBUILD_DEFAULTS=o2-dataflow
 PR_REPO=AliceO2Group/QualityControl
@@ -6,7 +6,7 @@ PR_BRANCH=master
 TRUSTED_USERS=ktf,Barthelemy,awegrzyn
 TRUST_COLLABORATORS=true
 NO_ASSUME_CONSISTENT_EXTERNALS=
-CHECK_NAME=build/QualityControl/o2-dataflow-cs8
+CHECK_NAME=build/QualityControl/o2-dataflow-slc9
 DONT_USE_COMMENTS=1
 DEVEL_PKGS="$PR_REPO $PR_BRANCH
 AliceO2Group/AliceO2 dev O2


### PR DESCRIPTION
Oversight from #1531

Requires changing the names of the required checks when merged