### PR TITLE
Standardize ali-ci date report

### DIFF
--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -10,9 +10,11 @@
 get_config
 
 PR_START_TIME=$(TZ=Europe/Zurich date +'%a %H:%M CET')
+# shellcheck disable=SC2034 # used in report-pr-errors
+PR_START_TIME_FULL=$(TZ=Europe/Zurich date +'%a %-d %b %Y, %H:%M:%S %Z')
 echo "$PR_START_TIME: Started building check $CHECK_NAME for $PR_REPO@$PR_HASH on $host_id"
 
-ensure_vars CI_NAME CHECK_NAME PR_REPO PR_BRANCH PACKAGE ALIBUILD_DEFAULTS PR_START_TIME
+ensure_vars CI_NAME CHECK_NAME PR_REPO PR_BRANCH PACKAGE ALIBUILD_DEFAULTS PR_START_TIME PR_START_TIME_FULL
 
 : "${WORKERS_POOL_SIZE:=1}" "${WORKER_INDEX:=0}" "${PR_REPO_CHECKOUT:=$(basename "$PR_REPO")}"
 

--- a/report-pr-errors
+++ b/report-pr-errors
@@ -370,8 +370,8 @@ class Logs(object):
                                        self.fst_task_timeout or
                                        self.fst_failed_command),
                 'hostname': htmlescape(platform.node()),
-                'pr_start_time': os.getenv('PR_START_TIME', ''),
-                'finish_time': datetime.datetime.now().strftime('%a %-d %b %Y, %H:%M:%S %Z'),
+                'pr_start_time': os.getenv('PR_START_TIME_FULL', ''),
+                'finish_time': datetime.datetime.now().astimezone().strftime('%a %-d %b %Y, %H:%M:%S %Z'),
                 'repo': self.pr_built.repo_name,
                 'pr_id': self.pr_built.id,
                 'commit': self.pr_built.commit,


### PR DESCRIPTION
It currently looks heterogeneous

<img width="395" height="147" alt="Screenshot 2025-08-20 at 16 48 09" src="https://github.com/user-attachments/assets/8de6edd2-a4fe-4b2e-8762-8b34ab1508fe" />

I'm also making the timezone object aware for the end time, so we get the timezone properly printed in both (https://docs.python.org/3/library/datetime.html#datetime.datetime.astimezone)