### PR TITLE
Fix github_utilities to work with non-github API endpoints

### DIFF
--- a/alibot_helpers/github_utilities.py
+++ b/alibot_helpers/github_utilities.py
@@ -8,6 +8,7 @@ import json
 import pickle
 import re
 import sys
+from urllib.parse import urlsplit
 
 import requests
 
@@ -112,11 +113,33 @@ def parseLinks(linkString):
             return sanitized
 
 
+def relativeLink(link):
+    """Reduce an absolute pagination link to something makeURL() can join.
+
+    GitHub puts the UPSTREAM host in its Link header -- api.github.com -- even
+    when we reached it through a credential broker. Stripping our own api base
+    therefore matches nothing, the follow-up request goes straight to GitHub
+    carrying a gate token it will not accept, and self.get() returns None.
+
+    Taking path and query instead works for either destination. The leading
+    slash has to go as well: makeURL() uses os.path.join(), which throws the
+    base away when the second argument is absolute -- so the old
+    `.replace(api, "")` produced a bare "/repos/..." that was broken even
+    talking to GitHub directly. Only commits with enough statuses to paginate
+    ever reach this, which is how it survived.
+    """
+    _, _, path, query, _ = urlsplit(link)
+    return path.lstrip("/") + ("?" + query if query else "")
+
+
 def pagination(cache_item, nextLink, api, self, stable_api):
     for x in cache_item["payload"]:
         yield x
     if nextLink:
-        for x in self.get(nextLink.replace(api, ""), stable_api):
+        # `or ()` because get() returns None on a failed or 304 response, and
+        # iterating that raises TypeError from deep inside setGithubStatus,
+        # where it looks nothing like a pagination problem.
+        for x in self.get(relativeLink(nextLink), stable_api) or ():
             yield x
 
 

--- a/test/test_githubUtilities.py
+++ b/test/test_githubUtilities.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from alibot_helpers.github_utilities import calculateMessageHash
 from alibot_helpers.github_utilities import parseGithubRef
 from alibot_helpers.github_utilities import GithubCachedClient
+from alibot_helpers.github_utilities import relativeLink
 
 
 class TestAuthorizationHeader(unittest.TestCase):
@@ -38,6 +39,41 @@ class TestAuthorizationHeader(unittest.TestCase):
     verbatim -- a stripped or re-encoded token fails as a 401 too."""
     for url in (None, "http://127.0.0.1:9999/github"):
       self.assertTrue(self.headerFor(url).endswith(" SECRET"))
+
+
+class TestPaginationLinks(unittest.TestCase):
+    """Following a Link header must work through a credential broker too.
+
+    GitHub names the UPSTREAM host in its Link header even when we reached it
+    via a broker, so the old `nextLink.replace(api, "")` matched nothing and the
+    follow-up request went straight to api.github.com with a gate token it will
+    not accept. get() then returned None and setGithubStatus died with
+    "TypeError: 'NoneType' object is not iterable" -- which named neither
+    pagination nor the proxy.
+
+    It was broken against GitHub directly as well: stripping the base left a
+    leading slash, and makeURL()'s os.path.join() discards its first argument
+    when the second is absolute. Only commits with enough statuses to paginate
+    reach this code, which is how it went unnoticed.
+    """
+
+    LINK = "https://api.github.com/repositories/123/statuses?page=2"
+
+    def test_the_result_joins_onto_either_base(self):
+        rel = relativeLink(self.LINK)
+        for base in ("https://api.github.com", "http://127.0.0.1:9/github"):
+            self.assertEqual(os.path.join(base, rel),
+                             base + "/repositories/123/statuses?page=2")
+
+    def test_no_leading_slash(self):
+        """os.path.join() throws the base away if this starts with '/'."""
+        self.assertFalse(relativeLink(self.LINK).startswith("/"))
+
+    def test_the_query_survives(self):
+        """Losing it re-requests page 1 for ever."""
+        self.assertIn("page=2", relativeLink(self.LINK))
+        self.assertIn("per_page=100", relativeLink(
+            "https://api.github.com/repos/a/b/pulls?per_page=100&page=3"))
 
 
 class TestGithubHelpers(unittest.TestCase):


### PR DESCRIPTION

Needed by the security proxy in the CI.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/alisw/ali-bot/pull/1727).
* #1725 (3 commits)
* __->__ #1727