### PR TITLE
[O2-6297] Don't show defaults packages as untested

### DIFF
--- a/.github/workflows/check-untested-packages.yml
+++ b/.github/workflows/check-untested-packages.yml
@@ -85,6 +85,10 @@ jobs:
           for file in $MODIFIED_FILES; do
             if [[ -f "$file" ]]; then
               PACKAGE=$(grep '^package:' "$file" | head -1 | cut -d: -f2 | tr -d ' ' || echo "")
+              if [[ "$PACKAGE" == defaults-* ]]; then
+                echo "Skipping defaults package: $PACKAGE"
+                continue
+              fi
               if [[ -n "$MODIFIED_PACKAGES" ]]; then
                 MODIFIED_PACKAGES="$MODIFIED_PACKAGES,$PACKAGE"
               else


### PR DESCRIPTION
The defaults are included in recipes indirectly so our ad-hoc logic for
detecting them as untested doesn't work
