### PR TITLE
Update notification lists with current users

### DIFF
--- a/publish/aliPublish-rpms-cc9.conf
+++ b/publish/aliPublish-rpms-cc9.conf
@@ -61,14 +61,11 @@ notification_email:
         - kirsch@fias.uni-frankfurt.de
       O2:
         - barthelemy.von.haller@cern.ch
-        - adam.wegrzynek@cern.ch
-        - teo.mrnjavac@cern.ch
       qcg:
         - barthelemy.von.haller@cern.ch
-        - adam.wegrzynek@cern.ch
         - piotr.jan.konopka@cern.ch
       Monitoring:
-        - adam.wegrzynek@cern.ch
+        - barthelemy.von.haller@cern.ch
       flpproto:
         - alice-o2-flp-prototype@cern.ch
       O2Suite:
@@ -76,23 +73,20 @@ notification_email:
       mesos-workqueue:
         - giulio.eulisse@cern.ch
       Configuration:
-        - adam.wegrzynek@cern.ch
+        - barthelemy.von.haller@cern.ch
       Configuration-Benchmark:
-        - adam.wegrzynek@cern.ch
+        - barthelemy.von.haller@cern.ch
       Readout:
         - sylvain.chapeland@cern.ch
-        - teo.mrnjavac@cern.ch
       Control:
-        - teo.mrnjavac@cern.ch
+        - piotr.jan.konopka@cern.ch
       DataDistribution:
         - gvozden.neskovic@cern.ch
-        - teo.mrnjavac@cern.ch
       QualityControl:
         - barthelemy.von.haller@cern.ch
         - piotr.jan.konopka@cern.ch
-        - teo.mrnjavac@cern.ch
       ODC:
-        - teo.mrnjavac@cern.ch
+        - piotr.jan.konopka@cern.ch
   failure:
     body: |
       Creation of RPM %(package)s %(version)s for architecture %(arch)s failed.

--- a/publish/aliPublish-rpms-cc9.conf
+++ b/publish/aliPublish-rpms-cc9.conf
@@ -61,9 +61,6 @@ notification_email:
         - kirsch@fias.uni-frankfurt.de
       O2:
         - barthelemy.von.haller@cern.ch
-      qcg:
-        - barthelemy.von.haller@cern.ch
-        - piotr.jan.konopka@cern.ch
       Monitoring:
         - barthelemy.von.haller@cern.ch
       flpproto:


### PR DESCRIPTION
In this PR:
- I update the emails/owners of some components which are not following them anymore so that we are not missing any potential critical notifications. 
- If a tool had only one email person, I replaced with someone else from the same team.
- QCG tool was replaced entirely as it has not been part of an RPM or alidist recipe for a few years now.