### PR TITLE
Drop ability to run arbitrary commands to retrieve secrets

### DIFF
--- a/.github/workflows/security-proxy-tests.yml
+++ b/.github/workflows/security-proxy-tests.yml
@@ -1,0 +1,56 @@
+---
+# Run the security-proxy test suite: route path scoping, attended-slot windows and the
+# declarative bootstrap sources. These pin security-relevant behaviour, so a red run
+# here means a credential boundary moved, not that a refactor needs tidying.
+name: Test security-proxy
+
+'on':
+  push:
+    paths:
+      - 'security-proxy/**'
+      - '.github/workflows/security-proxy-tests.yml'
+  pull_request:
+    paths:
+      - 'security-proxy/**'
+      - '.github/workflows/security-proxy-tests.yml'
+
+permissions: {}
+
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.10 is the real floor: the module uses PEP 604 (`str | None`) in runtime
+        # annotations, which 3.9 evaluates and rejects at import.
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: security-proxy/pyproject.toml
+
+      # An editable install is what the deployment does, so this covers packaging too:
+      # a missing `py-modules` once made pip report success while registering nothing,
+      # leaving every console script import-broken at runtime.
+      - name: Install the proxy
+        run: python -m pip install -e ./security-proxy
+
+      - name: Console scripts resolve
+        run: |
+          set -e
+          security-proxy-token --help > /dev/null
+          security-proxy-push --help > /dev/null
+          security-proxy-bootstrap --help > /dev/null
+          security-proxy-unlock --help > /dev/null
+          security-proxy --help > /dev/null
+
+      - name: Run the test suite
+        run: python security-proxy/tests/run_all.py

--- a/security-proxy/README.md
+++ b/security-proxy/README.md
@@ -30,6 +30,29 @@ This installs four commands into the venv: `security-proxy` (the daemon),
 `security-proxy-token` (read a gate token), `security-proxy-push` (push one secret
 from stdin), and `security-proxy-bootstrap` (push all secrets from a config).
 
+## Tests
+
+```bash
+./venv/bin/python tests/run_all.py      # everything
+./venv/bin/python tests/test_paths.py   # or one module
+```
+
+No pytest, no dependencies beyond the proxy's own venv; each module exits non-zero on
+failure. They pin the security-relevant behaviour rather than the plumbing:
+
+- `test_paths.py` — a route's upstream path is a *scope*, and `..` (raw, percent-encoded
+  or backslash-separated) must not escape it and reach the rest of that host with the
+  proxy's credential attached.
+- `test_attended.py` — an attended secret is absent outside a window a human opened: use
+  budget, TTL, the sweeper that drops an untouched value on time, and the 403-vs-503
+  split that tells a caller which fault it hit.
+- `test_sources.py` — bootstrap sources stay declarative; the removed `command` kind
+  stays rejected, with a hint pointing at `file` / `vault` / `device_authorize`.
+
+`test_sources.py` also checks `~/.security-proxy-bootstrap.json` when there is one —
+that every slot resolves to exactly one known kind and every attended slot is sourced
+from an explicit locked keychain. It skips that part on a machine without the file.
+
 ## Configuration
 
 Routes and credentials live in `~/.security-proxy.json` (run `security-proxy --help`
@@ -84,18 +107,28 @@ printf %s "$TOKEN" | security-proxy-push nomad
 ```
 
 `security-proxy-bootstrap` reads `~/.security-proxy-bootstrap.json`, which maps each
-slot to a **source** — either the macOS Keychain or an arbitrary command:
+slot to a **source**. Every kind is declarative — it names *what* to read, never a
+command to run:
 
 ```json
 {
   "nomad": {"keychain": {"service": "security-proxy", "account": "alinomad.cern.ch"}},
-  "other": {"command": "op read op://vault/item/field"}
+  "grid-cert": {"file": ["~/.globus/usercert.pem", "~/.globus/userkey.pem"]},
+  "gitlab": {"vault": {"path": "kv/data/ci", "field": "gitlab_pass"}}
 }
 ```
 
-The `command` source makes any secret store pluggable (1Password, vault, a file, or
-a one-time interactive SSO capture that caches its result). Because the proxy never
-touches the Keychain itself, it works headless and as a separate user.
+Kinds: `keychain` (a generic password; add `"keychain": "<path>"` to read a specific,
+locked keychain file), `keychain_identity` (a cert identity as combined PEM), `file`
+(one path, or several concatenated), `vault` (one field of a Vault secret, read
+*through the proxy's own vault route*, so bootstrap needs no Vault token of its own)
+and `device_authorize` (the OAuth2 device-code flow, cached after the first consent).
+
+There is deliberately **no shell/command source**. This file is writable by anything
+running as you, so a command source would be arbitrary code execution as you at the
+next bootstrap — the same-uid problem that attended slots exist to contain, arriving
+through a door they do not cover. Because the proxy never touches the Keychain itself,
+it still works headless and as a separate user.
 
 ## Attended slots (high-privilege secrets)
 
@@ -239,7 +272,9 @@ during `security-proxy-bootstrap`), caches the result, and emits the refresh tok
 stdout:
 
 ```json
-{"mail-refresh": {"command": "security-proxy device-authorize microsoft --tenant <tenant> --client-id <public-client-id> --scope 'https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/SMTP.Send offline_access' --account me@example.com"}}
+{"mail-refresh": {"device_authorize": {"provider": "microsoft", "tenant": "<tenant>",
+  "client_id": "<public-client-id>", "account": "me@example.com",
+  "scope": "https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/SMTP.Send offline_access"}}}
 ```
 
 **Client side.** A tiny helper prints a fresh access token; point each mail client's
@@ -385,7 +420,7 @@ paths), then add a bootstrap slot for it. Either export it from the Keychain:
 {"grid-cert": {"keychain_identity": "My Grid Cert"}}
 ```
 
-or, if your cert lives as PEM files, `{"grid-cert": {"command": "cat ~/.globus/usercert.pem ~/.globus/userkey.pem"}}`.
+or, if your cert lives as PEM files, `{"grid-cert": {"file": ["~/.globus/usercert.pem", "~/.globus/userkey.pem"]}}`.
 
 mTLS routes return `503` until it is pushed; the key is only ever briefly
 materialised to a `0600` temp file while loading, never persisted.

--- a/security-proxy/pyproject.toml
+++ b/security-proxy/pyproject.toml
@@ -2,7 +2,9 @@
 name = "security-proxy"
 version = "0.1.0"
 description = "Credential proxy for ALICE services (grid cert / CERN SSO / Nomad)"
-requires-python = ">=3.9"
+# PEP 604 unions (`str | None`) are used in runtime annotations, which 3.9 evaluates
+# and rejects at import time -- 3.10 is the real floor, despite what this said before.
+requires-python = ">=3.10"
 dependencies = [
     "fastapi==0.138.0",
     "uvicorn==0.49.0",

--- a/security-proxy/security_proxy.py
+++ b/security-proxy/security_proxy.py
@@ -38,6 +38,8 @@ from contextlib import asynccontextmanager
 from copy import deepcopy
 from dataclasses import dataclass
 import posixpath
+import urllib.error
+import urllib.request
 from urllib.parse import (urlparse, parse_qs, parse_qsl, quote, unquote, urlencode,
                           urlsplit, urlunsplit)
 import httpx
@@ -1716,19 +1718,76 @@ def _post_form(url: str, form: dict) -> tuple[int, dict]:
             return e.code, {}
 
 
+def device_authorize(provider: str, client_id: str, scope: str, tenant: str | None = None,
+                     account: str | None = None, cache: str | None = None,
+                     no_cache: bool = False, force: bool = False,
+                     devicecode_url: str | None = None, token_url: str | None = None) -> str:
+    """Run the OAuth2 device-code flow and return the refresh token.
+
+    Shared by the `device-authorize` CLI and the `device_authorize` bootstrap source.
+    The user prompt goes to stderr so it stays visible while bootstrap waits; the
+    token is cached (0600) and reused, so re-bootstrapping never re-prompts."""
+    preset = DEVICE_PROVIDERS[provider]
+    tenant = tenant or preset["default_tenant"] or "common"
+    devicecode_url = devicecode_url or preset["devicecode"].format(tenant=tenant)
+    token_url = token_url or preset["token"].format(tenant=tenant)
+
+    cache_path = None
+    if not no_cache:
+        label = account or client_id
+        cache_path = Path(cache).expanduser() if cache else \
+            Path("~/.config/security-proxy").expanduser() / f"{label}.refresh.json"
+        if not force:
+            cached = _file_get_token(cache_path)
+            if cached:
+                return cached
+
+    # 1. Ask for a device + user code
+    status, dc = _post_form(devicecode_url, {"client_id": client_id, "scope": scope})
+    if status != 200 or "device_code" not in dc:
+        raise RuntimeError(f"device-code request failed ({status}): "
+                           f"{dc.get('error_description', dc)}")
+    prompt = dc.get("message") or (
+        f"To authorize, visit {dc.get('verification_uri', dc.get('verification_url'))} "
+        f"and enter code: {dc['user_code']}")
+    print(prompt, file=sys.stderr, flush=True)
+
+    # 2. Poll the token endpoint until the user approves (or it expires)
+    interval = int(dc.get("interval", 5))
+    deadline = time.monotonic() + int(dc.get("expires_in", 900))
+    while time.monotonic() < deadline:
+        time.sleep(interval)
+        status, tok = _post_form(token_url, {
+            "grant_type": DEVICE_GRANT, "client_id": client_id, "device_code": dc["device_code"],
+        })
+        if status == 200 and tok.get("refresh_token"):
+            rt = tok["refresh_token"]
+            if cache_path is not None:
+                _file_set_token(cache_path, rt, token_url)
+            return rt
+        err = tok.get("error")
+        if err == "authorization_pending":
+            continue
+        if err == "slow_down":
+            interval += 5
+            continue
+        raise RuntimeError(f"authorization failed: {tok.get('error_description', err or tok)}")
+    raise RuntimeError("device code expired before authorization completed")
+
+
 def device_authorize_main(argv=None) -> None:
     """`security-proxy device-authorize <provider>` -- run the OAuth2 device-code flow
     and print the resulting refresh token to stdout (prompts go to stderr).
 
-    Intended as a `command` bootstrap source for an oauth route's refresh-token slot,
-    so the one-time browser consent happens at provisioning time -- no oama needed.
-    Caches the token (default ~/.config/security-proxy/<account>.refresh.json, 0600) and
-    reuses it on later runs, so re-bootstrapping never re-prompts; pass --force to
-    re-authorize. Device-code flow is for public clients, so no client_secret."""
+    Usually not run by hand: a `device_authorize` bootstrap source calls the same code,
+    so the one-time browser consent happens during `security-proxy-bootstrap` -- no
+    oama needed. Caches the token (default ~/.config/security-proxy/<account>.refresh.json,
+    0600) and reuses it on later runs; pass --force to re-authorize. Device-code flow is
+    for public clients, so no client_secret."""
     ap = argparse.ArgumentParser(
         prog="security-proxy device-authorize",
         description="Run the OAuth2 device-code flow and print the refresh token to "
-                    "stdout (for use as a 'command' bootstrap source).")
+                    "stdout (the 'device_authorize' bootstrap source calls the same code).")
     ap.add_argument("provider", choices=sorted(DEVICE_PROVIDERS),
                     help="OAuth provider preset (sets the device-code/token endpoints)")
     ap.add_argument("--client-id", required=True, help="public OAuth client id")
@@ -1743,53 +1802,13 @@ def device_authorize_main(argv=None) -> None:
     ap.add_argument("--force", action="store_true", help="ignore any cached token and re-authorize")
     a = ap.parse_args(argv)
 
-    preset = DEVICE_PROVIDERS[a.provider]
-    tenant = a.tenant or preset["default_tenant"] or "common"
-    devicecode_url = a.devicecode_url or preset["devicecode"].format(tenant=tenant)
-    token_url = a.token_url or preset["token"].format(tenant=tenant)
-
-    cache_path = None
-    if not a.no_cache:
-        label = a.account or a.client_id
-        cache_path = Path(a.cache).expanduser() if a.cache else \
-            Path("~/.config/security-proxy").expanduser() / f"{label}.refresh.json"
-        if not a.force:
-            cached = _file_get_token(cache_path)
-            if cached:
-                print(cached)
-                return
-
-    # 1. Ask for a device + user code
-    status, dc = _post_form(devicecode_url, {"client_id": a.client_id, "scope": a.scope})
-    if status != 200 or "device_code" not in dc:
-        sys.exit(f"device-code request failed ({status}): {dc.get('error_description', dc)}")
-    prompt = dc.get("message") or (
-        f"To authorize, visit {dc.get('verification_uri', dc.get('verification_url'))} "
-        f"and enter code: {dc['user_code']}")
-    print(prompt, file=sys.stderr, flush=True)
-
-    # 2. Poll the token endpoint until the user approves (or it expires)
-    interval = int(dc.get("interval", 5))
-    deadline = time.monotonic() + int(dc.get("expires_in", 900))
-    while time.monotonic() < deadline:
-        time.sleep(interval)
-        status, tok = _post_form(token_url, {
-            "grant_type": DEVICE_GRANT, "client_id": a.client_id, "device_code": dc["device_code"],
-        })
-        if status == 200 and tok.get("refresh_token"):
-            rt = tok["refresh_token"]
-            if cache_path is not None:
-                _file_set_token(cache_path, rt, token_url)
-            print(rt)
-            return
-        err = tok.get("error")
-        if err == "authorization_pending":
-            continue
-        if err == "slow_down":
-            interval += 5
-            continue
-        sys.exit(f"authorization failed: {tok.get('error_description', err or tok)}")
-    sys.exit("device code expired before authorization completed")
+    try:
+        print(device_authorize(a.provider, a.client_id, a.scope, tenant=a.tenant,
+                               account=a.account, cache=a.cache, no_cache=a.no_cache,
+                               force=a.force, devicecode_url=a.devicecode_url,
+                               token_url=a.token_url))
+    except RuntimeError as exc:
+        sys.exit(str(exc))
 
 
 def push_slot(socket_path: Path, slot: str, value: str | None, clear: bool = False) -> dict:
@@ -1870,37 +1889,92 @@ def _export_identity_pem(identity: str) -> str:
     return pem.decode()
 
 
-def _resolve_source(source: dict) -> str | None:
+SOURCE_KINDS = ("keychain", "keychain_identity", "file", "vault", "device_authorize")
+
+
+def _vault_get(spec: dict, agent_socket: Path) -> str | None:
+    """Read one field of a Vault secret *through the proxy's own vault route*.
+
+    So the bootstrap tool needs no Vault token of its own: it presents the rotating
+    gate token, and the proxy swaps in the real one. Reads KV v2 (`data.data.<field>`)
+    and falls back to the KV v1 shape."""
+    path = spec["path"].strip("/")
+    field = spec["field"]
+    route = spec.get("route", "vault")
+    reply = fetch_from_agent(agent_socket, route)
+    if "token" not in reply:
+        raise RuntimeError(f"no gate token for the '{route}' route: {reply.get('error', reply)}")
+    url = f"http://127.0.0.1:{reply['port']}/v1/{path}"
+    req = urllib.request.Request(url, headers={"X-Vault-Token": reply["token"]})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode()[:200]
+        raise RuntimeError(f"vault read {path} failed ({exc.code}): {detail}") from None
+    except OSError as exc:
+        raise RuntimeError(f"cannot reach the proxy's vault route: {exc}") from None
+    data = body.get("data") or {}
+    values = data.get("data") if isinstance(data.get("data"), dict) else data  # v2, else v1
+    if field not in values:
+        raise RuntimeError(f"vault secret {path} has no field {field!r} "
+                           f"(has: {', '.join(sorted(values)) or 'nothing'})")
+    return values[field]
+
+
+def _resolve_source(source: dict, agent_socket: Path | None = None) -> str | None:
     """Resolve a bootstrap source descriptor to a secret value.
 
-    {"keychain": "<account>"} or {"keychain": {"service","account"}} (a generic
-    password), {"keychain_identity": "<name>"} (a cert identity -> combined PEM), or
-    {"command": "<shell>"} (its stdout is the value)."""
-    if "keychain" in source:
+    Every kind is *declarative*: the bootstrap config names what to read, never how.
+    There is deliberately no shell/command kind -- this file is writable by anything
+    running as the user, so an arbitrary-command source would be arbitrary code
+    execution as the user at the next bootstrap.
+
+      {"keychain": "<account>"}                       a generic password, default service
+      {"keychain": {"service","account","keychain"}}  ... explicit item / keychain file
+      {"keychain_identity": "<name>"}                 a cert identity -> combined PEM
+      {"file": "<path>"} or {"file": [paths...]}      file contents, concatenated
+      {"vault": {"path","field","route"}}             a Vault field, via the proxy
+      {"device_authorize": {provider, client_id, scope, tenant, account}}
+    """
+    kinds = [k for k in SOURCE_KINDS if k in source]
+    if len(kinds) != 1:
+        if "command" in source:
+            raise ValueError(
+                'the "command" source was removed: it ran arbitrary shell as you at '
+                'bootstrap time, from a file any process running as you can edit. Use '
+                '"file" (was: cat), "device_authorize" (was: security-proxy '
+                'device-authorize) or "vault" instead.')
+        raise ValueError(f"source must have exactly one of: {', '.join(SOURCE_KINDS)}")
+    kind = kinds[0]
+
+    if kind == "keychain":
         kc = source["keychain"]
         if isinstance(kc, str):
             kc = {"account": kc}
         return keychain_get_token(kc.get("service", "security-proxy"), kc["account"],
                                   kc.get("keychain"))
-    if "keychain_identity" in source:
+    if kind == "keychain_identity":
         return _export_identity_pem(source["keychain_identity"])
-    if "command" in source:
-        # Capture stdout (the value) but let stderr pass through to the terminal, so an
-        # interactive source -- e.g. `security-proxy device-authorize`, which prints its
-        # "visit this URL and enter this code" prompt to stderr -- is visible while
-        # bootstrap waits for it.
-        out = subprocess.run(source["command"], shell=True, stdout=subprocess.PIPE, text=True)
-        if out.returncode != 0:
-            raise RuntimeError(f"command exited {out.returncode}")
-        return out.stdout.strip()
-    raise ValueError('source must have "keychain", "keychain_identity", or "command"')
+    if kind == "file":
+        paths = source["file"]
+        if isinstance(paths, str):
+            paths = [paths]
+        return "".join(Path(p).expanduser().read_text() for p in paths)
+    if kind == "vault":
+        if agent_socket is None:
+            raise RuntimeError('a "vault" source needs "agent_socket" in the bootstrap config')
+        return _vault_get(source["vault"], agent_socket)
+    da = dict(source["device_authorize"])
+    return device_authorize(da.pop("provider"), da.pop("client_id"), da.pop("scope"), **da)
 
 
 def bootstrap_main(argv=None) -> None:
     """`security-proxy-bootstrap` -- fill the proxy's slots from a bootstrap config.
 
     The config (default ~/.security-proxy-bootstrap.json) maps each slot to a
-    source: {"keychain": {...}} or {"command": "<shell>"}. Re-run after each proxy
+    source: {"keychain": {...}}, {"file": ...}, {"vault": {...}} or
+    {"device_authorize": {...}}. Re-run after each proxy
     restart, since slots live only in the proxy's memory."""
     ap = argparse.ArgumentParser(
         prog="security-proxy-bootstrap",
@@ -1918,18 +1992,24 @@ def bootstrap_main(argv=None) -> None:
         sys.exit(f"cannot read bootstrap config {cfg_path}: {e}")
     slots = cfg.get("slots", cfg)  # accept {"slots": {...}} or a bare slot->source map
     socket_path = Path(a.socket or cfg.get("ingest_socket") or DEFAULT_INGEST_SOCKET).expanduser()
+    agent_socket = Path(cfg.get("agent_socket", DEFAULT_AGENT_SOCKET)).expanduser()
+
+    # "attended" holds the on-demand sources for attended slots -- deliberately not
+    # provisioned here, since the point is that they only enter the proxy when the human
+    # runs `security-proxy-unlock`.
+    pending = [(slot, src) for slot, src in slots.items()
+               if slot not in ("ingest_socket", "agent_socket", "attended")
+               and isinstance(src, dict)]
+    # A "vault" source reads *through* the proxy, so the slot backing the vault route has
+    # to be filled first -- do the local sources in one pass, then the vault-backed ones.
+    pending.sort(key=lambda item: "vault" in item[1])
 
     ok = 0
     total = 0
-    for slot, source in slots.items():
-        # "attended" holds the on-demand sources for attended slots -- deliberately not
-        # provisioned here, since the point is that they only enter the proxy when the
-        # human runs `security-proxy-unlock`.
-        if slot in ("ingest_socket", "attended") or not isinstance(source, dict):
-            continue
+    for slot, source in pending:
         total += 1
         try:
-            value = _resolve_source(source)
+            value = _resolve_source(source, agent_socket)
         except Exception as e:
             print(f"[{slot}] source error: {e}")
             continue
@@ -1994,8 +2074,31 @@ def unlock_main(argv=None) -> None:
         print(f"[{a.slot}] locked" if resp.get("ok") else f"[{a.slot}] failed: {resp.get('error')}")
         return
 
+    # An attended slot is only as good as the prompt guarding its source. This config
+    # file is writable by anything running as this user, so refuse any source that could
+    # be swapped in to make the unlock silent -- only an explicit keychain FILE (which is
+    # locked, hence prompts) counts. Rewriting the entry then breaks the unlock loudly
+    # instead of quietly removing the human from the loop.
+    source = attended[a.slot]
+    kc = source.get("keychain")
+    if not isinstance(kc, dict) or not kc.get("keychain"):
+        sys.exit(f'[{a.slot}] refusing to unlock: an attended source must be '
+                 f'{{"keychain": {{..., "keychain": "<path to a locked keychain>"}}}}, '
+                 f'so that reading it prompts. Got: {", ".join(source) or "nothing"}.')
+
+    # Lock the keychain before reading it. Otherwise the guarantee silently depends on
+    # ambient state: a keychain still unlocked from an earlier use (or with auto-lock
+    # unset) hands the secret over with no prompt at all, so an agent could unlock an
+    # attended slot unattended. Locking first makes the prompt unconditional.
+    kc_path = Path(kc["keychain"]).expanduser()
+    locked = subprocess.run(["security", "lock-keychain", str(kc_path)],
+                            capture_output=True, text=True)
+    if locked.returncode != 0:
+        sys.exit(f"[{a.slot}] refusing to unlock: could not lock {kc_path} first, so the "
+                 f"prompt cannot be guaranteed: {locked.stderr.strip()}")
+
     try:
-        value = _resolve_source(attended[a.slot])
+        value = _resolve_source(source, Path(cfg.get("agent_socket", DEFAULT_AGENT_SOCKET)).expanduser())
     except Exception as e:
         sys.exit(f"[{a.slot}] source error: {e}")
     if not value:
@@ -2187,9 +2290,15 @@ slot is filled. Push secrets in with either:
 The bootstrap config (~/.security-proxy-bootstrap.json) maps each slot to a source:
   {"nomad":     {"keychain": {"service": "security-proxy", "account": "alinomad.cern.ch"}},
    "grid-cert": {"keychain_identity": "My Grid Cert"},
-   "other":     {"command": "op read op://vault/item/field"}}
+   "gitlab":    {"vault": {"path": "kv/data/ci", "field": "gitlab_pass"}},
+   "mail":      {"device_authorize": {"provider": "microsoft", "client_id": "...",
+                                      "scope": "... offline_access", "account": "me@x"}}}
 Sources: "keychain" (generic password), "keychain_identity" (a cert identity, pushed
-as combined cert+key PEM), or "command" (its stdout is the value). A "keychain"
+as combined cert+key PEM), "file" (contents of one path or several concatenated),
+"vault" (one field of a Vault secret, read through the proxy's own vault route, so
+bootstrap needs no Vault token) or "device_authorize" (OAuth2 device-code flow). There
+is deliberately NO shell/command source: the bootstrap config is writable by anything
+running as you, so one would be arbitrary code execution as you. A "keychain"
 source may name an explicit keychain file:
   {"keychain": {"service": "s", "account": "a",
                 "keychain": "~/Library/Keychains/security-proxy.keychain-db"}}

--- a/security-proxy/tests/run_all.py
+++ b/security-proxy/tests/run_all.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Run every test module here. No pytest, no dependencies beyond the proxy's own venv:
+
+    ./venv/bin/python tests/run_all.py
+
+Each module is also runnable on its own and exits non-zero on failure.
+"""
+import importlib
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(HERE.parent))
+
+MODULES = sorted(p.stem for p in HERE.glob("test_*.py"))
+
+
+def main() -> int:
+    failures = []
+    for name in MODULES:
+        module = importlib.import_module(name)
+        print(f"\n== {name}: {module.__doc__.splitlines()[0]}")
+        failures += [f"{name}: {f}" for f in module.run()]
+
+    print(f"\n{'=' * 60}")
+    if failures:
+        print(f"{len(failures)} failure(s) across {len(MODULES)} module(s):")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print(f"all {len(MODULES)} module(s) passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/security-proxy/tests/test_attended.py
+++ b/security-proxy/tests/test_attended.py
@@ -1,0 +1,93 @@
+"""Attended slots: a high-privilege secret is absent outside a window a human opened.
+
+Covers the window mechanics -- use budget, TTL, the sweeper that drops an untouched
+value on time, and the 403-vs-503 split that tells a caller *which* fault it hit.
+"""
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import security_proxy as sp
+
+failures = []
+
+
+def check(label, got, want):
+    ok = got == want
+    if not ok:
+        failures.append(f"{label}: got {got!r}, want {want!r}")
+    print(f"  {'ok  ' if ok else 'FAIL'} {label}")
+
+
+def run():
+    sp.ATTENDED.update({"admin": {"ttl": 300, "max_uses": 2},
+                        "timed": {"ttl": 1, "max_uses": None}})
+
+    # --- use budget ---------------------------------------------------------
+    sp.SLOTS["admin"] = "s3cr3t"
+    sp.slot_arm("admin")
+    check("1st use served", sp.slot_get("admin"), "s3cr3t")
+    check("2nd use served", sp.slot_get("admin"), "s3cr3t")
+    check("3rd use denied once the budget is spent", sp.slot_get("admin"), None)
+    check("value wiped from memory", sp.SLOTS.get("admin"), None)
+    check("window state gone", sp.SLOT_STATE.get("admin"), None)
+
+    # --- a non-request read must not spend the budget ------------------------
+    sp.SLOTS["admin"] = "s3cr3t"
+    sp.slot_arm("admin")
+    sp.slot_get("admin", consume=False)
+    sp.slot_get("admin", consume=False)
+    check("consume=False leaves the budget intact", sp.SLOT_STATE["admin"]["uses_left"], 2)
+
+    # --- ttl, on access ------------------------------------------------------
+    sp.SLOTS["timed"] = "tmp"
+    sp.slot_arm("timed")
+    check("served inside the ttl", sp.slot_get("timed"), "tmp")
+    sp.SLOT_STATE["timed"]["expires"] = time.monotonic() - 1
+    check("denied past the ttl", sp.slot_get("timed"), None)
+    check("wiped past the ttl", sp.SLOTS.get("timed"), None)
+
+    # --- ttl, without access: the sweeper must still drop it -----------------
+    sp.SLOTS["timed"] = "tmp"
+    sp.slot_arm("timed")
+    sp.SLOT_STATE["timed"]["expires"] = time.monotonic() - 1
+    sp.sweep_attended_slots()
+    check("sweeper wipes an untouched expired slot", sp.SLOTS.get("timed"), None)
+
+    # --- a value with no window is refused, not served -----------------------
+    sp.SLOTS["admin"] = "orphan"
+    sp.SLOT_STATE.pop("admin", None)
+    check("value armed-less is refused", sp.slot_get("admin"), None)
+
+    # --- ordinary slots are untouched by any of this -------------------------
+    sp.SLOTS["nomad"] = "plain"
+    for _ in range(5):
+        sp.slot_get("nomad")
+    check("plain slot unaffected", sp.slot_get("nomad"), "plain")
+
+    # --- error mapping: different fault, different fix ------------------------
+    check("attended slot -> 403", sp.SlotUnavailable("admin").status, 403)
+    check("unprovisioned slot -> 503", sp.SlotUnavailable("nomad").status, 503)
+    check("403 detail names the unlock command",
+          "security-proxy-unlock admin" in sp.SlotUnavailable("admin").detail, True)
+
+    # --- a locked attended route raises, and raises as a 403 ------------------
+    rt = sp.Route(prefix="/", upstream="https://example.invalid", token="t",
+                  name="admin-route", ingest_headers={"X-Admin-Token": "admin"})
+    try:
+        sp.resolve_ingest_headers(rt)
+        check("locked attended route raises", "no exception", "SlotUnavailable")
+    except sp.SlotUnavailable as e:
+        check("locked attended route raises 403", e.status, 403)
+
+    return failures
+
+
+if __name__ == "__main__":
+    print(__doc__.splitlines()[0])
+    bad = run()
+    print(f"{len(bad)} failure(s)")
+    for f in bad:
+        print(f"  FAILED: {f}")
+    sys.exit(1 if bad else 0)

--- a/security-proxy/tests/test_paths.py
+++ b/security-proxy/tests/test_paths.py
@@ -1,0 +1,64 @@
+"""upstream_url_for(): a route's upstream path is a scope, and `..` must not escape it.
+
+Regression test for the traversal found in 2026-08: with an upstream that carries a
+path (`https://alimonitor.cern.ch/hyperloop`), a client could reach the rest of that
+host with the proxy's credential attached by sending `../..`. The URL is normalised
+downstream (httpx does it before the request goes out) and `..%2f` decodes to the same
+segments, so the check has to happen before the join, over the decoded path too.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import security_proxy as sp
+
+
+def route(upstream):
+    return sp.Route(prefix="/x/", upstream=upstream, token="t", name="x")
+
+
+SCOPED = route("https://alimonitor.cern.ch/hyperloop")   # has a path -> a scope to escape
+BARE = route("https://api.github.com")                   # no path -> nothing to escape
+
+CASES = [
+    # (route, client path, expected)
+    (SCOPED, "report", "allow"),
+    (SCOPED, "a/b/c", "allow"),
+    (SCOPED, "", "allow"),
+    (SCOPED, "a/../b", "allow"),          # resolves back inside the scope
+    (SCOPED, "../../admin", "block"),
+    (SCOPED, "..", "block"),
+    (SCOPED, "a/../../admin", "block"),
+    (SCOPED, "..%2F..%2Fadmin", "block"),  # percent-encoded, upper case
+    (SCOPED, "..%2f..%2fadmin", "block"),  # percent-encoded, lower case
+    (SCOPED, "%2e%2e/admin", "block"),     # encoded dots
+    (SCOPED, "..\\..\\admin", "block"),    # backslash separators
+    # A path-less upstream has no scope to escape and the host can never change, so `..`
+    # there is harmless -- blocking it would only break clients sending odd-but-legal paths.
+    (BARE, "../../whatever", "allow"),
+    (BARE, "repos/o/r/pulls/1", "allow"),
+]
+
+
+def run():
+    failures = []
+    for rt, path, want in CASES:
+        try:
+            sp.upstream_url_for(rt, path)
+            got = "allow"
+        except sp.PathTraversal:
+            got = "block"
+        ok = got == want
+        if not ok:
+            failures.append(f"{path!r} on {rt.upstream}: got {got}, want {want}")
+        print(f"  {'ok  ' if ok else 'FAIL'} {want:5} {path!r}")
+    return failures
+
+
+if __name__ == "__main__":
+    print(__doc__.splitlines()[0])
+    bad = run()
+    print(f"{len(CASES) - len(bad)}/{len(CASES)} passed")
+    for f in bad:
+        print(f"  FAILED: {f}")
+    sys.exit(1 if bad else 0)

--- a/security-proxy/tests/test_sources.py
+++ b/security-proxy/tests/test_sources.py
@@ -1,0 +1,146 @@
+"""Bootstrap sources are declarative: they name what to read, never a command to run.
+
+The `command` source was removed in 2026-08. The bootstrap config is writable by
+anything running as the user, so a shell source was arbitrary code execution as the
+user at the next bootstrap -- the same-uid problem attended slots exist to contain,
+arriving through a door they do not cover. These tests pin the replacements (`file`,
+`vault`, `device_authorize`) and that the old kind stays rejected with a migration hint.
+"""
+import http.server
+import json
+import socket as _socket
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import security_proxy as sp
+
+failures = []
+
+
+def check(label, got, want):
+    ok = got == want
+    if not ok:
+        failures.append(f"{label}: got {got!r}, want {want!r}")
+    print(f"  {'ok  ' if ok else 'FAIL'} {label}")
+
+
+def _fake_vault(tmp):
+    """A stand-in for the proxy's vault route plus its agent socket.
+
+    Proves the wiring -- gate token in, field out -- without touching real Vault.
+    """
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            token = self.headers.get("X-Vault-Token")
+            body = json.dumps({"data": {"data": {"gitlab_pass": f"SECRET-for-{token}"}}}).encode()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):
+            pass
+
+    srv = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    port = srv.server_address[1]
+
+    sock_path = tmp / "agent.sock"
+
+    def serve_agent():
+        s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        s.bind(str(sock_path))
+        s.listen(4)
+        while True:
+            conn, _ = s.accept()
+            conn.recv(4096)
+            conn.sendall((json.dumps({"port": port, "service": "vault",
+                                      "token": "GATE"}) + "\n").encode())
+            conn.close()
+
+    threading.Thread(target=serve_agent, daemon=True).start()
+    for _ in range(50):                      # wait for the socket to appear
+        if sock_path.exists():
+            break
+        time.sleep(0.02)
+    return sock_path
+
+
+def run():
+    tmp = Path(tempfile.mkdtemp(prefix="security-proxy-tests-"))
+
+    # --- file: replaces `cat a b` -------------------------------------------
+    (tmp / "cert.pem").write_text("CERT\n")
+    (tmp / "key.pem").write_text("KEY\n")
+    check("file, single path", sp._resolve_source({"file": str(tmp / "cert.pem")}), "CERT\n")
+    check("file, several concatenated",
+          sp._resolve_source({"file": [str(tmp / "cert.pem"), str(tmp / "key.pem")]}),
+          "CERT\nKEY\n")
+
+    # --- the removed kind ----------------------------------------------------
+    try:
+        sp._resolve_source({"command": "echo pwned"})
+        check("command source rejected", "accepted", "rejected")
+    except ValueError as e:
+        check("command source rejected with a migration hint",
+              "removed" in str(e) and "arbitrary shell" in str(e), True)
+
+    # --- malformed sources ---------------------------------------------------
+    for bad, label in [({}, "empty source rejected"),
+                       ({"nope": 1}, "unknown kind rejected"),
+                       ({"file": "x", "keychain": "y"}, "two kinds at once rejected")]:
+        try:
+            sp._resolve_source(bad)
+            check(label, "accepted", "rejected")
+        except ValueError:
+            check(label, "rejected", "rejected")
+
+    # --- vault ---------------------------------------------------------------
+    try:
+        sp._resolve_source({"vault": {"path": "kv/data/ci", "field": "x"}}, None)
+        check("vault without an agent socket is refused", "accepted", "rejected")
+    except RuntimeError as e:
+        check("vault without an agent socket names the missing key", "agent_socket" in str(e), True)
+
+    sock = _fake_vault(tmp)
+    check("vault reads its field through the proxy (KV v2 shape)",
+          sp._resolve_source({"vault": {"path": "kv/data/ci", "field": "gitlab_pass"}}, sock),
+          "SECRET-for-GATE")
+    try:
+        sp._resolve_source({"vault": {"path": "kv/data/ci", "field": "absent"}}, sock)
+        check("missing vault field is an error", "accepted", "rejected")
+    except RuntimeError as e:
+        check("missing vault field says what the secret does have",
+              "gitlab_pass" in str(e), True)
+
+    # --- the real map, when there is one (skipped on a fresh machine) --------
+    real = Path("~/.security-proxy-bootstrap.json").expanduser()
+    if real.exists():
+        cfg = json.load(open(real))
+        slots = cfg.get("slots", {})
+        check("every slot in the real map has exactly one known kind",
+              all(len([k for k in sp.SOURCE_KINDS if k in src]) == 1
+                  for src in slots.values()), True)
+        check("no command source left in the real map",
+              any("command" in src for src in slots.values()), False)
+        for slot, src in (cfg.get("attended") or {}).items():
+            kc = src.get("keychain")
+            check(f"attended {slot!r} is sourced from an explicit locked keychain",
+                  isinstance(kc, dict) and bool(kc.get("keychain")), True)
+    else:
+        print("  skip  no ~/.security-proxy-bootstrap.json on this machine")
+
+    return failures
+
+
+if __name__ == "__main__":
+    print(__doc__.splitlines()[0])
+    bad = run()
+    print(f"{len(bad)} failure(s)")
+    for f in bad:
+        print(f"  FAILED: {f}")
+    sys.exit(1 if bad else 0)


### PR DESCRIPTION

Such ability could be exploited to avoid user presence checks.

Add tests for various security-proxy parts
