### PR TITLE
Pass RECC_CONFIG_DIRECTORY to aliBuild

### DIFF
--- a/ci/build-loop.sh
+++ b/ci/build-loop.sh
@@ -265,6 +265,16 @@ fi
 build_identifier=${NO_ASSUME_CONSISTENT_EXTERNALS:+${PR_NUMBER//-/_}}
 : "${build_identifier:=${CHECK_NAME//\//_}}"
 
+# Mount the RECC config directory inside the container if using Docker.
+if [[ -n "$USE_RECC" && -n "$RECC_CONFIG_DIRECTORY" ]]; then
+  if [[ -n "$use_docker" ]]; then
+    path_in_container="/recc"
+    recc_config=(-e "RECC_CONFIG_DIRECTORY=$path_in_container" -v "$RECC_CONFIG_DIRECTORY:$path_in_container:ro")
+  else
+    recc_config=(-e "RECC_CONFIG_DIRECTORY=$RECC_CONFIG_DIRECTORY")
+  fi
+fi
+
 # o2checkcode and O2DPG checks need the ALIBUILD_{HEAD,BASE}_HASH variables.
 # We need "--no-auto-cleanup" so that build logs for dependencies are kept, too.
 # For instance, when building O2FullCI, we want to keep the o2checkcode log, as
@@ -280,6 +290,7 @@ if clean_env long_timeout $BUILD_CMD build "$PACKAGE"          \
      -e "ALIBUILD_O2_FORCE_GPU=$ALIBUILD_O2_FORCE_GPU"       \
      ${USE_RECC:+-e "USE_RECC=$USE_RECC"}                    \
      ${RECC_LOG_LEVEL:+-e "RECC_LOG_LEVEL=$RECC_LOG_LEVEL"}  \
+     "${recc_config:+${recc_config[@]}}"                     \
      -e "ALIBUILD_O2PHYSICS_TESTS=$ALIBUILD_O2PHYSICS_TESTS" \
      -e "ALIBUILD_XJALIENFS_TESTS=$ALIBUILD_XJALIENFS_TESTS" \
      -e "ALIBUILD_HEAD_HASH=$PR_HASH"                        \


### PR DESCRIPTION
If using RECC inside a container and with defined `RECC_CONFIG_DIRECTORY`, mount the directory path inside the container at an internal `RECC_CONFIG_DIRECTORY` path, otherwise pass it as is.