### PR TITLE
Add configuration to test alidist

### DIFF
--- a/ci/repo-config/mesosci/slc10/o2-alidist.env
+++ b/ci/repo-config/mesosci/slc10/o2-alidist.env
@@ -1,0 +1,25 @@
+CI_NAME=build_O2_alidist_slc10_x86
+PACKAGE=O2
+ALIBUILD_DEFAULTS=o2
+PR_REPO=alisw/alidist
+PR_BRANCH=master
+NO_ASSUME_CONSISTENT_EXTERNALS=
+TRUST_COLLABORATORS=true
+CHECK_NAME=build/O2/alidist-slc10-x86
+DONT_USE_COMMENTS=1
+DEVEL_PKGS="$PR_REPO $PR_BRANCH
+AliceO2Group/AliceO2 dev O2"
+# aliBuild 2.0, which is the builder slc10 is being brought up against -- so the
+# check exercises the two together rather than validating slc10 on a builder
+# nobody will use. Overriding here leaves every other check on the pinned
+# version from repo-config/DEFAULTS.env.
+#
+# That pin (v1.17.43) would fail anyway: its VALID_ARCHS_RE is "^slc[5-9]_...",
+# a character class that cannot express 10, so it rejects slc10_x86-64 outright.
+#
+# A ref, not a tag or SHA: the loop reinstalls before every build, so the check
+# follows the PR as it develops -- which is the point during bring-up, and also
+# means a broken commit on the PR breaks the check rather than silently testing
+# a stale build. Verified that pip resolves this form and that the branch still
+# accepts every flag build-loop.sh passes.
+INSTALL_ALIBUILD='alisw/alibuild@refs/pull/1038/head'


### PR DESCRIPTION

Uses the new alibuild and will be deployed using an autoscaling
ci builder.
