### PR TITLE
Remove el7 o2-full-deps release

### DIFF
--- a/.github/workflows/o2-full-deps.yml
+++ b/.github/workflows/o2-full-deps.yml
@@ -18,16 +18,12 @@ jobs:
       matrix:
         # For every entry in el_version:, add an {el_version, container, alibuild_tag} entry to include:!
         el_version:
-          - el7
           - el8
           - el9
           - fedora
 
         # The include: key extends the matrix specified above with extra variables.
         include:
-          - el_version: el7
-            container: centos:7
-            alibuild_tag: v1.17.27
           - el_version: el8
             container: almalinux:8
             alibuild_tag: v1.17.27
@@ -43,7 +39,6 @@ jobs:
     env:
       ALIBUILD_TAG: ${{ matrix.alibuild_tag }}
       DISTRO: ${{ matrix.el_version }}
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true' # Only required for CentOS 7
 
     steps:
       # For rpms/*.spec
@@ -52,13 +47,6 @@ jobs:
       - name: "Install prerequisites"
         run: |
           set -ex
-          if [[ "$DISTRO" == "el7" ]]; then
-            sed -i.bak -e 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-            sed -i.bak -r -e 's|# ?baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-            find /etc/yum.repos.d -name "*.bak" -delete
-            yum clean all
-            yum update -y
-          fi
           yum clean all
           yum update -y
           yum install -y rpm-build scl-utils-build createrepo unzip git python3 python3-pip python3-setuptools
@@ -84,12 +72,8 @@ jobs:
           cd  ~/rpmbuild/RPMS/"$(uname -m)"/
           createrepo .
           ls -la
-          case "$DISTRO" in
-            el7) repo_suffix=_ ;;
-            *) repo_suffix=_$DISTRO. ;;
-          esac
           rclone --config /tmp/rclone.conf --transfers=10 --progress --delete-before \
-                 sync local:./ "rpms3:alibuild-repo/RPMS/o2-full-deps${repo_suffix}$(uname -m | tr _ -)/"
+                 sync local:./ "rpms3:alibuild-repo/RPMS/o2-full-deps_$DISTRO.$(uname -m | tr _ -)/"
 
   deb-ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We no longer support el7 for end users nor rely on the RPMs for the few
odd internal jobs where we still use it
