### PR TITLE
Bump ubuntu2204 to use the new aliBuild

### DIFF
--- a/ci/repo-config/mesosci/ubuntu2204/DEFAULTS.env
+++ b/ci/repo-config/mesosci/ubuntu2204/DEFAULTS.env
@@ -1,0 +1,66 @@
+# Per container; see mesosci/slc10/DEFAULTS.env for why.
+ARCHITECTURE=ubuntu2204_x86-64
+CONTAINER_IMAGE=registry.cern.ch/alisw/ubuntu2204-builder:latest
+
+# mesosci/DEFAULTS.env sets JOBS=24 for the shared pool, and source_env_files
+# runs before build-loop.sh reads it -- so that value silently overrides the
+# JOBS the job exports, and the 54 GiB budget in ci-linux-x86.nomad was being
+# spent 24 ways rather than 14. Now that build-loop.sh caps the container at
+# that budget, an overrun is an OOM-killed build rather than a node-wide
+# reclaim storm, so the split has to be one the budget can actually cover:
+# measured peak RSS for the heaviest O2Physics TUs runs 3-6 GiB each.
+#
+# 14 was the first attempt and it did NOT fit: with the cap live, builds died on
+# "c++: fatal error: Killed signal terminated program cc1plus". That matches the
+# measurement -- the 14 heaviest model at ~52 GiB against a ~51 GiB cap, i.e. no
+# headroom at all, and the model under-predicts the tail.
+#
+# 24 = the logical CPUs this allocation is actually entitled to. Nomad reports
+# cpu.numcores=64 on these nodes and the ci task reserves CpuShares=79440, which
+# at 3310 MHz per core is exactly 24. JOBS should match that.
+#
+# It did not, and the mismatch cost real throughput -- worth recording so the
+# next resize does not repeat it. The 2026-08-31 roll doubled the allocation
+# (cores 12 -> 24, memory 54 -> 108 GiB) and cut the fleet from six builders to
+# three, on the reasoning that total capacity was unchanged. But JOBS lives HERE,
+# not in the jobspec, and was left at 14: three builders each compiling 14-wide
+# on 24 cores is less parallelism than the six 14-wide-on-12 they replaced, so
+# the fleet got slower. Resizing the allocation without moving JOBS is only half
+# the change.
+#
+# Memory is no longer the binding constraint. 24 compiles inside the ~104 GiB
+# container cap is ~4.3 GiB each, against ~3.6 GiB when 14 shared ~51 GiB -- so
+# this is less tight than what already worked. The 7-10 GiB analysis TUs are
+# capped separately by ANALYSIS_COMPILE_POOL, which reads the cgroup limit and
+# now sizes itself to 12 rather than 6.
+#
+# Not oversubscribed, unlike the old 14-on-12: the task is limited by CPU shares
+# rather than a pinned cpuset, so asking for more than the entitlement buys
+# throttling and context switches rather than parallelism.
+#
+# If OOM kills come back, lower this rather than raising the reservation, and
+# check the pool actually bound (look for "Limiting workflow compilations in
+# parallel to:" in the O2Physics configure output).
+JOBS=24
+
+# v1.17.44, not the v1.17.43 in repo-config/DEFAULTS.env: these checks read
+# TARS/ubuntu2204_x86-64/ from alibuild-repo over https, and that tree is about
+# to contain reapi:// redirect stubs rather than tarballs.
+#
+# The HttpRemoteSync in v1.17.43 ignores x-amz-website-redirect-location
+# all, so it would download the ~78-byte stub AS the tarball. v1.17.44 (tag
+# eaa8e2c) carries "Follow store redirects when downloading over http", the
+# s3cmd equivalent, and "Handle absolute redirect links in legacy store" -- the
+# last one being what matters here, because splitting the legacy tree from the
+# CAS makes the redirect absolute. Verified against a real published stub: it
+# follows it out of alibuild-repo into alibuild-cas and returns the 271 MiB
+# tarball, gzip magic and all.
+#
+# A tag, not refs/pull/1038/head as slc10 uses: these are production PR checks,
+# so they take a released aliBuild. The reapi:// machinery is not in 1.17.44 and
+# is not needed -- these checks only READ the tree the release builder writes.
+#
+# slc10 never needed this because slc10_x86-64 is not in S3_SUPPORTED_ARCHS and
+# its checks are pinned to the PR anyway. ubuntu2204_x86-64 IS in that list, so
+# an unpinned aliBuild defaults to alibuild-repo here.
+INSTALL_ALIBUILD='alisw/alibuild@v1.17.44'


### PR DESCRIPTION

Will allow it to consume releases created by the new release builders
